### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/drupdater/drupdater/security/code-scanning/5](https://github.com/drupdater/drupdater/security/code-scanning/5)

Add an explicit `permissions` block at the workflow root so it applies to all jobs unless overridden. For this workflow, the minimal and appropriate permission is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI actions while preventing unintended write access by default.  
Edit `.github/workflows/go.yml` by inserting the permissions block after the trigger (`on:` section) and before `jobs:`. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
