### PR TITLE
Check for path definitions in phpcs.xml

### DIFF
--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"encoding/xml"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,6 +60,35 @@ var fileExists = func(path string) bool {
 	return true
 }
 
+type phpcsRuleset struct {
+	XMLName xml.Name `xml:"ruleset"`
+	Files   []string `xml:"file"`
+}
+
+// hasPHPCSPathDefinitions checks if phpcs.xml or phpcs.xml.dist contains <file> path definitions
+var hasPHPCSPathDefinitions = func(path string) (bool, error) {
+	var configPath string
+	if _, err := os.Stat(filepath.Join(path, "phpcs.xml")); err == nil {
+		configPath = filepath.Join(path, "phpcs.xml")
+	} else if _, err := os.Stat(filepath.Join(path, "phpcs.xml.dist")); err == nil {
+		configPath = filepath.Join(path, "phpcs.xml.dist")
+	} else {
+		return false, nil
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read phpcs config: %w", err)
+	}
+
+	var ruleset phpcsRuleset
+	if err := xml.Unmarshal(data, &ruleset); err != nil {
+		return false, fmt.Errorf("failed to parse phpcs config: %w", err)
+	}
+
+	return len(ruleset.Files) > 0, nil
+}
+
 func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error {
 	event := e.(*services.PostCodeUpdateEvent)
 	cb.logger.Info("updating coding styles")
@@ -70,6 +100,15 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error {
 		}
 		if !created {
 			cb.logger.Debug("no phpcs.xml created, skipping coding style update")
+			return nil
+		}
+	} else {
+		hasPaths, err := hasPHPCSPathDefinitions(event.Path())
+		if err != nil {
+			return err
+		}
+		if !hasPaths {
+			cb.logger.Warn("phpcs.xml found but no file path definitions, skipping coding style update")
 			return nil
 		}
 	}

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -219,6 +219,32 @@ func TestHasPHPCSPathDefinitions(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to parse phpcs config")
 		assert.False(t, result)
 	})
+
+	t.Run("returns error when phpcs.xml cannot be read", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Create phpcs.xml as a directory so Stat succeeds but ReadFile fails
+		err := os.MkdirAll(filepath.Join(tmpDir, "phpcs.xml"), 0755)
+		assert.NoError(t, err)
+
+		result, err := hasPHPCSPathDefinitions(tmpDir)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read phpcs config")
+		assert.False(t, result)
+	})
+
+	t.Run("returns false when phpcs.xml.dist has no file definitions", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		content := `<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="test">
+    <rule ref="Drupal"/>
+</ruleset>`
+		err := os.WriteFile(filepath.Join(tmpDir, "phpcs.xml.dist"), []byte(content), 0600)
+		assert.NoError(t, err)
+
+		result, err := hasPHPCSPathDefinitions(tmpDir)
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
 }
 
 func TestCodingStyles(t *testing.T) {

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -160,12 +160,116 @@ func TestCreatePHPCSConfig(t *testing.T) {
 	})
 }
 
