### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bumpr.yml
+++ b/.github/workflows/bumpr.yml
@@ -28,6 +28,9 @@ jobs:
   release-check:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Post bumpr status comment


### PR DESCRIPTION
Potential fix for [https://github.com/drupdater/drupdater/security/code-scanning/3](https://github.com/drupdater/drupdater/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `release-check` job. Since the job only checks the status and posts a comment, it likely only requires `contents: read` and possibly `pull-requests: write` if it interacts with pull requests. We will explicitly define these permissions to limit the scope of the `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
