### PR TITLE
fix: suppress 403 log noise when GITHUB_TOKEN lacks /user permission

### DIFF
--- a/internal/codehosting/github.go
+++ b/internal/codehosting/github.go
@@ -103,29 +103,43 @@ func (g *Github) logError(err error) {
 }
 
 // GetUser returns the name and email of the authenticated user.
-// When called with a GITHUB_TOKEN (Actions bot), GET /user returns 403; in that
-// case we fall back to the well-known github-actions[bot] identity so that git
-// commits are attributed correctly without requiring a PAT.
+// When called with a GITHUB_TOKEN (Actions bot), GET /user returns 403 with the
+// message "Resource not accessible by integration"; in that case we fall back to
+// the well-known github-actions[bot] identity so that git commits are attributed
+// correctly without requiring a PAT.
+// Any other error (including a 403 from bad user credentials) is logged and
+// returns empty strings so callers can detect the failure.
 func (g *Github) GetUser() (name string, email string) {
 	user, resp, err := g.client.Users.Get(context.Background(), "")
 	if err != nil {
-		if is403(resp, err) {
+		if isGitHubActionsToken403(resp, err) {
 			return "github-actions[bot]", "41898282+github-actions[bot]@users.noreply.github.com"
 		}
 		g.logError(fmt.Errorf("failed to get user: %w", err))
-		return "github-actions[bot]", "41898282+github-actions[bot]@users.noreply.github.com"
+		return "", ""
 	}
 
 	return user.GetName(), user.GetEmail()
 }
 
-// is403 reports whether an error (or the accompanying response) represents an
-// HTTP 403. go-github can return the status code either on the *Response or
-// wrapped inside a *github.ErrorResponse, so we check both.
-func is403(resp *github.Response, err error) bool {
-	if resp != nil && resp.StatusCode == 403 {
-		return true
-	}
+// isGitHubActionsToken403 reports whether the error is the specific 403 returned
+// by GitHub for an Actions integration token (GITHUB_TOKEN) that cannot access
+// the /user endpoint. Such responses carry the message
+// "Resource not accessible by integration".
+//
+// A real user whose credentials are wrong or whose PAT lacks the required scope
+// also receives a 403, but with a different message; those errors must NOT be
+// suppressed so callers can detect and surface them.
+func isGitHubActionsToken403(resp *github.Response, err error) bool {
 	var ghErr *github.ErrorResponse
-	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == 403
+	if !errors.As(err, &ghErr) {
+		return false
+	}
+	statusCode := 0
+	if ghErr.Response != nil {
+		statusCode = ghErr.Response.StatusCode
+	} else if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	return statusCode == 403 && strings.Contains(ghErr.Message, "Resource not accessible by integration")
 }

--- a/internal/codehosting/github.go
+++ b/internal/codehosting/github.go
@@ -2,6 +2,7 @@ package codehosting
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -108,7 +109,7 @@ func (g *Github) logError(err error) {
 func (g *Github) GetUser() (name string, email string) {
 	user, resp, err := g.client.Users.Get(context.Background(), "")
 	if err != nil {
-		if resp != nil && resp.StatusCode == 403 {
+		if is403(resp, err) {
 			return "github-actions[bot]", "41898282+github-actions[bot]@users.noreply.github.com"
 		}
 		g.logError(fmt.Errorf("failed to get user: %w", err))
@@ -116,4 +117,15 @@ func (g *Github) GetUser() (name string, email string) {
 	}
 
 	return user.GetName(), user.GetEmail()
+}
+
+// is403 reports whether an error (or the accompanying response) represents an
+// HTTP 403. go-github can return the status code either on the *Response or
+// wrapped inside a *github.ErrorResponse, so we check both.
+func is403(resp *github.Response, err error) bool {
+	if resp != nil && resp.StatusCode == 403 {
+		return true
+	}
+	var ghErr *github.ErrorResponse
+	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == 403
 }

--- a/internal/codehosting/github_test.go
+++ b/internal/codehosting/github_test.go
@@ -62,6 +62,40 @@ func TestGithub_CreateMergeRequest(t *testing.T) {
 	assert.Equal(t, "http://example.com", mr.URL)
 }
 
+func TestGithub_GetUser_Returns403FallbackSilently(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration","errors":[]}`))
+	}))
+	defer mockServer.Close()
+
+	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
+	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
+
+	name, email := gh.GetUser()
+
+	assert.Equal(t, "github-actions[bot]", name)
+	assert.Equal(t, "41898282+github-actions[bot]@users.noreply.github.com", email)
+}
+
+func TestGithub_GetUser_ReturnsUserOnSuccess(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"login":"octocat","name":"The Octocat","email":"octocat@github.com"}`))
+	}))
+	defer mockServer.Close()
+
+	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
+	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
+
+	name, email := gh.GetUser()
+
+	assert.Equal(t, "The Octocat", name)
+	assert.Equal(t, "octocat@github.com", email)
+}
+
 func TestGithub_DownloadComposerFiles(t *testing.T) {
 	// Setup mock HTTP server for file content
 	mockContentServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/codehosting/github_test.go
+++ b/internal/codehosting/github_test.go
@@ -1,6 +1,7 @@
 package codehosting
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,7 +64,7 @@ func TestGithub_CreateMergeRequest(t *testing.T) {
 }
 
 func TestGithub_GetUser_Returns403FallbackSilently(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration","errors":[]}`))