+func TestHasPHPCSPathDefinitions(t *testing.T) {
+	t.Run("returns false when neither file exists", func(t *testing.T) {
+		result, err := hasPHPCSPathDefinitions("/nonexistent/path")
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("returns true when phpcs.xml has file definitions", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		content := `<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="test">
+    <file>web/modules/custom</file>
+</ruleset>`
+		err := os.WriteFile(filepath.Join(tmpDir, "phpcs.xml"), []byte(content), 0600)
+		assert.NoError(t, err)
+
+		result, err := hasPHPCSPathDefinitions(tmpDir)
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("returns false when phpcs.xml has no file definitions", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		content := `<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="test">
+    <rule ref="Drupal"/>
+</ruleset>`
+		err := os.WriteFile(filepath.Join(tmpDir, "phpcs.xml"), []byte(content), 0600)
+		assert.NoError(t, err)
+
+		result, err := hasPHPCSPathDefinitions(tmpDir)
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("returns true when phpcs.xml.dist has file definitions", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		content := `<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="test">
+    <file>web/themes/custom</file>
+</ruleset>`
+		err := os.WriteFile(filepath.Join(tmpDir, "phpcs.xml.dist"), []byte(content), 0600)
+		assert.NoError(t, err)
+
+		result, err := hasPHPCSPathDefinitions(tmpDir)
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("returns error when phpcs.xml is not valid XML", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		err := os.WriteFile(filepath.Join(tmpDir, "phpcs.xml"), []byte("not valid xml"), 0600)
+		assert.NoError(t, err)
+
+		result, err := hasPHPCSPathDefinitions(tmpDir)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse phpcs config")
+		assert.False(t, result)
+	})
+}
+
 func TestCodingStyles(t *testing.T) {
 	// Create reusable test dependencies
 	logger := zap.NewNop()
 	worktree := NewMockWorktree(t)
 
 	// Subtests using table-driven approach
+	t.Run("Config file exists but no path definitions", func(t *testing.T) {
+		fileExists = func(_ string) bool {
+			return true
+		}
+		oldFn := hasPHPCSPathDefinitions
+		hasPHPCSPathDefinitions = func(_ string) (bool, error) {
+			return false, nil
+		}
+		defer func() { hasPHPCSPathDefinitions = oldFn }()
+
+		runner := NewMockPHPCS(t)
+		composer := NewMockComposer(t)
+
+		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{SkipCBF: false}, composer)
+		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)
+
+		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
+		assert.NoError(t, err)
+
+		runner.AssertExpectations(t)
+		composer.AssertExpectations(t)
+	})
+
+	t.Run("Config file exists but hasPHPCSPathDefinitions returns error", func(t *testing.T) {
+		fileExists = func(_ string) bool {
+			return true
+		}
+		oldFn := hasPHPCSPathDefinitions
+		hasPHPCSPathDefinitions = func(_ string) (bool, error) {
+			return false, assert.AnError
+		}
+		defer func() { hasPHPCSPathDefinitions = oldFn }()
+
+		runner := NewMockPHPCS(t)
+		composer := NewMockComposer(t)
+
+		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{SkipCBF: false}, composer)
+		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)
+
+		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
+		assert.Error(t, err)
+	})
+
 	t.Run("No config file found", func(t *testing.T) {
 		// Setup test environment
 		fileExists = func(_ string) bool {
@@ -209,6 +313,9 @@ func TestCodingStyles(t *testing.T) {
 		fileExists = func(_ string) bool {
 			return true
 		}
+		oldFn := hasPHPCSPathDefinitions
+		hasPHPCSPathDefinitions = func(_ string) (bool, error) { return true, nil }
+		defer func() { hasPHPCSPathDefinitions = oldFn }()
 
 		runner := NewMockPHPCS(t)
 		runner.EXPECT().Run(mock.Anything, "/tmp").Return(phpcs.ReturnOutput{
@@ -240,6 +347,9 @@ func TestCodingStyles(t *testing.T) {
 		fileExists = func(_ string) bool {
 			return true
 		}
+		oldFn := hasPHPCSPathDefinitions
+		hasPHPCSPathDefinitions = func(_ string) (bool, error) { return true, nil }
+		defer func() { hasPHPCSPathDefinitions = oldFn }()
 
 		runner := NewMockPHPCS(t)
 		runner.EXPECT().Run(mock.Anything, "/path/to/repo").Return(phpcs.ReturnOutput{
@@ -266,6 +376,9 @@ func TestCodingStyles(t *testing.T) {
 		fileExists = func(_ string) bool {
 			return true
 		}
+		oldFn := hasPHPCSPathDefinitions
+		hasPHPCSPathDefinitions = func(_ string) (bool, error) { return true, nil }
+		defer func() { hasPHPCSPathDefinitions = oldFn }()
 
 		runner := NewMockPHPCS(t)
 		runner.EXPECT().Run(mock.Anything, "/path/to/repo").Return(phpcs.ReturnOutput{
@@ -314,6 +427,9 @@ func TestCodingStyles(t *testing.T) {
 		fileExists = func(_ string) bool {
 			return true
 		}
+		oldFn := hasPHPCSPathDefinitions
+		hasPHPCSPathDefinitions = func(_ string) (bool, error) { return true, nil }
+		defer func() { hasPHPCSPathDefinitions = oldFn }()
 
 		runner := NewMockPHPCS(t)
 		runner.EXPECT().Run(mock.Anything, "/path/to/repo").Return(phpcs.ReturnOutput{


### PR DESCRIPTION
When phpcs.xml or phpcs.xml.dist exists but contains no `<file>` path definitions, log a warning and skip the coding style update instead of running PHPCS blindly.

Closes #94

Generated with [Claude Code](https://claude.ai/code)