### PR TITLE
fix: respect caller context in StartUpdate

### DIFF
--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -70,7 +70,7 @@ func NewWorkflowBaseService(
 }
 
 func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []internal.Addon) error {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 
 	defer func() {
 		// Clean up the temporary directory


### PR DESCRIPTION
## Summary

- `StartUpdate` accepted a `ctx context.Context` parameter but immediately replaced it with `context.WithCancel(context.Background())`, silently discarding any deadline, timeout, or cancellation signal from the caller.
- Fixed by deriving the cancel context from the passed-in `ctx` instead.

## Details

**Before:**
```go
ctx, cancel := context.WithCancel(context.Background())
```

**After:**
```go
ctx, cancel := context.WithCancel(ctx)
```

This ensures OS signals, test cancellations, and any caller-imposed deadlines propagate correctly into the workflow goroutines.

## Test plan

- [ ] All existing `TestStartUpdate*` tests pass (verified locally)
- [ ] Manually trigger cancellation via the caller context and confirm goroutines exit cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPaxWhhfhR6p2CF3897DNh)_