### PR TITLE
Add "ci.skip" git push option

### DIFF
--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -345,6 +345,9 @@ func (ws *WorkflowBaseService) publishWork(repository internal.Repository, updat
 			Username: "du", // yes, this can be anything except an empty string
 			Password: ws.config.Token,
 		},
+		Options: map[string]string{
+			"ci.skip": "",
+		},
 	})
 
 	if err != nil {


### PR DESCRIPTION
I'm trying to find out if the elevated privileges for the Drupdater token due to it triggering the CI pipeline can be avoided by avoiding CI in the Git push and instead using Gitlab's [parent-child pipelines](https://docs.gitlab.com/ci/pipelines/downstream_pipelines/#parent-child-pipelines).

Let's see...