### PR TITLE
Add run timeouts, context propagation, and signal handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,8 +83,9 @@ var rootCmd = &cobra.Command{
 			if err := handleWorkflowError(logger, err); err != nil {
 				return err
 			}
+		} else {
+			logger.Info("update finished")
 		}
-		logger.Info("update finished")
 		return nil
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/addon"
@@ -149,10 +153,15 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&config.SkipRector, "skip-rector", false, "Skip Rector. If true, the Rector will not run to remove deprecated code.")
 	rootCmd.PersistentFlags().BoolVar(&config.DryRun, "dry-run", false, "Dry run. If true, no branch and merge request will be created.")
 	rootCmd.PersistentFlags().BoolVar(&config.Verbose, "verbose", false, "Verbose")
+	rootCmd.PersistentFlags().DurationVar(&config.Timeout, "timeout", 30*time.Minute, "Overall run timeout. Set to 0 to disable.")
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	// Cancel the workflow context on SIGINT/SIGTERM so cleanup runs on termination.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}
 }

--- a/internal/codehosting/factory.go
+++ b/internal/codehosting/factory.go
@@ -1,16 +1,17 @@
 package codehosting
 
 import (
+	"context"
 	"strings"
 )
 
 // Platform defines the interface for version control system providers.
 type Platform interface {
 	// CreateMergeRequest creates a merge/pull request on the platform.
-	CreateMergeRequest(title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error)
+	CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error)
 
 	// GetUser returns the user name and email from the platform.
-	GetUser() (name string, email string)
+	GetUser(ctx context.Context) (name string, email string)
 }
 
 // MergeRequest represents a merge or pull request on a code hosting platform.

--- a/internal/codehosting/github.go
+++ b/internal/codehosting/github.go
@@ -30,8 +30,8 @@ func newGithub(repositoryURL string, token string) *Github {
 	}
 }
 
