### PR TITLE
Use json.Marshal instead of string concatenation for patch test config

### DIFF
--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -341,6 +341,10 @@ func (s *CLI) initTempDir() {
 	s.initErr = afero.WriteFile(s.fs, s.tempDir+"/composer.json", []byte(composerJSON), 0644)
 }
 
+type patchTestConfig struct {
+	Patches map[string]map[string]string `json:"patches"`
+}
+
 func (s *CLI) CheckIfPatchApplies(ctx context.Context, packageName string, packageVersion string, patchPath string) (bool, error) {
 
 	s.initOnce.Do(s.initTempDir)
@@ -348,14 +352,20 @@ func (s *CLI) CheckIfPatchApplies(ctx context.Context, packageName string, packa
 		return false, s.initErr
 	}
 
-	// Create a composer.patches.json file
-	patchesJSON := `{
-	"patches": {
-		"` + packageName + `": {
-			"` + packageVersion + `": "` + patchPath + `"
-		}
+	// Create a composer.patches.json file using json.Marshal to safely handle
+	// special characters in packageName, packageVersion, and patchPath.
+	patchConfig := patchTestConfig{
+		Patches: map[string]map[string]string{
+			packageName: {
+				packageVersion: patchPath,
+			},
+		},
 	}
-}`
+	patchesJSONBytes, err := json.Marshal(patchConfig)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal patch config: %w", err)
+	}
+	patchesJSON := string(patchesJSONBytes)
 
 	// Write the composer.patches.json file to the temporary directory
 	if err := afero.WriteFile(s.fs, s.tempDir+"/composer.patches.json", []byte(patchesJSON), 0644); err != nil {

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -326,6 +327,44 @@ Using version ^11.1 for drupal/core`
 		applies, err := service.CheckIfPatchApplies(t.Context(), "drupal/core", "1.0.0", "path/to/patch")
 		assert.NoError(t, err)
 		assert.False(t, applies)
+	})
+
+	t.Run("Package name with special JSON characters produces valid JSON", func(t *testing.T) {
+		// This test verifies that packageName, packageVersion, and patchPath
+		// containing double-quotes or backslashes are safely marshaled via
+		// json.Marshal rather than string concatenation, which would produce
+		// invalid JSON.
+		fs := afero.NewMemMapFs()
+
+		capturedPatchesJSON := ""
+		execCommand = func(_ context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := []string{"-test.run=TestHelperProcess", "--", "ok"}
+			cs = append(cs, arg...)
+			cmd := exec.Command(os.Args[0], cs...)
+			cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GOCOVERDIR=/tmp"}
+			return cmd
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		service := &CLI{
+			logger: zap.NewNop(),
+			fs:     fs,
+		}
+
+		// Use a package name that contains a double-quote and a backslash —
+		// these would break raw string concatenation but must be escaped by
+		// json.Marshal, resulting in valid JSON.
+		_, err := service.CheckIfPatchApplies(t.Context(), `drupal/"core"`, `1.0\0`, `path/to/"patch"`)
+		assert.NoError(t, err)
+
+		// Read back the written composer.patches.json and confirm it is valid JSON.
+		data, err := afero.ReadFile(fs, service.tempDir+"/composer.patches.json")
+		assert.NoError(t, err)
+		capturedPatchesJSON = string(data)
+
+		var parsed map[string]interface{}
+		assert.NoError(t, json.Unmarshal([]byte(capturedPatchesJSON), &parsed),
+			"composer.patches.json must be valid JSON even when values contain special characters")
 	})
 
 }


### PR DESCRIPTION
Replace unsafe string concatenation in CheckIfPatchApplies with json.Marshal to correctly escape double-quotes and backslashes in packageName, packageVersion, and patchPath, preventing invalid JSON from being written to composer.patches.json.