### PR TITLE
fix: log AbortError message instead of nil when branch already exists

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,10 +78,7 @@ var rootCmd = &cobra.Command{
 		// Start the update workflow
 		err := workflow.StartUpdate(cmd.Context(), addons)
 		if err != nil {
-			if errors.As(err, &services.AbortError{}) {
-				logger.Sugar().Warn(err)
-			} else {
-				logger.Sugar().Error(err)
+			if err := handleWorkflowError(logger, err); err != nil {
 				return err
 			}
 		}
@@ -125,6 +122,16 @@ func createAddons(
 	)
 
 	return addons
+}
+
+// handleWorkflowError logs AbortErrors as warnings (non-fatal) and all others as errors (fatal).
+func handleWorkflowError(logger *zap.Logger, err error) error {
+	if errors.As(err, &services.AbortError{}) {
+		logger.Sugar().Warn(err)
+		return nil
+	}
+	logger.Sugar().Error(err)
+	return err
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,7 +79,7 @@ var rootCmd = &cobra.Command{
 		err := workflow.StartUpdate(cmd.Context(), addons)
 		if err != nil {
 			if errors.As(err, &services.AbortError{}) {
-				logger.Sugar().Warn(errors.Unwrap(err))
+				logger.Sugar().Warn(err)
 			} else {
 				logger.Sugar().Error(err)
 				return err

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/services"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestNewLogger(t *testing.T) {
@@ -53,6 +57,39 @@ func TestNewCache(t *testing.T) {
 
 	assert.True(t, found)
 	assert.Equal(t, "test_value", value)
+}
+
+func TestHandleWorkflowError(t *testing.T) {
+	t.Run("AbortError logs warning with message not nil", func(t *testing.T) {
+		core, logs := observer.New(zap.WarnLevel)
+		logger := zap.New(core)
+
+		abortErr := services.AbortError{Msg: "branch already exists, skipping"}
+		result := handleWorkflowError(logger, abortErr)
+
+		assert.NoError(t, result)
+		assert.Equal(t, 1, logs.Len())
+		assert.Equal(t, zap.WarnLevel, logs.All()[0].Level)
+		assert.Equal(t, abortErr.Error(), logs.All()[0].Message)
+	})
+
+	t.Run("regular error logs at error level and is returned", func(t *testing.T) {
+		core, logs := observer.New(zap.ErrorLevel)
+		logger := zap.New(core)
+
+		regularErr := errors.New("something went wrong")
+		result := handleWorkflowError(logger, regularErr)
+
+		assert.ErrorIs(t, result, regularErr)
+		assert.Equal(t, 1, logs.Len())
+		assert.Equal(t, zap.ErrorLevel, logs.All()[0].Level)
+	})
+
+	t.Run("errors.Unwrap returns nil for AbortError confirming fix is needed", func(t *testing.T) {
+		abortErr := services.AbortError{Msg: "no changes detected"}
+		assert.Nil(t, errors.Unwrap(abortErr), "AbortError has no wrapped error, so Unwrap returns nil")
+		assert.Equal(t, "no changes detected", abortErr.Error())
+	})
 }
 
 func TestCreateAddons(t *testing.T) {


### PR DESCRIPTION
errors.Unwrap returns nil for AbortError since it has no wrapped error,
causing the warning to log <nil>. Log err directly instead.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JY2KuXzyQrJGiLXFNk74jL