### PR TITLE
modernize: apply go fix modernizers and add make fix target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean mock lint fmt run docker-build docker-run help
+.PHONY: build test clean mock lint fmt fix run docker-build docker-run help
 
 # Variables
 BINARY_NAME=drupdater
@@ -31,6 +31,9 @@ lint: ## Run linters
 
 fmt: ## Format code
 	go fmt ./...
+
+fix: ## Apply go fix modernizers (interface{} → any, strings.Cut, etc.)
+	go fix ./...
 
 run: ## Run the application (requires REPO and TOKEN args)
 	@if [ -z "$(REPO)" ] || [ -z "$(TOKEN)" ]; then \

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -36,8 +36,8 @@ func NewCodeBeautifier(logger *zap.Logger, phpcs PHPCS, config internal.Config, 
 }
 
 // SubscribedEvents returns the events this addon listens to
-func (cb *CodeBeautifier) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (cb *CodeBeautifier) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"post-code-update": event.ListenerItem{
 			Priority: event.Normal,
 			Listener: event.ListenerFunc(cb.postCodeUpdateHandler),

--- a/internal/addon/composer_allow_plugins.go
+++ b/internal/addon/composer_allow_plugins.go
@@ -28,8 +28,8 @@ func NewComposerAllowPlugins(logger *zap.Logger, composer Composer) *ComposerAll
 }
 
 // SubscribedEvents returns the events this addon subscribes to