@@ -80,7 +81,7 @@ func TestGithub_GetUser_Returns403FallbackSilently(t *testing.T) {
 }
 
 func TestGithub_GetUser_Returns403ErrorForBadCredentials(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}`))
@@ -97,7 +98,7 @@ func TestGithub_GetUser_Returns403ErrorForBadCredentials(t *testing.T) {
 }
 
 func TestGithub_GetUser_ReturnsUserOnSuccess(t *testing.T) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"login":"octocat","name":"The Octocat","email":"octocat@github.com"}`))
@@ -166,4 +167,19 @@ func TestGithub_DownloadComposerFiles(t *testing.T) {
 
 	_, err = gh.fs.Stat(dir + "/composer.lock")
 	assert.NoError(t, err)
+}
+
+func TestIsGitHubActionsToken403_ReturnsFalseForNonGitHubError(t *testing.T) {
+	result := isGitHubActionsToken403(nil, errors.New("plain network error"))
+	assert.False(t, result)
+}
+
+func TestIsGitHubActionsToken403_ReturnsTrueWhenRespFallback(t *testing.T) {
+	// github.ErrorResponse with nil Response but matching integration message —
+	// status code comes from the resp fallback parameter.
+	ghErr := &github.ErrorResponse{
+		Message: "Resource not accessible by integration",
+	}
+	resp := &github.Response{Response: &http.Response{StatusCode: http.StatusForbidden}}
+	assert.True(t, isGitHubActionsToken403(resp, ghErr))
 }

--- a/internal/codehosting/github_test.go
+++ b/internal/codehosting/github_test.go
@@ -79,6 +79,23 @@ func TestGithub_GetUser_Returns403FallbackSilently(t *testing.T) {
 	assert.Equal(t, "41898282+github-actions[bot]@users.noreply.github.com", email)
 }
 
+func TestGithub_GetUser_Returns403ErrorForBadCredentials(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}`))
+	}))
+	defer mockServer.Close()
+
+	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
+	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
+
+	name, email := gh.GetUser()
+
+	assert.Empty(t, name)
+	assert.Empty(t, email)
+}
+
 func TestGithub_GetUser_ReturnsUserOnSuccess(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
When drupdater runs inside a GitHub Actions workflow, the default GITHUB_TOKEN is an integration token that returns "403 Resource not accessible by integration" for GET /user. The previous check missed cases where go-github returns resp=nil but wraps the 403 inside a *github.ErrorResponse.

Fixes #96

Generated with [Claude Code](https://claude.ai/code)