### PR TITLE
Use text/template instead of html/template for MR descriptions

### DIFF
--- a/internal/addon.go
+++ b/internal/addon.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"html/template"
+	"text/template"
 
 	"github.com/gookit/event"
 )


### PR DESCRIPTION
html/template auto-escapes HTML characters, causing version constraints like ">= 10.3.0" to appear as "&gt;= 10.3.0" in merge request bodies.