### PR TITLE
Use os.TempDir() in cleanup to match how temp directories are created

### DIFF
--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"text/template"
@@ -73,7 +74,7 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 
 	defer func() {
 		// Clean up the temporary directory
-		tmpDirName := fmt.Sprintf("/tmp/%x", md5.Sum([]byte(ws.config.RepositoryURL)))
+		tmpDirName := filepath.Join(os.TempDir(), fmt.Sprintf("%x", md5.Sum([]byte(ws.config.RepositoryURL))))
 		os.RemoveAll(tmpDirName)
 
 		cancel()


### PR DESCRIPTION
The defer block in StartUpdate was using a hardcoded /tmp prefix to build the cleanup path, but pkg/repo/repo.go creates the temp directory with filepath.Join(os.TempDir(), hash). On macOS, os.TempDir() resolves to $TMPDIR (e.g. /var/folders/…), not /tmp, so the RemoveAll call never found the directory and git clones leaked permanently.