-func (ap *ComposerAllowPlugins) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (ap *ComposerAllowPlugins) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"pre-composer-update": event.ListenerItem{
 			Priority: event.Normal,
 			Listener: event.ListenerFunc(ap.preComposerUpdateHandler),

--- a/internal/addon/composer_allow_plugins_test.go
+++ b/internal/addon/composer_allow_plugins_test.go
@@ -84,7 +84,7 @@ func TestDefaultAllowPlugins_PostComposerUpdateHandler(t *testing.T) {
 	}
 
 	// Configure mock expectations
-	allPlugins := map[string]interface{}{
+	allPlugins := map[string]any{
 		"existing/plugin": struct{}{},
 		"new/plugin":      struct{}{},
 	}

--- a/internal/addon/composer_audit.go
+++ b/internal/addon/composer_audit.go
@@ -41,8 +41,8 @@ func NewComposerAudit(logger *zap.Logger, composer Composer) *ComposerAudit {
 }
 
 // SubscribedEvents returns the events this addon listens to.
-func (ca *ComposerAudit) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (ca *ComposerAudit) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"pre-composer-update": event.ListenerItem{
 			Priority: event.Max,
 			Listener: event.ListenerFunc(ca.preComposerUpdateHandler),

--- a/internal/addon/composer_diff.go
+++ b/internal/addon/composer_diff.go
@@ -27,8 +27,8 @@ func NewComposerDiff(logger *zap.Logger, composer Composer) *ComposerDiff {
 }
 
 // SubscribedEvents returns the events this addon listens to.
-func (cd *ComposerDiff) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (cd *ComposerDiff) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"post-composer-update": event.ListenerItem{
 			Priority: event.Min,
 			Listener: event.ListenerFunc(cd.postComposerUpdateHandler),

--- a/internal/addon/composer_normalizer.go
+++ b/internal/addon/composer_normalizer.go
@@ -25,8 +25,8 @@ func NewComposerNormalizer(logger *zap.Logger, composer Composer) *ComposerNorma
 }
 
 // SubscribedEvents returns the events this addon listens to.
-func (cn *ComposerNormalizer) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (cn *ComposerNormalizer) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"post-composer-update": event.ListenerItem{
 			Priority: event.Min,
 			Listener: event.ListenerFunc(cn.postComposerUpdateHandler),

--- a/internal/addon/composer_patches_1.go
+++ b/internal/addon/composer_patches_1.go
@@ -76,8 +76,8 @@ func NewComposerPatches1(logger *zap.Logger, composer Composer, drupalOrg Drupal
 	}
 }
 
-func (h *ComposerPatches1) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (h *ComposerPatches1) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"pre-composer-update": event.ListenerItem{
 			Priority: event.Normal,
 			Listener: event.ListenerFunc(h.preComposerUpdateHandler),

--- a/internal/addon/deprecations_remover.go
+++ b/internal/addon/deprecations_remover.go
@@ -28,8 +28,8 @@ func NewDeprecationsRemover(logger *zap.Logger, rector Rector, config internal.C
 }
 
 // SubscribedEvents returns the events this addon listens to
-func (dr *DeprecationsRemover) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (dr *DeprecationsRemover) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"post-code-update": event.ListenerItem{
 			Priority: event.Normal,
 			Listener: event.ListenerFunc(dr.postCodeUpdateHandler),

--- a/internal/addon/interfaces.go
+++ b/internal/addon/interfaces.go
@@ -26,7 +26,7 @@ type Composer interface {
 	SetConfig(ctx context.Context, dir string, key string, value string) error
 
 	CheckIfPatchApplies(ctx context.Context, packageName string, packageVersion string, patchPath string) (bool, error)
-	GetInstalledPlugins(ctx context.Context, dir string) (map[string]interface{}, error)
+	GetInstalledPlugins(ctx context.Context, dir string) (map[string]any, error)
 	IsPackageInstalled(ctx context.Context, dir string, packageToCheck string) (bool, error)
 	UpdateLockHash(ctx context.Context, dir string) error
 	GetCustomCodeDirectories(ctx context.Context, dir string) ([]string, error)

--- a/internal/addon/translations_updater.go
+++ b/internal/addon/translations_updater.go
@@ -27,8 +27,8 @@ func NewTranslationsUpdater(logger *zap.Logger, drush Drush, repository Reposito
 }
 
 // SubscribedEvents returns the events this addon listens to
-func (tu *TranslationsUpdater) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (tu *TranslationsUpdater) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"post-site-update": event.ListenerItem{
 			Priority: event.Normal,
 			Listener: event.ListenerFunc(tu.postSiteUpdateHandler),

--- a/internal/addon/update_hooks.go
+++ b/internal/addon/update_hooks.go
@@ -32,8 +32,8 @@ func NewUpdateHooks(logger *zap.Logger, drush Drush) *UpdateHooks {
 }
 
 // SubscribedEvents returns the events this addon listens to
-func (uh *UpdateHooks) SubscribedEvents() map[string]interface{} {
-	return map[string]interface{}{
+func (uh *UpdateHooks) SubscribedEvents() map[string]any {
+	return map[string]any{
 		"pre-site-update": event.ListenerItem{
 			Priority: event.Min,
 			Listener: event.ListenerFunc(uh.preSiteUpdateHandler),

--- a/internal/codehosting/factory_test.go
+++ b/internal/codehosting/factory_test.go
@@ -12,7 +12,7 @@ func TestDefaultVcsProviderFactory_Create(t *testing.T) {
 		name          string
 		repositoryURL string
 		token         string
-		expectedType  interface{}
+		expectedType  any
 	}{
 		{
 			name:          "returns gitlab platform for gitlab URLs",

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -375,7 +375,7 @@ func (ws *WorkflowBaseService) publishWork(repository GitRepository, updateBranc
 	return nil
 }
 
-func (ws *WorkflowBaseService) GenerateDescription(data interface{}, filename string) (string, error) {
+func (ws *WorkflowBaseService) GenerateDescription(data any, filename string) (string, error) {
 	tmpl, err := template.ParseFS(templates, "templates/*.go.tmpl")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse template: %w", err)

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -191,7 +191,7 @@ type Audit struct {
 // UnmarshalJSON flattens nested advisories into a single list.
 func (c *Audit) UnmarshalJSON(data []byte) error {
 	// Temporary map to parse nested structure
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
@@ -204,10 +204,10 @@ func (c *Audit) UnmarshalJSON(data []byte) error {
 
 	// Flatten advisories
 	var advisories []Advisory
-	if advMap, ok := advisoriesData.(map[string]interface{}); ok {
+	if advMap, ok := advisoriesData.(map[string]any); ok {
 		for _, value := range advMap {
 			switch v := value.(type) {
-			case []interface{}: // Simple advisory list
+			case []any: // Simple advisory list
 				for _, item := range v {
 					var adv Advisory
 					itemBytes, _ := json.Marshal(item)
@@ -216,7 +216,7 @@ func (c *Audit) UnmarshalJSON(data []byte) error {
 					}
 					advisories = append(advisories, adv)
 				}
-			case map[string]interface{}: // Nested map (e.g., drupal/core)
+			case map[string]any: // Nested map (e.g., drupal/core)
 				for _, nestedItem := range v {
 					var adv Advisory
 					nestedBytes, _ := json.Marshal(nestedItem)
@@ -383,14 +383,14 @@ func (s *CLI) CheckIfPatchApplies(ctx context.Context, packageName string, packa
 	return true, nil
 }
 
-func (s *CLI) GetInstalledPlugins(ctx context.Context, dir string) (map[string]interface{}, error) {
+func (s *CLI) GetInstalledPlugins(ctx context.Context, dir string) (map[string]any, error) {
 
 	out, err := s.execComposer(ctx, dir, "depends", "composer-plugin-api", "--locked")
 	if err != nil {
 		return nil, err
 	}
 
-	var packages = make(map[string]interface{})
+	var packages = make(map[string]any)
 	reg := regexp.MustCompile(`(?m)^(\S+)\s+v?[\d\.]+\s+requires`)
 	matches := reg.FindAllStringSubmatch(out, -1)
 

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -140,7 +140,7 @@ zaporylie/composer-drupal-optimizations        1.2.0   requires composer-plugin-
 		plugins, err := service.GetInstalledPlugins(t.Context(), "/tmp")
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]interface{}{
+		assert.Equal(t, map[string]any{
 			"composer/installers":                            nil,
 			"cweagans/composer-patches":                      nil,
 			"dealerdirect/phpcodesniffer-composer-installer": nil,
@@ -404,7 +404,7 @@ Using version ^11.1 for drupal/core`
 		assert.NoError(t, err)
 		capturedPatchesJSON = string(data)
 
-		var parsed map[string]interface{}
+		var parsed map[string]any
 		assert.NoError(t, json.Unmarshal([]byte(capturedPatchesJSON), &parsed),
 			"composer.patches.json must be valid JSON even when values contain special characters")
 	})

--- a/pkg/drupal/installer.go
+++ b/pkg/drupal/installer.go
@@ -136,13 +136,13 @@ func (is *Installer) isSqliteModuleEnabled(ctx context.Context, dir string, site
 	}
 
 	// Unmarshal the YAML data
-	var config map[string]interface{}
+	var config map[string]any
 	if err := yaml.Unmarshal(file, &config); err != nil {
 		return false, fmt.Errorf("failed to unmarshal core extension file: %w", err)
 	}
 
 	// Check if the sqlite module is enabled
-	if enabled, exists := config["module"].(map[string]interface{})["sqlite"]; exists && enabled == 0 {
+	if enabled, exists := config["module"].(map[string]any)["sqlite"]; exists && enabled == 0 {
 		siteLogger.Debug("sqlite module is enabled")
 		return true, nil
 	}
@@ -167,12 +167,12 @@ func (is *Installer) addSqliteModule(ctx context.Context, dir string, site strin
 	}
 
 	// Unmarshal the YAML data
-	var config map[string]interface{}
+	var config map[string]any
 	if err := yaml.Unmarshal(file, &config); err != nil {
 		return fmt.Errorf("failed to unmarshal core extension file: %w", err)
 	}
 
-	config["module"].(map[string]interface{})["sqlite"] = 0
+	config["module"].(map[string]any)["sqlite"] = 0
 
 	// Marshal the updated config back to YAML
 	updatedConfig, err := yaml.Marshal(config)

--- a/pkg/drupal/installer_test.go
+++ b/pkg/drupal/installer_test.go
@@ -167,13 +167,13 @@ profile: thunder
 	}
 
 	// Unmarshal the updated content
-	var updatedConfig map[string]interface{}
+	var updatedConfig map[string]any
 	if err := yaml.Unmarshal(updatedContent, &updatedConfig); err != nil {
 		t.Fatalf("Failed to unmarshal updated content: %v", err)
 	}
 
 	// Check if the SQLite module was added correctly
-	modules, ok := updatedConfig["module"].(map[string]interface{})
+	modules, ok := updatedConfig["module"].(map[string]any)
 	if !ok {
 		t.Fatalf("Modules key is not a map")
 	}

--- a/pkg/drush/drush.go
+++ b/pkg/drush/drush.go
@@ -112,10 +112,10 @@ func (e *CLI) GetTranslationPath(ctx context.Context, dir string, site string, r
 }
 
 type UpdateHook struct {
-	Module      string      `json:"module"`
-	UpdateID    interface{} `json:"update_id"`
-	Description string      `json:"description"`
-	Type        string      `json:"type"`
+	Module      string `json:"module"`
+	UpdateID    any    `json:"update_id"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
 }
 
 func (e *CLI) GetUpdateHooks(ctx context.Context, dir string, site string) (map[string]UpdateHook, error) {


### PR DESCRIPTION
Runs go fix ./... to convert interface{} → any across 18 files
(addon SubscribedEvents, composer/drush/installer maps, factory test).
Adds a `make fix` target to make this repeatable.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFzkyrq8S3f3QZA8PNA4JZ