### PR TITLE
docs: add daily security-only CI/CD job examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Replace `<repository_url>` with your repository's HTTPS URL and `<token>` with a
 
 #### GitLab CI
 
+**Weekly full update** — run via a [scheduled pipeline](https://docs.gitlab.com/ee/ci/pipelines/schedules.html) set to a weekly interval:
+
 ```yaml
 drupdater:
   image:
@@ -69,10 +71,25 @@ drupdater:
   script:
     - /opt/drupdater/bin $CI_PROJECT_URL $DRUPDATER_TOKEN
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $DRUPDATER_SCHEDULE == "weekly"
+```
+
+**Daily security-only update** — run via a separate scheduled pipeline set to a daily interval. Add `DRUPDATER_SCHEDULE=daily` as a pipeline schedule variable to distinguish it from the weekly run:
+
+```yaml
+drupdater-security:
+  image:
+    name: ghcr.io/drupdater/drupdater-php8.3:latest
+    entrypoint: [""]
+  script:
+    - /opt/drupdater/bin $CI_PROJECT_URL $DRUPDATER_TOKEN --security
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $DRUPDATER_SCHEDULE == "daily"
 ```
 
 #### GitHub Actions
+
+**Weekly full update:**
 
 ```yaml
 name: Drupdater
@@ -94,6 +111,30 @@ jobs:
     steps:
       - name: Run Drupdater
         run: /opt/drupdater/bin ${{ github.server_url }}/${{ github.repository }} ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Daily security-only update** — create a separate workflow file (e.g. `.github/workflows/drupdater-security.yml`) that runs every day and passes `--security` to only update packages with known vulnerabilities:
+
+```yaml
+name: Drupdater Security
+
+on:
+  schedule:
+    - cron: "0 4 * * *"  # every day at 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  drupdater-security:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/drupdater/drupdater-php8.3:latest
+    steps:
+      - name: Run Drupdater (security only)
+        run: /opt/drupdater/bin ${{ github.server_url }}/${{ github.repository }} ${{ secrets.GITHUB_TOKEN }} --security
 ```
 
 > **Note:** `GITHUB_TOKEN` is sufficient to push a branch and open a pull request. However, GitHub prevents workflows triggered by `GITHUB_TOKEN` from starting other workflows, so CI will not run automatically on the resulting PR. To have CI trigger on the Drupdater PR, use a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) or a [GitHub App token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) stored as a repository secret instead.


### PR DESCRIPTION
Extend the README CI/CD Integration section with daily security-only job examples for both GitHub Actions and GitLab CI, using the `--security` flag.

Closes #98

Generated with [Claude Code](https://claude.ai/code)