### PR TITLE
feat: add per_package commit strategy (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,14 @@ Events fired during the workflow: `PreComposerUpdateEvent`, `PostComposerUpdateE
 Config is split into two tiers, with no overlap:
 
 - **CLI flags** — how a given run is invoked (volatile): token (positional arg), plus the flags below.
-- **`.drupdater.yaml`** — what the project needs (committed at the repo root, read from `<working-dir>/.drupdater.yaml` or `--config`). Loaded by `internal/configfile.go`; a missing file falls back to built-in defaults, absent keys keep their default, and unknown keys are rejected (strict decode). Keys: `sites`, `timeout` (Go duration string, e.g. `30m`), and `addons.normal` / `addons.security`. Addon names in both lists are validated up front via `validateAddons`; `drupdater addons` lists valid names.
+- **`.drupdater.yaml`** — what the project needs (committed at the repo root, read from `<working-dir>/.drupdater.yaml` or `--config`). Loaded by `internal/configfile.go`; a missing file falls back to built-in defaults, absent keys keep their default, and unknown keys are rejected (strict decode). Keys: `sites`, `timeout` (Go duration string, e.g. `30m`), `commit_strategy` (`bulk` / `per_package`), and `addons.normal` / `addons.security`. Addon names in both lists are validated up front via `validateAddons`; `drupdater addons` lists valid names.
+
+### Commit strategy
+
+`commit_strategy` (default `bulk`) controls how the update is committed:
+
+- **`bulk`** — one `composer update` for all packages, one drush cycle, the existing addon commits. Fastest; the default.
+- **`per_package`** — iterate the direct outdated packages (`composer outdated --direct`) and produce one atomic commit per package (`Update drupal/core 10.1.8 → 10.3.14`) bundling that package's composer + config + patch + translation changes, so any single commit reverts cleanly. The package loop is serial (one working dir, incremental lock + DB); sites still run concurrently within each package. `code_beautifier` and `deprecations_remover` run once at the end. **Not supported with `--security`** (incompatible with `composer_audit`'s whole-run semantics) — a security run logs a warning and falls back to `bulk`. Implemented as a squash: existing components commit as usual, then the workflow soft-resets and re-commits everything as one commit per package.
 
 ### CLI Flags
 
@@ -98,6 +105,7 @@ Config is split into two tiers, with no overlap:
 ```yaml
 sites: [default]      # Drupal site names
 timeout: 30m          # overall run timeout (Go duration; 0 disables)
+commit_strategy: bulk # bulk (one commit) or per_package (one atomic commit per package)
 addons:               # configurable addons per mode; mandatory addons always run
   normal:
     - code_beautifier

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ falls back to the defaults shown below. Unknown keys are rejected, so typos fail
 ```yaml
 sites: [default]      # Drupal site directories to update
 timeout: 30m          # overall run timeout (Go duration string; 0 disables)
+commit_strategy: bulk # bulk (one commit for all packages) or per_package (one per package)
 addons:               # which configurable addons run in each mode
   normal:
     - code_beautifier        # phpcbf PHP code style fixes
@@ -188,6 +189,12 @@ addons:               # which configurable addons run in each mode
     - composer_normalizer
   security: []          # minimal by default: just the security fix, nothing else
 ```
+
+`commit_strategy` defaults to `bulk` (one `composer update` for everything, committed together).
+Set it to `per_package` to update one direct package at a time and produce one atomic commit per
+package (`Update drupal/core 10.1.8 → 10.3.14`) that bundles that package's composer, config,
+patch, and translation changes, so any single commit can be reverted cleanly. It is not supported
+with `--security` (a security run falls back to `bulk`).
 
 `--security` picks the `addons.security` list; otherwise `addons.normal` is used. Security runs
 default to no extra addons so nothing interferes with the package update — add entries here only

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ names you can set there. See the README for the full file format.`,
 			zap.Duration("timeout", config.Timeout),
 			zap.Strings("addons.normal", config.Addons.Normal),
 			zap.Strings("addons.security", config.Addons.Security),
+			zap.String("commit_strategy", config.CommitStrategy),
 		)
 
 		cache := NewCache()

--- a/internal/addon/mocks_test.go
+++ b/internal/addon/mocks_test.go
@@ -2460,6 +2460,57 @@ func (_c *MockWorktree_Remove_Call) RunAndReturn(run func(path string) (plumbing
 	return _c
 }
 
+// Reset provides a mock function for the type MockWorktree
+func (_mock *MockWorktree) Reset(opts *git.ResetOptions) error {
+	ret := _mock.Called(opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reset")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*git.ResetOptions) error); ok {
+		r0 = returnFunc(opts)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorktree_Reset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reset'
+type MockWorktree_Reset_Call struct {
+	*mock.Call
+}
+
+// Reset is a helper method to define mock.On call
+//   - opts *git.ResetOptions
+func (_e *MockWorktree_Expecter) Reset(opts any) *MockWorktree_Reset_Call {
+	return &MockWorktree_Reset_Call{Call: _e.mock.On("Reset", opts)}
+}
+
+func (_c *MockWorktree_Reset_Call) Run(run func(opts *git.ResetOptions)) *MockWorktree_Reset_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *git.ResetOptions
+		if args[0] != nil {
+			arg0 = args[0].(*git.ResetOptions)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorktree_Reset_Call) Return(err error) *MockWorktree_Reset_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorktree_Reset_Call) RunAndReturn(run func(opts *git.ResetOptions) error) *MockWorktree_Reset_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Status provides a mock function for the type MockWorktree
 func (_mock *MockWorktree) Status() (git.Status, error) {
 	ret := _mock.Called()

--- a/internal/config.go
+++ b/internal/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	Verbose       bool
 	Timeout       time.Duration
 	Addons        AddonsConfig
+	// CommitStrategy is "bulk" (one commit for all packages, default) or "per_package"
+	// (one atomic commit per direct package, including its config/patch/translation changes).
+	CommitStrategy string
 }
 
 // AddonsConfig lists which configurable addons run in each mode. Mandatory addons

--- a/internal/configfile.go
+++ b/internal/configfile.go
@@ -22,9 +22,10 @@ var defaultNormalAddons = []string{
 // fileConfig mirrors the YAML-settable keys of .drupdater.yaml. Timeout is a string because
 // yaml.v3 cannot decode a duration like "30m" into a time.Duration.
 type fileConfig struct {
-	Sites   []string     `yaml:"sites"`
-	Timeout string       `yaml:"timeout"`
-	Addons  AddonsConfig `yaml:"addons"`
+	Sites          []string     `yaml:"sites"`
+	Timeout        string       `yaml:"timeout"`
+	Addons         AddonsConfig `yaml:"addons"`
+	CommitStrategy string       `yaml:"commit_strategy"`
 }
 
 // defaultFileConfig returns a fileConfig pre-populated with defaults. Unmarshaling a YAML file
@@ -38,6 +39,7 @@ func defaultFileConfig() fileConfig {
 			Normal:   defaultNormalAddons,
 			Security: nil, // minimal by default; composer_audit is added automatically
 		},
+		CommitStrategy: "bulk",
 	}
 }
 
@@ -72,8 +74,12 @@ func applyFileConfig(fc fileConfig, c *Config) error {
 	if err != nil {
 		return fmt.Errorf("invalid timeout %q (use a Go duration like \"30m\" or \"2h\"): %w", fc.Timeout, err)
 	}
+	if fc.CommitStrategy != "bulk" && fc.CommitStrategy != "per_package" {
+		return fmt.Errorf("invalid commit_strategy %q (use \"bulk\" or \"per_package\")", fc.CommitStrategy)
+	}
 	c.Sites = fc.Sites
 	c.Timeout = timeout
 	c.Addons = fc.Addons
+	c.CommitStrategy = fc.CommitStrategy
 	return nil
 }

--- a/internal/configfile_test.go
+++ b/internal/configfile_test.go
@@ -61,4 +61,25 @@ func TestLoadConfigFile(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "timout")
 	})
+
+	t.Run("commit_strategy defaults to bulk", func(t *testing.T) {
+		var c Config
+		_, err := LoadConfigFile(filepath.Join(t.TempDir(), "absent.yaml"), &c)
+		require.NoError(t, err)
+		assert.Equal(t, "bulk", c.CommitStrategy)
+	})
+
+	t.Run("commit_strategy per_package is accepted", func(t *testing.T) {
+		var c Config
+		_, err := LoadConfigFile(writeConfig(t, "commit_strategy: per_package\n"), &c)
+		require.NoError(t, err)
+		assert.Equal(t, "per_package", c.CommitStrategy)
+	})
+
+	t.Run("invalid commit_strategy is an error", func(t *testing.T) {
+		var c Config
+		_, err := LoadConfigFile(writeConfig(t, "commit_strategy: nonsense\n"), &c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "commit_strategy")
+	})
 }

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -14,6 +14,7 @@ type Composer interface {
 	Update(ctx context.Context, dir string, packagesToUpdate []string, packagesToKeep []string, minimalChanges bool, dryRun bool) ([]composer.PackageChange, error)
 	GetLockHash(dir string) (string, error)
 	CheckPlatformReqs(ctx context.Context, dir string) (string, error)
+	Outdated(ctx context.Context, dir string) ([]string, error)
 }
 
 type Drush interface {

--- a/internal/services/mocks_test.go
+++ b/internal/services/mocks_test.go
@@ -227,6 +227,74 @@ func (_c *MockComposer_Install_Call) RunAndReturn(run func(ctx context.Context, 
 	return _c
 }
 
+// Outdated provides a mock function for the type MockComposer
+func (_mock *MockComposer) Outdated(ctx context.Context, dir string) ([]string, error) {
+	ret := _mock.Called(ctx, dir)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Outdated")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
+		return returnFunc(ctx, dir)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, dir)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, dir)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockComposer_Outdated_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Outdated'
+type MockComposer_Outdated_Call struct {
+	*mock.Call
+}
+
+// Outdated is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dir string
+func (_e *MockComposer_Expecter) Outdated(ctx any, dir any) *MockComposer_Outdated_Call {
+	return &MockComposer_Outdated_Call{Call: _e.mock.On("Outdated", ctx, dir)}
+}
+
+func (_c *MockComposer_Outdated_Call) Run(run func(ctx context.Context, dir string)) *MockComposer_Outdated_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockComposer_Outdated_Call) Return(strings []string, err error) *MockComposer_Outdated_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockComposer_Outdated_Call) RunAndReturn(run func(ctx context.Context, dir string) ([]string, error)) *MockComposer_Outdated_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function for the type MockComposer
 func (_mock *MockComposer) Update(ctx context.Context, dir string, packagesToUpdate []string, packagesToKeep []string, minimalChanges bool, dryRun bool) ([]composer.PackageChange, error) {
 	ret := _mock.Called(ctx, dir, packagesToUpdate, packagesToKeep, minimalChanges, dryRun)
@@ -963,6 +1031,61 @@ func (_m *MockGitRepository) EXPECT() *MockGitRepository_Expecter {
 	return &MockGitRepository_Expecter{mock: &_m.Mock}
 }
 
+// Head provides a mock function for the type MockGitRepository
+func (_mock *MockGitRepository) Head() (*plumbing.Reference, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Head")
+	}
+
+	var r0 *plumbing.Reference
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (*plumbing.Reference, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() *plumbing.Reference); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*plumbing.Reference)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGitRepository_Head_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Head'
+type MockGitRepository_Head_Call struct {
+	*mock.Call
+}
+
+// Head is a helper method to define mock.On call
+func (_e *MockGitRepository_Expecter) Head() *MockGitRepository_Head_Call {
+	return &MockGitRepository_Head_Call{Call: _e.mock.On("Head")}
+}
+
+func (_c *MockGitRepository_Head_Call) Run(run func()) *MockGitRepository_Head_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockGitRepository_Head_Call) Return(reference *plumbing.Reference, err error) *MockGitRepository_Head_Call {
+	_c.Call.Return(reference, err)
+	return _c
+}
+
+func (_c *MockGitRepository_Head_Call) RunAndReturn(run func() (*plumbing.Reference, error)) *MockGitRepository_Head_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Push provides a mock function for the type MockGitRepository
 func (_mock *MockGitRepository) Push(o *git.PushOptions) error {
 	ret := _mock.Called(o)
@@ -1386,6 +1509,57 @@ func (_c *MockWorktree_Remove_Call) Return(hash plumbing.Hash, err error) *MockW
 }
 
 func (_c *MockWorktree_Remove_Call) RunAndReturn(run func(path string) (plumbing.Hash, error)) *MockWorktree_Remove_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Reset provides a mock function for the type MockWorktree
+func (_mock *MockWorktree) Reset(opts *git.ResetOptions) error {
+	ret := _mock.Called(opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reset")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*git.ResetOptions) error); ok {
+		r0 = returnFunc(opts)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorktree_Reset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reset'
+type MockWorktree_Reset_Call struct {
+	*mock.Call
+}
+
+// Reset is a helper method to define mock.On call
+//   - opts *git.ResetOptions
+func (_e *MockWorktree_Expecter) Reset(opts any) *MockWorktree_Reset_Call {
+	return &MockWorktree_Reset_Call{Call: _e.mock.On("Reset", opts)}
+}
+
+func (_c *MockWorktree_Reset_Call) Run(run func(opts *git.ResetOptions)) *MockWorktree_Reset_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *git.ResetOptions
+		if args[0] != nil {
+			arg0 = args[0].(*git.ResetOptions)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorktree_Reset_Call) Return(err error) *MockWorktree_Reset_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorktree_Reset_Call) RunAndReturn(run func(opts *git.ResetOptions) error) *MockWorktree_Reset_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/pkg/composer"
 
 	git "github.com/go-git/go-git/v5"
 	gitConfig "github.com/go-git/go-git/v5/config"
@@ -109,17 +110,33 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 		return err
 	}
 
-	// Update the shared code: composer update, commit, and create the update branch.
-	updateBranchName, err := ws.updateSharedCode(ctx, repository, worktree, path)
-	if err != nil {
-		return err
+	// per_package mode produces one atomic commit per direct package. It's incompatible with
+	// the composer_audit addon's whole-run semantics, so it only applies to normal updates;
+	// security runs fall back to bulk.
+	perPackage := ws.config.CommitStrategy == "per_package" && !ws.config.Security
+	if ws.config.CommitStrategy == "per_package" && ws.config.Security {
+		ws.logger.Warn("per_package commit strategy is not supported with --security; falling back to bulk")
 	}
 
-	// Run the update hooks and export config per site against the now-updated code.
-	if err := ws.forEachSite(ctx, func(ctx context.Context, site string) error {
-		return ws.updateSite(ctx, path, worktree, site)
-	}); err != nil {
-		return err
+	var updateBranchName string
+	if perPackage {
+		updateBranchName, err = ws.updatePerPackage(ctx, repository, worktree, path)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Update the shared code: composer update, commit, and create the update branch.
+		updateBranchName, err = ws.updateSharedCode(ctx, repository, worktree, path)
+		if err != nil {
+			return err
+		}
+
+		// Run the update hooks and export config per site against the now-updated code.
+		if err := ws.forEachSite(ctx, func(ctx context.Context, site string) error {
+			return ws.updateSite(ctx, path, worktree, site)
+		}); err != nil {
+			return err
+		}
 	}
 
 	if !ws.config.DryRun {
@@ -240,6 +257,134 @@ func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository 
 	}
 
 	return updateBranchName, nil
+}
+
+// updatePerPackage updates one direct package at a time, running the full site cycle for each
+// and squashing all of a package's side effects (composer, config, patches, translations) into
+// a single atomic commit. It returns the name of the created update branch.
+func (ws *WorkflowBaseService) updatePerPackage(ctx context.Context, repository GitRepository, worktree Worktree, path string) (string, error) {
+	ws.logger.Info("updating dependencies per package")
+
+	packages, err := ws.composer.Outdated(ctx, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to list outdated packages: %w", err)
+	}
+	if len(packages) == 0 {
+		return "", AbortError{Msg: "no outdated packages detected"}
+	}
+
+	committed := 0
+	for _, pkg := range packages {
+		head, err := repository.Head()
+		if err != nil {
+			return "", fmt.Errorf("failed to read HEAD: %w", err)
+		}
+		start := head.Hash()
+
+		// Let the patches addon update patch entries for this package, and open plugins.
+		preComposerUpdateEvent := NewPreComposerUpdateEvent(ctx, path, worktree, []string{pkg}, []string{}, false)
+		if err := ws.dispatcher.FireEvent(preComposerUpdateEvent); err != nil {
+			return "", fmt.Errorf("failed to fire event: %w", err)
+		}
+
+		changes, err := ws.composer.Update(ctx, path, []string{pkg}, preComposerUpdateEvent.PackagesToKeep, preComposerUpdateEvent.MinimalChanges, false)
+		if err != nil {
+			return "", fmt.Errorf("failed to update %s: %w", pkg, err)
+		}
+		if len(changes) == 0 {
+			// Already updated as a transitive dependency of an earlier package: drop any patch
+			// commit and move on without emitting a commit for this package.
+			if err := worktree.Reset(&git.ResetOptions{Commit: start, Mode: git.SoftReset}); err != nil {
+				return "", fmt.Errorf("failed to reset worktree: %w", err)
+			}
+			ws.logger.Info("skipping package with no lock change", zap.String("package", pkg))
+			continue
+		}
+
+		postComposerUpdateEvent := NewPostComposerUpdateEvent(ctx, path, worktree)
+		if err := ws.dispatcher.FireEvent(postComposerUpdateEvent); err != nil {
+			return "", fmt.Errorf("failed to fire event: %w", err)
+		}
+
+		if err := worktree.AddGlob("composer.*"); err != nil {
+			return "", fmt.Errorf("failed to add composer.* files: %w", err)
+		}
+		if _, err := worktree.Commit("Update composer.json and composer.lock", &git.CommitOptions{}); err != nil {
+			return "", fmt.Errorf("failed to commit composer.json and composer.lock: %w", err)
+		}
+
+		// Run the update hooks and export config per site against the updated code.
+		if err := ws.forEachSite(ctx, func(ctx context.Context, site string) error {
+			return ws.updateSite(ctx, path, worktree, site)
+		}); err != nil {
+			return "", err
+		}
+
+		// Squash this package's composer/config/patch/translation commits into one atomic commit.
+		if err := worktree.Reset(&git.ResetOptions{Commit: start, Mode: git.SoftReset}); err != nil {
+			return "", fmt.Errorf("failed to reset worktree: %w", err)
+		}
+		if _, err := worktree.Commit(commitMessage(pkg, changes), &git.CommitOptions{}); err != nil {
+			return "", fmt.Errorf("failed to commit package %s: %w", pkg, err)
+		}
+		committed++
+	}
+
+	if committed == 0 {
+		return "", AbortError{Msg: "no changes detected"}
+	}
+
+	// Run the codebase-wide addons (phpcbf, rector) once, after all packages are updated.
+	postCodeUpdateEvent := NewPostCodeUpdateEvent(ctx, path, worktree)
+	if err := ws.dispatcher.FireEvent(postCodeUpdateEvent); err != nil {
+		return "", fmt.Errorf("failed to fire event: %w", err)
+	}
+
+	composerLockHash, err := ws.composer.GetLockHash(path)
+	if err != nil {
+		return "", err
+	}
+	updateBranchName := fmt.Sprintf("update-%s", composerLockHash)
+
+	// ponytail: the existence check runs after all the work; an already-existing branch only
+	// aborts at the end. Acceptable — move it before the loop if rerun cost becomes a problem.
+	exists, err := ws.repository.BranchExists(repository, updateBranchName)
+	if err != nil {
+		return "", fmt.Errorf("failed to check if branch exists: %w", err)
+	}
+	if exists {
+		return "", AbortError{Msg: fmt.Sprintf("branch %s already exists, skipping", updateBranchName)}
+	}
+
+	if err := worktree.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(updateBranchName),
+		Create: true,
+		Force:  false,
+		Keep:   true,
+	}); err != nil {
+		return "", fmt.Errorf("failed to checkout branch: %w", err)
+	}
+
+	return updateBranchName, nil
+}
+
+// commitMessage builds the atomic commit subject for a package from its change set.
+func commitMessage(pkg string, changes []composer.PackageChange) string {
+	for _, c := range changes {
+		if c.Package != pkg {
+			continue
+		}
+		switch c.Action {
+		case "Install":
+			return fmt.Sprintf("Install %s %s", pkg, c.To)
+		case "Remove":
+			return fmt.Sprintf("Remove %s %s", pkg, c.From)
+		default: // Upgrade, Downgrade
+			return fmt.Sprintf("Update %s %s → %s", pkg, c.From, c.To)
+		}
+	}
+	// Only the package's dependencies moved; the package itself stayed put.
+	return fmt.Sprintf("Update %s", pkg)
 }
 
 func (ws *WorkflowBaseService) updateSite(ctx context.Context, path string, worktree Worktree, site string) error {

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -86,6 +86,230 @@ func TestStartUpdate(t *testing.T) {
 	vcsProvider.AssertExpectations(t)
 }
 
+func TestStartUpdatePerPackage(t *testing.T) {
+	// per_package mode: one atomic commit per outdated package. drupal/core has changes and
+	// produces a commit; drupal/token is already up to date (no changes) and is skipped.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		RepositoryURL:  "https://example.com/repo.git",
+		Branch:         "main",
+		Token:          "token",
+		Clone:          true,
+		Sites:          []string{"site1"},
+		CommitStrategy: "per_package",
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Reset(mock.Anything).Return(nil)
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil)
+
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything).Return(false, nil)
+	repository.EXPECT().Head().Return(plumbing.NewHashReference(plumbing.HEAD, plumbing.ZeroHash), nil)
+	repository.EXPECT().Push(mock.Anything).Return(nil)
+
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().Outdated(mock.Anything, "/tmp").Return([]string{"drupal/core", "drupal/token"}, nil)
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", []string{"drupal/core"}, mock.Anything, mock.Anything, false).Return([]composer.PackageChange{
+		{Action: "Upgrade", Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", []string{"drupal/token"}, mock.Anything, mock.Anything, false).Return(nil, nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	fixture, err := os.ReadFile("testdata/dependency_update.md")
+	assert.NoError(t, err)
+
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, string(fixture), mock.Anything, config.Branch).Return(codehosting.MergeRequest{}, nil)
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err = workflowService.StartUpdate(ctx, nil)
+
+	assert.NoError(t, err)
+	mockComposer.AssertExpectations(t)
+	drush.AssertExpectations(t)
+	vcsProvider.AssertExpectations(t)
+}
+
+func TestStartUpdatePerPackageNoOutdated(t *testing.T) {
+	// No outdated packages aborts cleanly.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+
+	config := internal.Config{
+		RepositoryURL:  "https://example.com/repo.git",
+		Branch:         "main",
+		Token:          "token",
+		Clone:          true,
+		Sites:          []string{"site1"},
+		CommitStrategy: "per_package",
+	}
+
+	worktree := NewMockWorktree(t)
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().Outdated(mock.Anything, "/tmp").Return(nil, nil)
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(context.Background(), nil)
+
+	var abort AbortError
+	assert.ErrorAs(t, err, &abort)
+}
+
+func TestStartUpdatePerPackageBranchExists(t *testing.T) {
+	// An already-existing update branch aborts after the package loop.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+
+	config := internal.Config{
+		RepositoryURL:  "https://example.com/repo.git",
+		Branch:         "main",
+		Token:          "token",
+		Clone:          true,
+		Sites:          []string{"site1"},
+		CommitStrategy: "per_package",
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Reset(mock.Anything).Return(nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything).Return(true, nil)
+	repository.EXPECT().Head().Return(plumbing.NewHashReference(plumbing.HEAD, plumbing.ZeroHash), nil)
+
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().Outdated(mock.Anything, "/tmp").Return([]string{"drupal/core"}, nil)
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", []string{"drupal/core"}, mock.Anything, mock.Anything, false).Return([]composer.PackageChange{
+		{Action: "Upgrade", Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(context.Background(), nil)
+
+	var abort AbortError
+	assert.ErrorAs(t, err, &abort)
+}
+
+func TestStartUpdatePerPackageSecurityFallsBackToBulk(t *testing.T) {
+	// per_package is unsupported in security mode: it must fall back to the bulk path
+	// (single composer.Update for all packages, no composer.Outdated call).
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+
+	config := internal.Config{
+		RepositoryURL:  "https://example.com/repo.git",
+		Branch:         "main",
+		Token:          "token",
+		Clone:          true,
+		Sites:          []string{"site1"},
+		Security:       true,
+		CommitStrategy: "per_package",
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything).Return(false, nil)
+	repository.EXPECT().Push(mock.Anything).Return(nil)
+
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	// Bulk path: one Update for everything; Outdated is never called.
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
+		{Action: "Upgrade", Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	fixture, err := os.ReadFile("testdata/dependency_update.md")
+	assert.NoError(t, err)
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, string(fixture), mock.Anything, config.Branch).Return(codehosting.MergeRequest{}, nil)
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err = workflowService.StartUpdate(context.Background(), nil)
+
+	assert.NoError(t, err)
+	mockComposer.AssertExpectations(t)
+}
+
+func TestCommitMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		pkg     string
+		changes []composer.PackageChange
+		want    string
+	}{
+		{"upgrade", "drupal/core", []composer.PackageChange{{Action: "Upgrade", Package: "drupal/core", From: "9.0.0", To: "9.1.0"}}, "Update drupal/core 9.0.0 → 9.1.0"},
+		{"downgrade", "drupal/core", []composer.PackageChange{{Action: "Downgrade", Package: "drupal/core", From: "9.1.0", To: "9.0.0"}}, "Update drupal/core 9.1.0 → 9.0.0"},
+		{"install", "drupal/token", []composer.PackageChange{{Action: "Install", Package: "drupal/token", To: "1.12.0"}}, "Install drupal/token 1.12.0"},
+		{"remove", "drupal/old", []composer.PackageChange{{Action: "Remove", Package: "drupal/old", From: "1.0.0"}}, "Remove drupal/old 1.0.0"},
+		{"deps only", "drupal/core", []composer.PackageChange{{Action: "Upgrade", Package: "symfony/console", From: "6.0", To: "6.1"}}, "Update drupal/core"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, commitMessage(tt.pkg, tt.changes))
+		})
+	}
+}
+
 func TestStartUpdatePublishUsesLiveContext(t *testing.T) {
 	// Regression: publishWork must run on the outer (timeout-bounded) context, not the
 	// errgroup-derived context. The errgroup context is cancelled as soon as g.Wait()

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -120,6 +120,30 @@ func (s *CLI) Update(ctx context.Context, dir string, packages []string, package
 	return changes, nil
 }
 
+// Outdated returns the names of direct dependencies that have an available update, as the
+// candidate list for per-package update mode.
+func (s *CLI) Outdated(ctx context.Context, dir string) ([]string, error) {
+	out, err := s.execComposer(ctx, dir, "outdated", "--direct", "--format=json", "--no-ansi")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list outdated packages: %w, output: %s", err, out)
+	}
+
+	var result struct {
+		Installed []struct {
+			Name string `json:"name"`
+		} `json:"installed"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse composer outdated output: %w, output: %s", err, out)
+	}
+
+	names := make([]string, 0, len(result.Installed))
+	for _, pkg := range result.Installed {
+		names = append(names, pkg.Name)
+	}
+	return names, nil
+}
+
 func (s *CLI) Install(ctx context.Context, dir string) error {
 	out, err := s.execComposer(ctx, dir, "install", "--no-interaction", "--no-progress", "--optimize-autoloader")
 	if err != nil {

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -109,6 +109,52 @@ func TestGetComposerUpdates(t *testing.T) {
 	assert.Equal(t, "v1.0.2", changes[4].To)
 }
 
+func TestOutdated(t *testing.T) {
+	service := &CLI{logger: zap.NewNop(), fs: afero.NewMemMapFs()}
+
+	t.Run("parses package names", func(t *testing.T) {
+		out := `{"installed":[{"name":"drupal/core"},{"name":"drupal/token"}]}`
+		execCommand = func(_ context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := append([]string{"-test.run=TestHelperProcess", "--", out}, arg...)
+			cmd := exec.Command(os.Args[0], cs...)
+			cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GOCOVERDIR=/tmp"}
+			return cmd
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		names, err := service.Outdated(t.Context(), "/tmp")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"drupal/core", "drupal/token"}, names)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		execCommand = func(_ context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := append([]string{"-test.run=TestHelperProcess", "--", `{"installed":[]}`}, arg...)
+			cmd := exec.Command(os.Args[0], cs...)
+			cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GOCOVERDIR=/tmp"}
+			return cmd
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		names, err := service.Outdated(t.Context(), "/tmp")
+		assert.NoError(t, err)
+		assert.Empty(t, names)
+	})
+
+	t.Run("invalid json is an error", func(t *testing.T) {
+		execCommand = func(_ context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := append([]string{"-test.run=TestHelperProcess", "--", "not json"}, arg...)
+			cmd := exec.Command(os.Args[0], cs...)
+			cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GOCOVERDIR=/tmp"}
+			return cmd
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		_, err := service.Outdated(t.Context(), "/tmp")
+		assert.Error(t, err)
+	})
+}
+
 func TestGetInstalledPlugins(t *testing.T) {
 
 	t.Run("A list of plugins", func(t *testing.T) {

--- a/pkg/repo/mocks_test.go
+++ b/pkg/repo/mocks_test.go
@@ -38,6 +38,61 @@ func (_m *MockRepository) EXPECT() *MockRepository_Expecter {
 	return &MockRepository_Expecter{mock: &_m.Mock}
 }
 
+// Head provides a mock function for the type MockRepository
+func (_mock *MockRepository) Head() (*plumbing.Reference, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Head")
+	}
+
+	var r0 *plumbing.Reference
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (*plumbing.Reference, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() *plumbing.Reference); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*plumbing.Reference)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepository_Head_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Head'
+type MockRepository_Head_Call struct {
+	*mock.Call
+}
+
+// Head is a helper method to define mock.On call
+func (_e *MockRepository_Expecter) Head() *MockRepository_Head_Call {
+	return &MockRepository_Head_Call{Call: _e.mock.On("Head")}
+}
+
+func (_c *MockRepository_Head_Call) Run(run func()) *MockRepository_Head_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockRepository_Head_Call) Return(reference *plumbing.Reference, err error) *MockRepository_Head_Call {
+	_c.Call.Return(reference, err)
+	return _c
+}
+
+func (_c *MockRepository_Head_Call) RunAndReturn(run func() (*plumbing.Reference, error)) *MockRepository_Head_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Push provides a mock function for the type MockRepository
 func (_mock *MockRepository) Push(o *git.PushOptions) error {
 	ret := _mock.Called(o)
@@ -461,6 +516,57 @@ func (_c *MockWorktree_Remove_Call) Return(hash plumbing.Hash, err error) *MockW
 }
 
 func (_c *MockWorktree_Remove_Call) RunAndReturn(run func(path string) (plumbing.Hash, error)) *MockWorktree_Remove_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Reset provides a mock function for the type MockWorktree
+func (_mock *MockWorktree) Reset(opts *git.ResetOptions) error {
+	ret := _mock.Called(opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reset")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*git.ResetOptions) error); ok {
+		r0 = returnFunc(opts)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorktree_Reset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reset'
+type MockWorktree_Reset_Call struct {
+	*mock.Call
+}
+
+// Reset is a helper method to define mock.On call
+//   - opts *git.ResetOptions
+func (_e *MockWorktree_Expecter) Reset(opts any) *MockWorktree_Reset_Call {
+	return &MockWorktree_Reset_Call{Call: _e.mock.On("Reset", opts)}
+}
+
+func (_c *MockWorktree_Reset_Call) Run(run func(opts *git.ResetOptions)) *MockWorktree_Reset_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *git.ResetOptions
+		if args[0] != nil {
+			arg0 = args[0].(*git.ResetOptions)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorktree_Reset_Call) Return(err error) *MockWorktree_Reset_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorktree_Reset_Call) RunAndReturn(run func(opts *git.ResetOptions) error) *MockWorktree_Reset_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -21,6 +21,7 @@ import (
 type Repository interface {
 	Push(o *git.PushOptions) error
 	References() (storer.ReferenceIter, error)
+	Head() (*plumbing.Reference, error)
 }
 
 type Worktree interface {
@@ -30,6 +31,7 @@ type Worktree interface {
 	Commit(msg string, opts *git.CommitOptions) (plumbing.Hash, error)
 	Status() (git.Status, error)
 	Checkout(opts *git.CheckoutOptions) error
+	Reset(opts *git.ResetOptions) error
 }
 
 type GitRepositoryService struct {


### PR DESCRIPTION
Add an opt-in commit_strategy: per_package mode in .drupdater.yaml that runs the full update cycle once per direct outdated package and produces one atomic commit per package (composer + config + patch + translation changes), so any single commit reverts cleanly. Bulk mode stays the default and is unchanged.

Implemented as a squash: existing components commit as they do today, then the workflow soft-resets and re-commits each package's changes as one commit. Adds composer.Outdated for enumeration and Worktree.Reset / Repository.Head to the git interfaces. The package loop is serial; sites still run concurrently within each package. code_beautifier/deprecations_remover run once at the end.

Not supported with --security (incompatible with composer_audit's whole-run semantics): a security run logs a warning and falls back to bulk.