### PR TITLE
Use interfaces instead of concrete types in createAddons and createDispatcher

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,10 +88,10 @@ var rootCmd = &cobra.Command{
 func createAddons(
 	logger *zap.Logger,
 	config internal.Config,
-	drush *drush.CLI,
-	composer *composer.CLI,
-	drupalOrg *drupalorg.HTTPClient,
-	git *repo.GitRepositoryService,
+	drush addon.Drush,
+	composer addon.Composer,
+	drupalOrg addon.DrupalOrg,
+	git addon.Repository,
 ) []internal.Addon {
 	var addons []internal.Addon
 
@@ -122,7 +122,7 @@ func createAddons(
 }
 
 // createDispatcher creates a new event manager and subscribes all addons to it.
-func createDispatcher(addons []internal.Addon) *event.Manager {
+func createDispatcher(addons []internal.Addon) services.EventDispatcher {
 	dispatcher := event.NewManager("")
 	for _, addon := range addons {
 		dispatcher.AddSubscriber(addon)

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -12,10 +12,27 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 )
+
+func TestCodeBeautifier_SubscribedEvents(t *testing.T) {
+	cb := &CodeBeautifier{}
+	events := cb.SubscribedEvents()
+
+	assert.Contains(t, events, "post-code-update")
+	item := events["post-code-update"].(event.ListenerItem)
+	assert.Equal(t, event.Normal, item.Priority)
+}
+
+func TestCodeBeautifier_RenderTemplate(t *testing.T) {
+	cb := &CodeBeautifier{}
+	result, err := cb.RenderTemplate()
+	assert.NoError(t, err)
+	assert.Equal(t, "", result)
+}
 
 func TestCreatePHPCSConfig(t *testing.T) {
 	logger := zap.NewNop()

--- a/internal/addon/composer_patches_1_test.go
+++ b/internal/addon/composer_patches_1_test.go
@@ -10,11 +10,29 @@ import (
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/drupdater/drupdater/pkg/drupalorg"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.uber.org/zap"
 )
+
+func TestComposerPatches1_SubscribedEvents(t *testing.T) {
+	h := &ComposerPatches1{}
+	events := h.SubscribedEvents()
+
+	assert.Contains(t, events, "pre-composer-update")
+	item := events["pre-composer-update"].(event.ListenerItem)
+	assert.Equal(t, event.Normal, item.Priority)
+}
+
+func TestComposerPatches1_RenderTemplate_NoChanges(t *testing.T) {
+	logger := zap.NewNop()
+	h := &ComposerPatches1{logger: logger, patchUpdates: PatchUpdates{}}
+	result, err := h.RenderTemplate()
+	assert.NoError(t, err)
+	assert.Equal(t, "", result)
+}
 
 func TestUpdatePatches(t *testing.T) {
 

--- a/internal/addon/deprecations_remover_test.go
+++ b/internal/addon/deprecations_remover_test.go
@@ -9,10 +9,27 @@ import (
 	"github.com/drupdater/drupdater/pkg/rector"
 
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 )
+
+func TestDeprecationsRemover_SubscribedEvents(t *testing.T) {
+	dr := &DeprecationsRemover{}
+	events := dr.SubscribedEvents()
+
+	assert.Contains(t, events, "post-code-update")
+	item := events["post-code-update"].(event.ListenerItem)
+	assert.Equal(t, event.Normal, item.Priority)
+}
+
+func TestDeprecationsRemover_RenderTemplate(t *testing.T) {
+	dr := &DeprecationsRemover{}
+	result, err := dr.RenderTemplate()
+	assert.NoError(t, err)
+	assert.Equal(t, "", result)
+}
 
 func TestRemoveDeprecations(t *testing.T) {
 	// Common test setup

--- a/internal/addon/translations_updater_test.go
+++ b/internal/addon/translations_updater_test.go
@@ -8,10 +8,27 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 )
+
+func TestTranslationsUpdater_SubscribedEvents(t *testing.T) {
+	tu := &TranslationsUpdater{}
+	events := tu.SubscribedEvents()
+
+	assert.Contains(t, events, "post-site-update")
+	item := events["post-site-update"].(event.ListenerItem)
+	assert.Equal(t, event.Normal, item.Priority)
+}
+
+func TestTranslationsUpdater_RenderTemplate(t *testing.T) {
+	tu := &TranslationsUpdater{}
+	result, err := tu.RenderTemplate()
+	assert.NoError(t, err)
+	assert.Equal(t, "", result)
+}
 
 func TestUpdateTranslationsEventHandlerWithoutLocaleDeploy(t *testing.T) {
 	// Setup - Create mocks and system under test

--- a/internal/services/event_test.go
+++ b/internal/services/event_test.go
@@ -1,0 +1,80 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAbortError(t *testing.T) {
+	err := AbortError{Msg: "something aborted"}
+	assert.Equal(t, "something aborted", err.Error())
+}
+
+func TestNewPreComposerUpdateEvent(t *testing.T) {
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+	evt := NewPreComposerUpdateEvent(ctx, "/repo", worktree, []string{"drupal/core"}, []string{"keep/me"}, true)
+
+	assert.Equal(t, "pre-composer-update", evt.Name())
+	assert.Equal(t, ctx, evt.Context())
+	assert.Equal(t, "/repo", evt.Path())
+	assert.Equal(t, worktree, evt.Worktree())
+	assert.Equal(t, []string{"drupal/core"}, evt.PackagesToUpdate)
+	assert.Equal(t, []string{"keep/me"}, evt.PackagesToKeep)
+	assert.True(t, evt.MinimalChanges)
+}
+
+func TestNewPostComposerUpdateEvent(t *testing.T) {
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+	evt := NewPostComposerUpdateEvent(ctx, "/repo", worktree)
+
+	assert.Equal(t, "post-composer-update", evt.Name())
+	assert.Equal(t, ctx, evt.Context())
+	assert.Equal(t, "/repo", evt.Path())
+	assert.Equal(t, worktree, evt.Worktree())
+}
+
+func TestNewPostCodeUpdateEvent(t *testing.T) {
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+	evt := NewPostCodeUpdateEvent(ctx, "/repo", worktree)
+
+	assert.Equal(t, "post-code-update", evt.Name())
+	assert.Equal(t, ctx, evt.Context())
+	assert.Equal(t, "/repo", evt.Path())
+	assert.Equal(t, worktree, evt.Worktree())
+}
+
+func TestNewPreSiteUpdateEvent(t *testing.T) {
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+	evt := NewPreSiteUpdateEvent(ctx, "/repo", worktree, "default")
+
+	assert.Equal(t, "pre-site-update", evt.Name())
+	assert.Equal(t, ctx, evt.Context())
+	assert.Equal(t, "/repo", evt.Path())
+	assert.Equal(t, worktree, evt.Worktree())
+	assert.Equal(t, "default", evt.Site())
+}
+
+func TestNewPostSiteUpdateEvent(t *testing.T) {
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+	evt := NewPostSiteUpdateEvent(ctx, "/repo", worktree, "production")
+
+	assert.Equal(t, "post-site-update", evt.Name())
+	assert.Equal(t, ctx, evt.Context())
+	assert.Equal(t, "/repo", evt.Path())
+	assert.Equal(t, worktree, evt.Worktree())
+	assert.Equal(t, "production", evt.Site())
+}
+
+func TestNewPreMergeRequestCreateEvent(t *testing.T) {
+	evt := NewPreMergeRequestCreateEvent("June 2025: Drupal Updates")
+
+	assert.Equal(t, "pre-merge-request-create", evt.Name())
+	assert.Equal(t, "June 2025: Drupal Updates", evt.Title)
+}

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -253,6 +253,15 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 	vcsProvider.AssertExpectations(t)
 }
 
+func TestGenerateDescription_UnknownTemplate(t *testing.T) {
+	logger := zap.NewNop()
+	ws := NewWorkflowBaseService(logger, internal.Config{}, nil, nil, nil, nil, nil, nil)
+
+	_, err := ws.GenerateDescription(nil, "nonexistent.go.tmpl")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute template")
+}
+
 func TestStartUpdateFireEventError(t *testing.T) {
 	// Verify that a FireEvent error is propagated out of StartUpdate.
 	logger := zap.NewNop()


### PR DESCRIPTION
Replace *drush.CLI, *composer.CLI, *drupalorg.HTTPClient, and
*repo.GitRepositoryService with their respective addon package interfaces
(addon.Drush, addon.Composer, addon.DrupalOrg, addon.Repository) in the
createAddons function signature. Change createDispatcher to return
services.EventDispatcher instead of the concrete *event.Manager.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C8PDrpT2Ndm2FqSbnm2yhL