-func (g Github) CreateMergeRequest(title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error) {
-	mr, _, err := g.client.PullRequests.Create(context.TODO(), g.owner, g.repo, &github.NewPullRequest{
+func (g Github) CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error) {
+	mr, _, err := g.client.PullRequests.Create(ctx, g.owner, g.repo, &github.NewPullRequest{
 		Head:  &sourceBranch,
 		Base:  &targetBranch,
 		Title: &title,
@@ -60,8 +60,8 @@ func (g *Github) logError(err error) {
 // correctly without requiring a PAT.
 // Any other error (including a 403 from bad user credentials) is logged and
 // returns empty strings so callers can detect the failure.
-func (g *Github) GetUser() (name string, email string) {
-	user, resp, err := g.client.Users.Get(context.Background(), "")
+func (g *Github) GetUser(ctx context.Context) (name string, email string) {
+	user, resp, err := g.client.Users.Get(ctx, "")
 	if err != nil {
 		if isGitHubActionsToken403(resp, err) {
 			return "github-actions[bot]", "41898282+github-actions[bot]@users.noreply.github.com"

--- a/internal/codehosting/github_test.go
+++ b/internal/codehosting/github_test.go
@@ -1,6 +1,7 @@
 package codehosting
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -55,7 +56,7 @@ func TestGithub_CreateMergeRequest(t *testing.T) {
 	}
 
 	// Execute
-	mr, err := gh.CreateMergeRequest("Test MR", "This is a test MR", "source-branch", "target-branch")
+	mr, err := gh.CreateMergeRequest(context.Background(), "Test MR", "This is a test MR", "source-branch", "target-branch")
 
 	// Assert
 	assert.NoError(t, err)
@@ -74,7 +75,7 @@ func TestGithub_GetUser_Returns403FallbackSilently(t *testing.T) {
 	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
 	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
 
-	name, email := gh.GetUser()
+	name, email := gh.GetUser(context.Background())
 
 	assert.Equal(t, "github-actions[bot]", name)
 	assert.Equal(t, "41898282+github-actions[bot]@users.noreply.github.com", email)
@@ -91,7 +92,7 @@ func TestGithub_GetUser_Returns403ErrorForBadCredentials(t *testing.T) {
 	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
 	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
 
-	name, email := gh.GetUser()
+	name, email := gh.GetUser(context.Background())
 
 	assert.Empty(t, name)
 	assert.Empty(t, email)
@@ -108,7 +109,7 @@ func TestGithub_GetUser_ReturnsUserOnSuccess(t *testing.T) {
 	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
 	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
 
-	name, email := gh.GetUser()
+	name, email := gh.GetUser(context.Background())
 
 	assert.Equal(t, "The Octocat", name)
 	assert.Equal(t, "octocat@github.com", email)
@@ -125,7 +126,7 @@ func TestGithub_GetUser_NoEmailFallsBackToNoreply(t *testing.T) {
 	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
 	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
 
-	name, email := gh.GetUser()
+	name, email := gh.GetUser(context.Background())
 
 	assert.Equal(t, "The Octocat", name)
 	assert.Equal(t, "1234567+octocat@users.noreply.github.com", email)

--- a/internal/codehosting/github_test.go
+++ b/internal/codehosting/github_test.go
@@ -132,6 +132,32 @@ func TestGithub_GetUser_NoEmailFallsBackToNoreply(t *testing.T) {
 	assert.Equal(t, "1234567+octocat@users.noreply.github.com", email)
 }
 
+func TestGithub_CreateMergeRequest_HonorsContext(t *testing.T) {
+	// A cancelled context must abort before any request is sent. This would have
+	// passed silently when the implementation used context.TODO().
+	client, _ := github.NewClient(nil).WithEnterpriseURLs("http://example.invalid", "")
+	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := gh.CreateMergeRequest(ctx, "Test MR", "body", "source", "target")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestGithub_GetUser_HonorsContext(t *testing.T) {
+	client, _ := github.NewClient(nil).WithEnterpriseURLs("http://example.invalid", "")
+	gh := &Github{client: client, owner: "o", repo: "r", fs: afero.NewMemMapFs()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// A request error (not the Actions 403 fallback) yields empty strings.
+	name, email := gh.GetUser(ctx)
+	assert.Empty(t, name)
+	assert.Empty(t, email)
+}
+
 func TestIsGitHubActionsToken403_ReturnsFalseForNonGitHubError(t *testing.T) {
 	result := isGitHubActionsToken403(nil, errors.New("plain network error"))
 	assert.False(t, result)

--- a/internal/codehosting/gitlab.go
+++ b/internal/codehosting/gitlab.go
@@ -1,6 +1,7 @@
 package codehosting
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -45,13 +46,13 @@ func newGitlab(repositoryURL string, token string) *Gitlab {
 }
 
 // CreateMergeRequest creates a merge request on GitLab.
-func (g *Gitlab) CreateMergeRequest(title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error) {
+func (g *Gitlab) CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error) {
 	mr, _, err := g.client.MergeRequests.CreateMergeRequest(g.projectPath, &gitlab.CreateMergeRequestOptions{
 		SourceBranch: &sourceBranch,
 		TargetBranch: &targetBranch,
 		Title:        &title,
 		Description:  &description,
-	})
+	}, gitlab.WithContext(ctx))
 
 	if err != nil {
 		return MergeRequest{}, fmt.Errorf("failed to create merge request: %w", err)
@@ -63,8 +64,8 @@ func (g *Gitlab) CreateMergeRequest(title string, description string, sourceBran
 	}, nil
 }
 
-func (g *Gitlab) GetUser() (name string, email string) {
-	user, _, err := g.client.Users.CurrentUser()
+func (g *Gitlab) GetUser(ctx context.Context) (name string, email string) {
+	user, _, err := g.client.Users.CurrentUser(gitlab.WithContext(ctx))
 	if err != nil {
 		fmt.Printf("Error getting GitLab user: %v\n", err)
 		return "", ""

--- a/internal/codehosting/gitlab_test.go
+++ b/internal/codehosting/gitlab_test.go
@@ -84,6 +84,28 @@ func TestCreateMergeRequest(t *testing.T) {
 	assert.Equal(t, "http://example.com", mr.URL)
 }
 
+func TestGitlab_CreateMergeRequest_HonorsContext(t *testing.T) {
+	// A cancelled context must abort before the request is sent.
+	g := newGitlab("https://gitlab.com/user/repo", "dummy-token")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := g.CreateMergeRequest(ctx, "Test MR", "body", "source", "target")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestGitlab_GetUser_HonorsContext(t *testing.T) {
+	g := newGitlab("https://gitlab.com/user/repo", "dummy-token")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	name, email := g.GetUser(ctx)
+	assert.Empty(t, name)
+	assert.Empty(t, email)
+}
+
 func TestGetUser_ReturnsEmptyStringsOnError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/codehosting/gitlab_test.go
+++ b/internal/codehosting/gitlab_test.go
@@ -1,6 +1,7 @@
 package codehosting
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,7 +22,7 @@ func TestGitlab_CreateMergeRequest(t *testing.T) {
 
 	t.Run("failed to get create mr", func(t *testing.T) {
 
-		_, err := gitlab.CreateMergeRequest(title, description, sourceBranch, targetBranch)
+		_, err := gitlab.CreateMergeRequest(context.Background(), title, description, sourceBranch, targetBranch)
 		assert.Error(t, err)
 	})
 
@@ -77,7 +78,7 @@ func TestCreateMergeRequest(t *testing.T) {
 		fs:          afero.NewMemMapFs(),
 	}
 
-	mr, err := gitlab.CreateMergeRequest("Test MR", "This is a test MR", "source-branch", "target-branch")
+	mr, err := gitlab.CreateMergeRequest(context.Background(), "Test MR", "This is a test MR", "source-branch", "target-branch")
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), mr.ID)
 	assert.Equal(t, "http://example.com", mr.URL)
@@ -97,8 +98,7 @@ func TestGetUser_ReturnsEmptyStringsOnError(t *testing.T) {
 		fs:          afero.NewMemMapFs(),
 	}
 
-	name, email := g.GetUser()
+	name, email := g.GetUser(context.Background())
 	assert.Equal(t, "", name)
 	assert.Equal(t, "", email)
 }
-

--- a/internal/codehosting/mocks_test.go
+++ b/internal/codehosting/mocks_test.go
@@ -5,6 +5,8 @@
 package codehosting
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,8 +38,8 @@ func (_m *MockPlatform) EXPECT() *MockPlatform_Expecter {
 }
 
 // CreateMergeRequest provides a mock function for the type MockPlatform
-func (_mock *MockPlatform) CreateMergeRequest(title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error) {
-	ret := _mock.Called(title, description, sourceBranch, targetBranch)
+func (_mock *MockPlatform) CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error) {
+	ret := _mock.Called(ctx, title, description, sourceBranch, targetBranch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateMergeRequest")
@@ -45,16 +47,16 @@ func (_mock *MockPlatform) CreateMergeRequest(title string, description string, 
 
 	var r0 MergeRequest
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, string) (MergeRequest, error)); ok {
-		return returnFunc(title, description, sourceBranch, targetBranch)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string) (MergeRequest, error)); ok {
+		return returnFunc(ctx, title, description, sourceBranch, targetBranch)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, string) MergeRequest); ok {
-		r0 = returnFunc(title, description, sourceBranch, targetBranch)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string) MergeRequest); ok {
+		r0 = returnFunc(ctx, title, description, sourceBranch, targetBranch)
 	} else {
 		r0 = ret.Get(0).(MergeRequest)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string, string) error); ok {
-		r1 = returnFunc(title, description, sourceBranch, targetBranch)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
+		r1 = returnFunc(ctx, title, description, sourceBranch, targetBranch)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -67,19 +69,20 @@ type MockPlatform_CreateMergeRequest_Call struct {
 }
 
 // CreateMergeRequest is a helper method to define mock.On call
+//   - ctx context.Context
 //   - title string
 //   - description string
 //   - sourceBranch string
 //   - targetBranch string
-func (_e *MockPlatform_Expecter) CreateMergeRequest(title any, description any, sourceBranch any, targetBranch any) *MockPlatform_CreateMergeRequest_Call {
-	return &MockPlatform_CreateMergeRequest_Call{Call: _e.mock.On("CreateMergeRequest", title, description, sourceBranch, targetBranch)}
+func (_e *MockPlatform_Expecter) CreateMergeRequest(ctx any, title any, description any, sourceBranch any, targetBranch any) *MockPlatform_CreateMergeRequest_Call {
+	return &MockPlatform_CreateMergeRequest_Call{Call: _e.mock.On("CreateMergeRequest", ctx, title, description, sourceBranch, targetBranch)}
 }
 
-func (_c *MockPlatform_CreateMergeRequest_Call) Run(run func(title string, description string, sourceBranch string, targetBranch string)) *MockPlatform_CreateMergeRequest_Call {
+func (_c *MockPlatform_CreateMergeRequest_Call) Run(run func(ctx context.Context, title string, description string, sourceBranch string, targetBranch string)) *MockPlatform_CreateMergeRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -93,11 +96,16 @@ func (_c *MockPlatform_CreateMergeRequest_Call) Run(run func(title string, descr
 		if args[3] != nil {
 			arg3 = args[3].(string)
 		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -108,14 +116,14 @@ func (_c *MockPlatform_CreateMergeRequest_Call) Return(mergeRequest MergeRequest
 	return _c
 }
 
-func (_c *MockPlatform_CreateMergeRequest_Call) RunAndReturn(run func(title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error)) *MockPlatform_CreateMergeRequest_Call {
+func (_c *MockPlatform_CreateMergeRequest_Call) RunAndReturn(run func(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error)) *MockPlatform_CreateMergeRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUser provides a mock function for the type MockPlatform
-func (_mock *MockPlatform) GetUser() (string, string) {
-	ret := _mock.Called()
+func (_mock *MockPlatform) GetUser(ctx context.Context) (string, string) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUser")
@@ -123,16 +131,16 @@ func (_mock *MockPlatform) GetUser() (string, string) {
 
 	var r0 string
 	var r1 string
-	if returnFunc, ok := ret.Get(0).(func() (string, string)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, string)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() string); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func() string); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) string); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Get(1).(string)
 	}
@@ -145,13 +153,20 @@ type MockPlatform_GetUser_Call struct {
 }
 
 // GetUser is a helper method to define mock.On call
-func (_e *MockPlatform_Expecter) GetUser() *MockPlatform_GetUser_Call {
-	return &MockPlatform_GetUser_Call{Call: _e.mock.On("GetUser")}
+//   - ctx context.Context
+func (_e *MockPlatform_Expecter) GetUser(ctx any) *MockPlatform_GetUser_Call {
+	return &MockPlatform_GetUser_Call{Call: _e.mock.On("GetUser", ctx)}
 }
 
-func (_c *MockPlatform_GetUser_Call) Run(run func()) *MockPlatform_GetUser_Call {
+func (_c *MockPlatform_GetUser_Call) Run(run func(ctx context.Context)) *MockPlatform_GetUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -161,7 +176,7 @@ func (_c *MockPlatform_GetUser_Call) Return(name string, email string) *MockPlat
 	return _c
 }
 
-func (_c *MockPlatform_GetUser_Call) RunAndReturn(run func() (string, string)) *MockPlatform_GetUser_Call {
+func (_c *MockPlatform_GetUser_Call) RunAndReturn(run func(ctx context.Context) (string, string)) *MockPlatform_GetUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,5 +1,7 @@
 package internal
 
+import "time"
+
 type Config struct {
 	RepositoryURL string
 	Branch        string
@@ -10,4 +12,5 @@ type Config struct {
 	SkipRector    bool
 	DryRun        bool
 	Verbose       bool
+	Timeout       time.Duration
 }

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -38,8 +38,8 @@ type Installer interface {
 }
 
 type Platform interface {
-	CreateMergeRequest(title string, description string, sourceBranch string, targetBranch string) (codehosting.MergeRequest, error)
-	GetUser() (name string, email string)
+	CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (codehosting.MergeRequest, error)
+	GetUser(ctx context.Context) (name string, email string)
 }
 
 // EventDispatcher abstracts the event bus so it can be injected and tested independently.

--- a/internal/services/mocks_test.go
+++ b/internal/services/mocks_test.go
@@ -1352,8 +1352,8 @@ func (_m *MockPlatform) EXPECT() *MockPlatform_Expecter {
 }
 
 // CreateMergeRequest provides a mock function for the type MockPlatform
-func (_mock *MockPlatform) CreateMergeRequest(title string, description string, sourceBranch string, targetBranch string) (codehosting.MergeRequest, error) {
-	ret := _mock.Called(title, description, sourceBranch, targetBranch)
+func (_mock *MockPlatform) CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (codehosting.MergeRequest, error) {
+	ret := _mock.Called(ctx, title, description, sourceBranch, targetBranch)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateMergeRequest")
@@ -1361,16 +1361,16 @@ func (_mock *MockPlatform) CreateMergeRequest(title string, description string, 
 
 	var r0 codehosting.MergeRequest
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, string) (codehosting.MergeRequest, error)); ok {
-		return returnFunc(title, description, sourceBranch, targetBranch)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string) (codehosting.MergeRequest, error)); ok {
+		return returnFunc(ctx, title, description, sourceBranch, targetBranch)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, string) codehosting.MergeRequest); ok {
-		r0 = returnFunc(title, description, sourceBranch, targetBranch)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string) codehosting.MergeRequest); ok {
+		r0 = returnFunc(ctx, title, description, sourceBranch, targetBranch)
 	} else {
 		r0 = ret.Get(0).(codehosting.MergeRequest)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string, string) error); ok {
-		r1 = returnFunc(title, description, sourceBranch, targetBranch)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
+		r1 = returnFunc(ctx, title, description, sourceBranch, targetBranch)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1383,19 +1383,20 @@ type MockPlatform_CreateMergeRequest_Call struct {
 }
 
 // CreateMergeRequest is a helper method to define mock.On call
+//   - ctx context.Context
 //   - title string
 //   - description string
 //   - sourceBranch string
 //   - targetBranch string
-func (_e *MockPlatform_Expecter) CreateMergeRequest(title any, description any, sourceBranch any, targetBranch any) *MockPlatform_CreateMergeRequest_Call {
-	return &MockPlatform_CreateMergeRequest_Call{Call: _e.mock.On("CreateMergeRequest", title, description, sourceBranch, targetBranch)}
+func (_e *MockPlatform_Expecter) CreateMergeRequest(ctx any, title any, description any, sourceBranch any, targetBranch any) *MockPlatform_CreateMergeRequest_Call {
+	return &MockPlatform_CreateMergeRequest_Call{Call: _e.mock.On("CreateMergeRequest", ctx, title, description, sourceBranch, targetBranch)}
 }
 
-func (_c *MockPlatform_CreateMergeRequest_Call) Run(run func(title string, description string, sourceBranch string, targetBranch string)) *MockPlatform_CreateMergeRequest_Call {
+func (_c *MockPlatform_CreateMergeRequest_Call) Run(run func(ctx context.Context, title string, description string, sourceBranch string, targetBranch string)) *MockPlatform_CreateMergeRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -1409,11 +1410,16 @@ func (_c *MockPlatform_CreateMergeRequest_Call) Run(run func(title string, descr
 		if args[3] != nil {
 			arg3 = args[3].(string)
 		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -1424,14 +1430,14 @@ func (_c *MockPlatform_CreateMergeRequest_Call) Return(mergeRequest codehosting.
 	return _c
 }
 
-func (_c *MockPlatform_CreateMergeRequest_Call) RunAndReturn(run func(title string, description string, sourceBranch string, targetBranch string) (codehosting.MergeRequest, error)) *MockPlatform_CreateMergeRequest_Call {
+func (_c *MockPlatform_CreateMergeRequest_Call) RunAndReturn(run func(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (codehosting.MergeRequest, error)) *MockPlatform_CreateMergeRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetUser provides a mock function for the type MockPlatform
-func (_mock *MockPlatform) GetUser() (string, string) {
-	ret := _mock.Called()
+func (_mock *MockPlatform) GetUser(ctx context.Context) (string, string) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUser")
@@ -1439,16 +1445,16 @@ func (_mock *MockPlatform) GetUser() (string, string) {
 
 	var r0 string
 	var r1 string
-	if returnFunc, ok := ret.Get(0).(func() (string, string)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, string)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() string); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func() string); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) string); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Get(1).(string)
 	}
@@ -1461,13 +1467,20 @@ type MockPlatform_GetUser_Call struct {
 }
 
 // GetUser is a helper method to define mock.On call
-func (_e *MockPlatform_Expecter) GetUser() *MockPlatform_GetUser_Call {
-	return &MockPlatform_GetUser_Call{Call: _e.mock.On("GetUser")}
+//   - ctx context.Context
+func (_e *MockPlatform_Expecter) GetUser(ctx any) *MockPlatform_GetUser_Call {
+	return &MockPlatform_GetUser_Call{Call: _e.mock.On("GetUser", ctx)}
 }
 
-func (_c *MockPlatform_GetUser_Call) Run(run func()) *MockPlatform_GetUser_Call {
+func (_c *MockPlatform_GetUser_Call) Run(run func(ctx context.Context)) *MockPlatform_GetUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1477,7 +1490,7 @@ func (_c *MockPlatform_GetUser_Call) Return(name string, email string) *MockPlat
 	return _c
 }
 
-func (_c *MockPlatform_GetUser_Call) RunAndReturn(run func() (string, string)) *MockPlatform_GetUser_Call {
+func (_c *MockPlatform_GetUser_Call) RunAndReturn(run func(ctx context.Context) (string, string)) *MockPlatform_GetUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -78,6 +78,13 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 		os.RemoveAll(tmpDirName)
 	}()
 
+	// Bound the whole run so a wedged subprocess or network call can't hang forever.
+	if ws.config.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, ws.config.Timeout)
+		defer cancel()
+	}
+
 	// errgroup cancels ctx on the first error and bounds concurrency to the CPU count.
 	// publishWork runs only after Wait() returns nil, so a failed phase can never publish an MR.
 	g, ctx := errgroup.WithContext(ctx)
@@ -137,13 +144,13 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 	}
 
 	if !ws.config.DryRun {
-		return ws.publishWork(sharedUpdate.Repository, sharedUpdate.updateBranchName, addons)
+		return ws.publishWork(ctx, sharedUpdate.Repository, sharedUpdate.updateBranchName, addons)
 	}
 	return nil
 }
 
 func (ws *WorkflowBaseService) installCode(ctx context.Context) (string, error) {
-	username, email := ws.platform.GetUser()
+	username, email := ws.platform.GetUser(ctx)
 	ws.logger.Info("cloning repository for site-install", zap.String("repositoryURL", ws.config.RepositoryURL), zap.String("branch", ws.config.Branch))
 	_, _, path, err := ws.repository.CloneRepository(ws.config.RepositoryURL, ws.config.Branch, ws.config.Token, username, email)
 	if err != nil {
@@ -160,7 +167,7 @@ func (ws *WorkflowBaseService) installCode(ctx context.Context) (string, error) 
 
 func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context) (SharedUpdate, error) {
 	ws.logger.Info("cloning repository for update", zap.String("repositoryURL", ws.config.RepositoryURL), zap.String("branch", ws.config.Branch))
-	username, email := ws.platform.GetUser()
+	username, email := ws.platform.GetUser(ctx)
 	repository, worktree, path, err := ws.repository.CloneRepository(ws.config.RepositoryURL, ws.config.Branch, ws.config.Token, username, email)
 	if err != nil {
 		return SharedUpdate{}, fmt.Errorf("failed to clone repository: %w", err)
@@ -273,7 +280,7 @@ func (ws *WorkflowBaseService) updateSite(ctx context.Context, sharedUpdate Shar
 	return nil
 }
 
-func (ws *WorkflowBaseService) publishWork(repository GitRepository, updateBranchName string, addons []internal.Addon) error {
+func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRepository, updateBranchName string, addons []internal.Addon) error {
 	err := repository.Push(&git.PushOptions{
 		RemoteName: "origin",
 		RefSpecs: []gitConfig.RefSpec{
@@ -307,7 +314,7 @@ func (ws *WorkflowBaseService) publishWork(repository GitRepository, updateBranc
 		return fmt.Errorf("failed to fire event: %w", err)
 	}
 
-	mr, err := ws.platform.CreateMergeRequest(e.Title, description, updateBranchName, ws.config.Branch)
+	mr, err := ws.platform.CreateMergeRequest(ctx, e.Title, description, updateBranchName, ws.config.Branch)
 	if err != nil {
 		return fmt.Errorf("failed to create merge request: %w", err)
 	}

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/codehosting"
@@ -133,6 +134,51 @@ func TestStartUpdateSiteFailureDoesNotPublish(t *testing.T) {
 
 	// Assert: the error surfaces and no MR was published.
 	assert.ErrorIs(t, err, updateErr)
+	repository.AssertNotCalled(t, "Push", mock.Anything)
+	vcsProvider.AssertNotCalled(t, "CreateMergeRequest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestStartUpdateTimeout(t *testing.T) {
+	// A run-level timeout must cancel the workflow context and surface as a
+	// deadline error rather than hanging.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Sites:         []string{"site1"},
+		Timeout:       20 * time.Millisecond,
+	}
+
+	worktree := NewMockWorktree(t)
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil).Times(2)
+
+	// Both phases block on the context, simulating a wedged subprocess; the run
+	// timeout is what releases them.
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").RunAndReturn(func(ctx context.Context, _ string) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).RunAndReturn(func(ctx context.Context, _ string, _ []string, _ []string, _ bool, _ bool) ([]composer.PackageChange, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}).Maybe()
+
+	// Execute
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(ctx, nil)
+
+	// Assert: the deadline propagates and nothing is published.
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	repository.AssertNotCalled(t, "Push", mock.Anything)
 	vcsProvider.AssertNotCalled(t, "CreateMergeRequest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -56,8 +56,8 @@ func TestStartUpdate(t *testing.T) {
 	fixture, err := os.ReadFile("testdata/dependency_update.md")
 	assert.NoError(t, err, "Failed to read test fixture")
 
-	vcsProvider.EXPECT().GetUser().Return("user", "mail")
-	vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, string(fixture), mock.Anything, config.Branch).Return(codehosting.MergeRequest{}, nil)
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, string(fixture), mock.Anything, config.Branch).Return(codehosting.MergeRequest{}, nil)
 
 	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
 		{
@@ -111,7 +111,7 @@ func TestStartUpdateSiteFailureDoesNotPublish(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil).Times(2)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything).Return(false, nil)
 
-	vcsProvider.EXPECT().GetUser().Return("user", "mail")
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
 	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
@@ -134,7 +134,7 @@ func TestStartUpdateSiteFailureDoesNotPublish(t *testing.T) {
 	// Assert: the error surfaces and no MR was published.
 	assert.ErrorIs(t, err, updateErr)
 	repository.AssertNotCalled(t, "Push", mock.Anything)
-	vcsProvider.AssertNotCalled(t, "CreateMergeRequest", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	vcsProvider.AssertNotCalled(t, "CreateMergeRequest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestStartUpdateNoChanges(t *testing.T) {
@@ -160,7 +160,7 @@ func TestStartUpdateNoChanges(t *testing.T) {
 	// installSite may or may not run depending on goroutine scheduling after cancel.
 	worktree := NewMockWorktree(t)
 
-	vcsProvider.EXPECT().GetUser().Return("user", "mail")
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 
 	// installCode: one CloneRepository + Install
 	// updateSharedCode: one CloneRepository + Update (returns empty → AbortError)
@@ -214,7 +214,7 @@ func TestStartUpdateBranchAlreadyExists(t *testing.T) {
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
 
-	vcsProvider.EXPECT().GetUser().Return("user", "mail")
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil).Times(2)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything).Return(true, nil)
@@ -281,7 +281,7 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil).Times(2)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything).Return(false, nil)
 
-	vcsProvider.EXPECT().GetUser().Return("user", "mail")
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 
 	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
 		{
@@ -338,7 +338,7 @@ func TestStartUpdateFireEventError(t *testing.T) {
 
 	worktree := NewMockWorktree(t)
 
-	vcsProvider.EXPECT().GetUser().Return("user", "mail")
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 
 	// installCode and updateSharedCode each clone the repository.
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").

--- a/pkg/drupalorg/drupalorg.go
+++ b/pkg/drupalorg/drupalorg.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -12,12 +13,14 @@ import (
 type HTTPClient struct {
 	DrupalOrgBaseURL string
 	logger           *zap.Logger
+	client           *http.Client
 }
 
 func NewHTTPClient(logger *zap.Logger) *HTTPClient {
 	return &HTTPClient{
 		DrupalOrgBaseURL: "https://www.drupal.org",
 		logger:           logger,
+		client:           &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -32,7 +35,7 @@ type Issue struct {
 }
 
 func (s *HTTPClient) GetIssue(issueID string) (*Issue, error) {
-	resp, err := http.Get(s.DrupalOrgBaseURL + "/api-d7/node/" + issueID + ".json")
+	resp, err := s.client.Get(s.DrupalOrgBaseURL + "/api-d7/node/" + issueID + ".json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}

--- a/pkg/drupalorg/drupalorg_test.go
+++ b/pkg/drupalorg/drupalorg_test.go
@@ -30,6 +30,7 @@ func TestGetIssue(t *testing.T) {
 	service := &HTTPClient{
 		DrupalOrgBaseURL: mockServer.URL,
 		logger:           logger,
+		client:           &http.Client{},
 	}
 
 	// Call GetIssue method
@@ -57,6 +58,7 @@ func TestGetIssue_Failure(t *testing.T) {
 	service := &HTTPClient{
 		DrupalOrgBaseURL: mockServer.URL,
 		logger:           logger,
+		client:           &http.Client{},
 	}
 
 	// Call GetIssue method

--- a/pkg/drupalorg/drupalorg_test.go
+++ b/pkg/drupalorg/drupalorg_test.go
@@ -4,10 +4,37 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
+
+func TestNewHTTPClient_HasTimeout(t *testing.T) {
+	c := NewHTTPClient(zap.NewNop())
+	assert.Equal(t, 30*time.Second, c.client.Timeout)
+}
+
+func TestGetIssue_Timeout(t *testing.T) {
+	// Server never responds; the client timeout must abort the request.
+	block := make(chan struct{})
+	mockServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-block
+	}))
+	defer mockServer.Close()
+	defer close(block)
+
+	service := &HTTPClient{
+		DrupalOrgBaseURL: mockServer.URL,
+		logger:           zaptest.NewLogger(t),
+		client:           &http.Client{Timeout: 10 * time.Millisecond},
+	}
+
+	issue, err := service.GetIssue("12345")
+	assert.Error(t, err)
+	assert.Nil(t, issue)
+}
 
 func TestGetIssue(t *testing.T) {
 	// Mock server to simulate Drupal API


### PR DESCRIPTION
Nothing bounded a run: subprocesses used CommandContext but no deadline was ever set, the Drupal.org client used the default http client (no timeout), and the GitHub adapter passed context.TODO()/Background() so cancellation never reached the API. A wedged call could hang a CI job forever.

- Thread ctx through the Platform interface (CreateMergeRequest, GetUser); drop context.TODO()/Background() in github.go, pass gitlab.WithContext in gitlab.go.
- Add --timeout (default 30m, 0 disables); StartUpdate wraps ctx in context.WithTimeout so the whole run is bounded.
- Give the Drupal.org HTTP client a 30s timeout.
- Install signal.NotifyContext(SIGINT, SIGTERM) at the root via ExecuteContext so termination cancels the workflow and cleanup runs.

Regenerate mocks for the new Platform signatures.