### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bumpr.yml
+++ b/.github/workflows/bumpr.yml
@@ -9,6 +9,9 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   release:
     if: github.event.action != 'labeled'


### PR DESCRIPTION
Potential fix for [https://github.com/drupdater/drupdater/security/code-scanning/4](https://github.com/drupdater/drupdater/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/bumpr.yml` at the workflow root (right after `on:` section, before `jobs:`).  
Best minimal fix is to start with:

- `contents: read`

This satisfies the CodeQL requirement and documents baseline token scope without changing workflow logic.  
If later testing shows write actions are required (e.g., creating/updating tags), permissions can be elevated narrowly at the specific job level, but the single best immediate fix for this finding is adding explicit root permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
