### PR TITLE
Return AbortError when no composer changes are detected

### DIFF
--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -257,8 +257,7 @@ func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context) (SharedUpda
 		return SharedUpdate{}, fmt.Errorf("failed to update dependencies: %w", err)
 	}
 	if len(changes) == 0 {
-		ws.logger.Warn("no changes detected")
-		return SharedUpdate{}, nil
+		return SharedUpdate{}, AbortError{Msg: "no changes detected"}
 	}
 
 	postComposerUpdateEvent := NewPostComposerUpdateEvent(ctx, path, worktree)

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -81,6 +81,60 @@ func TestStartUpdate(t *testing.T) {
 	vcsProvider.AssertExpectations(t)
 }
 
+func TestStartUpdateNoChanges(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Sites:         []string{"site1"},
+		DryRun:        false,
+	}
+
+	// installCode runs concurrently with updateSharedCode and always completes.
+	// installSite may or may not run depending on goroutine scheduling after cancel.
+	worktree := NewMockWorktree(t)
+
+	vcsProvider.EXPECT().GetUser().Return("user", "mail")
+
+	// installCode: one CloneRepository + Install
+	// updateSharedCode: one CloneRepository + Update (returns empty → AbortError)
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil).Times(2)
+
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{}, nil)
+
+	// installSite and updateSite may not run if ctx is cancelled in time.
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+
+	// Execute
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer)
+	err := workflowService.StartUpdate(ctx, nil)
+
+	// Assert: should get an AbortError, not a nil or other error
+	var abortErr AbortError
+	assert.ErrorAs(t, err, &abortErr)
+	installer.AssertExpectations(t)
+	repositoryService.AssertExpectations(t)
+	repository.AssertExpectations(t)
+	drush.AssertExpectations(t)
+	mockComposer.AssertExpectations(t)
+	vcsProvider.AssertExpectations(t)
+}
+
 func TestStartUpdateWithDryRun(t *testing.T) {
 	// Setup
 	logger := zap.NewNop()


### PR DESCRIPTION
Fixes a nil-pointer panic: when composer update found no changes, updateSharedCode returned a zero-value SharedUpdate (nil Repository), which then caused a panic in publishWork when calling repository.Push. Now returns AbortError so the caller exits cleanly.