### PR TITLE
Add unsupported_modules addon for EOL module detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ addons:               # configurable addons per mode; mandatory addons always ru
     - deprecations_remover
     - translations_updater
     - composer_normalizer
+    - unsupported_modules
   security: []            # minimal by default; composer_audit is added automatically
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ The site databases are SQLite files written beside the working directory (`{dir}
 
 Addons implement the `Addon` interface and subscribe to workflow events via `gookit/event`. They hook into pre/post composer update and pre/post site update events.
 
-Which addons run is data-driven: `cmd/root.go` holds an `addonRegistry` (name → constructor) and `mandatoryAddons`. Four addons always run — `composer_allow_plugins`, `composer_patches`, `composer_diff`, `update_hooks` — and `composer_audit` is additionally mandatory in security mode. The rest are *configurable* and listed per mode in `.drupdater.yaml` under `addons.regular` / `addons.security`; `--security` selects which list is used. Configurable addon names: `code_beautifier`, `deprecations_remover`, `translations_updater`, `composer_normalizer`. An unknown name in the active list aborts the run.
+Which addons run is data-driven: `cmd/root.go` holds an `addonRegistry` (name → constructor) and `mandatoryAddons`. Four addons always run — `composer_allow_plugins`, `composer_patches`, `composer_diff`, `update_hooks` — and `composer_audit` is additionally mandatory in security mode. The rest are *configurable* and listed per mode in `.drupdater.yaml` under `addons.regular` / `addons.security`; `--security` selects which list is used. Configurable addon names: `code_beautifier`, `deprecations_remover`, `translations_updater`, `composer_normalizer`, `unsupported_modules`. An unknown name in the active list aborts the run.
 
 Addons use Go templates in `internal/addon/templates/` to render the MR description sections.
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ addons:               # configurable addons per mode (mandatory addons always ru
     - deprecations_remover   # drupal-rector deprecation removal
     - translations_updater   # interface translations
     - composer_normalizer    # normalize composer.json
+    - unsupported_modules    # report modules with no supported release
   security: []               # minimal by default — don't interfere with the fix
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -236,8 +236,9 @@ var addonRegistry = map[string]func(addonDeps) internal.Addon{
 	"composer_patches": func(d addonDeps) internal.Addon {
 		return addon.NewComposerPatches1(d.logger, d.composer, d.drupalOrg, http.DefaultClient)
 	},
-	"composer_diff": func(d addonDeps) internal.Addon { return addon.NewComposerDiff(d.logger, d.composer) },
-	"update_hooks":  func(d addonDeps) internal.Addon { return addon.NewUpdateHooks(d.logger, d.drush) },
+	"composer_diff":       func(d addonDeps) internal.Addon { return addon.NewComposerDiff(d.logger, d.composer) },
+	"update_hooks":        func(d addonDeps) internal.Addon { return addon.NewUpdateHooks(d.logger, d.drush) },
+	"unsupported_modules": func(d addonDeps) internal.Addon { return addon.NewUnsupportedModules(d.logger, d.drush) },
 }
 
 // mandatoryAddons always run, regardless of the .drupdater.yaml addon lists.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -182,12 +182,13 @@ func TestValidateAddons(t *testing.T) {
 func TestConfigurableAddons(t *testing.T) {
 	names := configurableAddons()
 
-	// Exactly the four configurable addons, sorted, and nothing mandatory.
+	// Exactly the five configurable addons, sorted, and nothing mandatory.
 	assert.Equal(t, []string{
 		"code_beautifier",
 		"composer_normalizer",
 		"deprecations_remover",
 		"translations_updater",
+		"unsupported_modules",
 	}, names)
 
 	for _, mandatory := range append(mandatoryAddons, "composer_audit") {

--- a/internal/addon/interfaces.go
+++ b/internal/addon/interfaces.go
@@ -40,6 +40,7 @@ type Drush interface {
 	LocalizeTranslations(ctx context.Context, dir string, site string) error
 	GetTranslationPath(ctx context.Context, dir string, site string, relative bool) (string, error)
 	GetUpdateHooks(ctx context.Context, dir string, site string) (map[string]drush.UpdateHook, error)
+	GetUnsupportedModules(ctx context.Context, dir string, site string) ([]drush.UnsupportedModule, error)
 }
 
 type PHPCS interface {

--- a/internal/addon/mocks_test.go
+++ b/internal/addon/mocks_test.go
@@ -1442,6 +1442,80 @@ func (_c *MockDrush_GetTranslationPath_Call) RunAndReturn(run func(ctx context.C
 	return _c
 }
 
+// GetUnsupportedModules provides a mock function for the type MockDrush
+func (_mock *MockDrush) GetUnsupportedModules(ctx context.Context, dir string, site string) ([]drush.UnsupportedModule, error) {
+	ret := _mock.Called(ctx, dir, site)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUnsupportedModules")
+	}
+
+	var r0 []drush.UnsupportedModule
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]drush.UnsupportedModule, error)); ok {
+		return returnFunc(ctx, dir, site)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []drush.UnsupportedModule); ok {
+		r0 = returnFunc(ctx, dir, site)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]drush.UnsupportedModule)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, dir, site)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDrush_GetUnsupportedModules_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUnsupportedModules'
+type MockDrush_GetUnsupportedModules_Call struct {
+	*mock.Call
+}
+
+// GetUnsupportedModules is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dir string
+//   - site string
+func (_e *MockDrush_Expecter) GetUnsupportedModules(ctx any, dir any, site any) *MockDrush_GetUnsupportedModules_Call {
+	return &MockDrush_GetUnsupportedModules_Call{Call: _e.mock.On("GetUnsupportedModules", ctx, dir, site)}
+}
+
+func (_c *MockDrush_GetUnsupportedModules_Call) Run(run func(ctx context.Context, dir string, site string)) *MockDrush_GetUnsupportedModules_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDrush_GetUnsupportedModules_Call) Return(unsupportedModules []drush.UnsupportedModule, err error) *MockDrush_GetUnsupportedModules_Call {
+	_c.Call.Return(unsupportedModules, err)
+	return _c
+}
+
+func (_c *MockDrush_GetUnsupportedModules_Call) RunAndReturn(run func(ctx context.Context, dir string, site string) ([]drush.UnsupportedModule, error)) *MockDrush_GetUnsupportedModules_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUpdateHooks provides a mock function for the type MockDrush
 func (_mock *MockDrush) GetUpdateHooks(ctx context.Context, dir string, site string) (map[string]drush.UpdateHook, error) {
 	ret := _mock.Called(ctx, dir, site)
@@ -2028,7 +2102,10 @@ func (_c *MockDrupalOrg_GetIssue_Call) Run(run func(ctx context.Context, issueID
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2038,7 +2115,7 @@ func (_c *MockDrupalOrg_GetIssue_Call) Return(issue *drupalorg.Issue, err error)
 	return _c
 }
 
-func (_c *MockDrupalOrg_GetIssue_Call) RunAndReturn(run func(context.Context, string) (*drupalorg.Issue, error)) *MockDrupalOrg_GetIssue_Call {
+func (_c *MockDrupalOrg_GetIssue_Call) RunAndReturn(run func(ctx context.Context, issueID string) (*drupalorg.Issue, error)) *MockDrupalOrg_GetIssue_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/addon/templates/unsupported_modules.go.tmpl
+++ b/internal/addon/templates/unsupported_modules.go.tmpl
@@ -1,0 +1,9 @@
+## ⚠️ Unsupported modules
+
+The following installed modules have reached end-of-life: they have no supported upgrade path, so they will not receive further fixes. Consider planning a replacement.
+
+| Module | Installed version | Recommended version |
+| ------ | ------------------ | -------------------- |
+{{ range . -}}
+| {{ .Name | cell }} | {{ .InstalledVersion | cell }} | {{ .RecommendedVersion | cell }} |
+{{ end -}}

--- a/internal/addon/testdata/unsupported_modules.md
+++ b/internal/addon/testdata/unsupported_modules.md
@@ -1,0 +1,8 @@
+## ⚠️ Unsupported modules
+
+The following installed modules have reached end-of-life: they have no supported upgrade path, so they will not receive further fixes. Consider planning a replacement.
+
+| Module | Installed version | Recommended version |
+| ------ | ------------------ | -------------------- |
+| module_a | 1.0.0 | None |
+| module_b | 2.3.1 | 3.0.0 |

--- a/internal/addon/unsupported_modules.go
+++ b/internal/addon/unsupported_modules.go
@@ -1,0 +1,86 @@
+package addon
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/services"
+	"github.com/drupdater/drupdater/pkg/drush"
+	"github.com/gookit/event"
+	"go.uber.org/zap"
+)
+
+// UnsupportedModules detects installed modules that have reached end-of-life according to
+// Drupal's update status service (status NOT_SUPPORTED): they have no supported upgrade path,
+// which is a different risk category than a security vulnerability caught by composer_audit.
+type UnsupportedModules struct {
+	internal.BasicAddon
+	logger *zap.Logger
+	drush  Drush
+
+	// mu guards modules: preSiteUpdateHandler runs concurrently for each site. Keyed by module
+	// name so results are deduplicated across sites in multisite runs.
+	mu      sync.Mutex
+	modules map[string]drush.UnsupportedModule
+}
+
+// NewUnsupportedModules creates a new unsupported modules detector instance.
+func NewUnsupportedModules(logger *zap.Logger, drushClient Drush) *UnsupportedModules {
+	return &UnsupportedModules{
+		logger:  logger,
+		drush:   drushClient,
+		modules: make(map[string]drush.UnsupportedModule),
+	}
+}
+
+// SubscribedEvents returns the events this addon listens to.
+func (um *UnsupportedModules) SubscribedEvents() map[string]any {
+	return map[string]any{
+		"pre-site-update": event.ListenerItem{
+			Priority: event.Normal,
+			Listener: event.ListenerFunc(um.preSiteUpdateHandler),
+		},
+	}
+}
+
+// RenderTemplate returns the rendered template for this addon.
+func (um *UnsupportedModules) RenderTemplate() (string, error) {
+	if len(um.modules) == 0 {
+		return "", nil
+	}
+
+	modules := make([]drush.UnsupportedModule, 0, len(um.modules))
+	for _, module := range um.modules {
+		modules = append(modules, module)
+	}
+	sort.Slice(modules, func(i, j int) bool { return modules[i].Name < modules[j].Name })
+
+	return um.Render("unsupported_modules.go.tmpl", modules)
+}
+
+// preSiteUpdateHandler checks a site for unsupported modules. This is a best-effort, informational
+// check: failures (e.g. the update status service being unreachable) are logged and swallowed
+// rather than aborting the run, since an unsupported module is reported, not treated as an error.
+func (um *UnsupportedModules) preSiteUpdateHandler(e event.Event) error {
+	evt := e.(*services.PreSiteUpdateEvent)
+
+	modules, err := um.drush.GetUnsupportedModules(evt.Context(), evt.Path(), evt.Site())
+	if err != nil {
+		um.logger.Warn("failed to check for unsupported modules", zap.String("site", evt.Site()), zap.Error(err))
+		return nil
+	}
+	if len(modules) == 0 {
+		return nil
+	}
+
+	um.mu.Lock()
+	for _, module := range modules {
+		um.modules[module.Name] = module
+	}
+	um.mu.Unlock()
+
+	um.logger.Info("unsupported modules found", zap.String("site", evt.Site()), zap.Int("count", len(modules)))
+
+	return nil
+}

--- a/internal/addon/unsupported_modules_test.go
+++ b/internal/addon/unsupported_modules_test.go
@@ -1,0 +1,177 @@
+package addon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/drupdater/drupdater/internal/services"
+	"github.com/drupdater/drupdater/pkg/drush"
+	"github.com/gookit/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestNewUnsupportedModules(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	mockDrush := NewMockDrush(t)
+
+	// Execute
+	um := NewUnsupportedModules(logger, mockDrush)
+
+	// Assert
+	assert.NotNil(t, um)
+	assert.Equal(t, logger, um.logger)
+	assert.Equal(t, mockDrush, um.drush)
+	assert.NotNil(t, um.modules)
+	assert.Empty(t, um.modules)
+}
+
+func TestUnsupportedModules_SubscribedEvents(t *testing.T) {
+	// Setup
+	um := &UnsupportedModules{}
+
+	// Execute
+	events := um.SubscribedEvents()
+
+	// Assert
+	assert.Contains(t, events, "pre-site-update")
+	assert.IsType(t, event.ListenerItem{}, events["pre-site-update"])
+}
+
+func TestUnsupportedModules_RenderTemplate(t *testing.T) {
+	// Setup
+	fixture, err := os.ReadFile("testdata/unsupported_modules.md")
+	require.NoError(t, err)
+	expected := string(fixture)
+
+	logger := zap.NewNop()
+	mockDrush := NewMockDrush(t)
+
+	um := NewUnsupportedModules(logger, mockDrush)
+	um.modules = map[string]drush.UnsupportedModule{
+		"module_b": {Name: "module_b", InstalledVersion: "2.3.1", RecommendedVersion: "3.0.0"},
+		"module_a": {Name: "module_a", InstalledVersion: "1.0.0", RecommendedVersion: "None"},
+	}
+
+	// Execute
+	result, err := um.RenderTemplate()
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestUnsupportedModules_RenderTemplate_Empty(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	mockDrush := NewMockDrush(t)
+	um := NewUnsupportedModules(logger, mockDrush)
+
+	// Execute
+	result, err := um.RenderTemplate()
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestUnsupportedModules_PreSiteUpdateHandler_Success(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	mockDrush := NewMockDrush(t)
+	um := NewUnsupportedModules(logger, mockDrush)
+
+	ctx := context.Background()
+	testPath := "/test/path"
+	testSite := "default"
+	mockModules := []drush.UnsupportedModule{
+		{Name: "module_a", InstalledVersion: "1.0.0", RecommendedVersion: "None"},
+	}
+
+	worktree := NewMockWorktree(t)
+	mockEvent := services.NewPreSiteUpdateEvent(ctx, testPath, worktree, testSite)
+
+	mockDrush.EXPECT().GetUnsupportedModules(ctx, testPath, testSite).Return(mockModules, nil)
+
+	// Execute
+	err := um.preSiteUpdateHandler(mockEvent)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, mockModules[0], um.modules["module_a"])
+}
+
+func TestUnsupportedModules_PreSiteUpdateHandler_Dedupe(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	mockDrush := NewMockDrush(t)
+	um := NewUnsupportedModules(logger, mockDrush)
+
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+
+	shared := drush.UnsupportedModule{Name: "module_a", InstalledVersion: "1.0.0", RecommendedVersion: "None"}
+
+	mockDrush.EXPECT().GetUnsupportedModules(ctx, "/test/path", "site1").Return([]drush.UnsupportedModule{shared}, nil)
+	mockDrush.EXPECT().GetUnsupportedModules(ctx, "/test/path", "site2").Return([]drush.UnsupportedModule{shared}, nil)
+
+	// Execute
+	require.NoError(t, um.preSiteUpdateHandler(services.NewPreSiteUpdateEvent(ctx, "/test/path", worktree, "site1")))
+	require.NoError(t, um.preSiteUpdateHandler(services.NewPreSiteUpdateEvent(ctx, "/test/path", worktree, "site2")))
+
+	// Assert
+	assert.Len(t, um.modules, 1)
+	assert.Equal(t, shared, um.modules["module_a"])
+}
+
+func TestUnsupportedModules_PreSiteUpdateHandler_NoModules(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	mockDrush := NewMockDrush(t)
+	um := NewUnsupportedModules(logger, mockDrush)
+
+	ctx := context.Background()
+	testPath := "/test/path"
+	testSite := "default"
+
+	worktree := NewMockWorktree(t)
+	mockEvent := services.NewPreSiteUpdateEvent(ctx, testPath, worktree, testSite)
+
+	mockDrush.EXPECT().GetUnsupportedModules(ctx, testPath, testSite).Return(nil, nil)
+
+	// Execute
+	err := um.preSiteUpdateHandler(mockEvent)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, um.modules)
+}
+
+func TestUnsupportedModules_PreSiteUpdateHandler_Error(t *testing.T) {
+	// Setup
+	logger := zap.NewNop()
+	mockDrush := NewMockDrush(t)
+	um := NewUnsupportedModules(logger, mockDrush)
+
+	ctx := context.Background()
+	testPath := "/test/path"
+	testSite := "default"
+	expectedError := errors.New("drush error")
+
+	worktree := NewMockWorktree(t)
+	mockEvent := services.NewPreSiteUpdateEvent(ctx, testPath, worktree, testSite)
+
+	mockDrush.EXPECT().GetUnsupportedModules(ctx, testPath, testSite).Return(nil, expectedError)
+
+	// Execute - errors are swallowed (logged, not returned): this is a best-effort,
+	// informational check that must not abort the run.
+	err := um.preSiteUpdateHandler(mockEvent)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, um.modules)
+}

--- a/internal/configfile.go
+++ b/internal/configfile.go
@@ -17,6 +17,7 @@ var defaultNormalAddons = []string{
 	"deprecations_remover",
 	"translations_updater",
 	"composer_normalizer",
+	"unsupported_modules",
 }
 
 // flexTimeout captures the raw scalar of the `timeout` key so both a quoted duration

--- a/pkg/drush/drush.go
+++ b/pkg/drush/drush.go
@@ -139,6 +139,36 @@ type UpdateHook struct {
 	Type        string `json:"type"`
 }
 
+// UnsupportedModule describes an installed module that has reached end-of-life according to
+// Drupal's update status service: no supported release exists, so it is not going to receive
+// further fixes.
+type UnsupportedModule struct {
+	Name               string `json:"name"`
+	InstalledVersion   string `json:"installed_version"`
+	RecommendedVersion string `json:"recommended_version"`
+}
+
+// GetUnsupportedModules returns the installed modules whose update status is NOT_SUPPORTED. It
+// relies on the bundled unsupported-modules.php script, which itself returns an empty result
+// when the Drupal update module is not enabled.
+func (e *CLI) GetUnsupportedModules(ctx context.Context, dir string, site string) ([]UnsupportedModule, error) {
+	stdout, stderr, err := e.execDrushStreams(ctx, dir, site, "php:script", "/opt/drupdater/unsupported-modules.php")
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for unsupported modules: %w, output: %s", err, stderr)
+	}
+
+	if strings.TrimSpace(stdout) == "" {
+		return nil, nil
+	}
+
+	var modules []UnsupportedModule
+	if err := json.Unmarshal([]byte(stdout), &modules); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal unsupported modules: %w", err)
+	}
+
+	return modules, nil
+}
+
 func (e *CLI) GetUpdateHooks(ctx context.Context, dir string, site string) (map[string]UpdateHook, error) {
 	stdout, stderr, err := e.execDrushStreams(ctx, dir, site, "updatedb-status", "--format=json")
 	if err != nil {

--- a/pkg/drush/drush_test.go
+++ b/pkg/drush/drush_test.go
@@ -192,6 +192,126 @@ func TestGetUpdateHooks(t *testing.T) {
 
 }
 
+func TestGetUnsupportedModules(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("JSON of unsupported modules", func(t *testing.T) {
+		data := `[{"name":"module_a","installed_version":"1.0.0","recommended_version":"None"},{"name":"module_b","installed_version":"2.3.1","recommended_version":"3.0.0"}]`
+
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		t.Setenv("GO_HELPER_PROCESS_RAW", "1")
+		t.Setenv("GOCOVERDIR", "/tmp")
+		execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := []string{"-test.run=TestHelperProcess", "--", data}
+			cs = append(cs, arg...)
+			return exec.CommandContext(ctx, os.Args[0], cs...)
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		drush := CLI{
+			logger: logger,
+		}
+
+		modules, err := drush.GetUnsupportedModules(t.Context(), "/tmp", "site1")
+
+		require.NoError(t, err)
+		assert.Equal(t, []UnsupportedModule{
+			{Name: "module_a", InstalledVersion: "1.0.0", RecommendedVersion: "None"},
+			{Name: "module_b", InstalledVersion: "2.3.1", RecommendedVersion: "3.0.0"},
+		}, modules)
+	})
+
+	t.Run("no unsupported modules", func(t *testing.T) {
+		data := `[]`
+
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		t.Setenv("GO_HELPER_PROCESS_RAW", "1")
+		t.Setenv("GOCOVERDIR", "/tmp")
+		execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := []string{"-test.run=TestHelperProcess", "--", data}
+			cs = append(cs, arg...)
+			return exec.CommandContext(ctx, os.Args[0], cs...)
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		drush := CLI{
+			logger: logger,
+		}
+
+		modules, err := drush.GetUnsupportedModules(t.Context(), "/tmp", "site1")
+
+		require.NoError(t, err)
+		assert.Empty(t, modules)
+	})
+
+	t.Run("empty output", func(t *testing.T) {
+		data := ``
+
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		t.Setenv("GO_HELPER_PROCESS_RAW", "1")
+		t.Setenv("GOCOVERDIR", "/tmp")
+		execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := []string{"-test.run=TestHelperProcess", "--", data}
+			cs = append(cs, arg...)
+			return exec.CommandContext(ctx, os.Args[0], cs...)
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		drush := CLI{
+			logger: logger,
+		}
+
+		modules, err := drush.GetUnsupportedModules(t.Context(), "/tmp", "site1")
+
+		require.NoError(t, err)
+		assert.Nil(t, modules)
+	})
+
+	t.Run("execution failure", func(t *testing.T) {
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		t.Setenv("GO_HELPER_PROCESS_ERROR", "1")
+		t.Setenv("GOCOVERDIR", "/tmp")
+		execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := []string{"-test.run=TestHelperProcess", "--"}
+			cs = append(cs, arg...)
+			return exec.CommandContext(ctx, os.Args[0], cs...)
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		drush := CLI{
+			logger: logger,
+		}
+
+		modules, err := drush.GetUnsupportedModules(t.Context(), "/tmp", "site1")
+
+		require.Error(t, err)
+		assert.Nil(t, modules)
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		data := `not json`
+
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		t.Setenv("GO_HELPER_PROCESS_RAW", "1")
+		t.Setenv("GOCOVERDIR", "/tmp")
+		execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+			cs := []string{"-test.run=TestHelperProcess", "--", data}
+			cs = append(cs, arg...)
+			return exec.CommandContext(ctx, os.Args[0], cs...)
+		}
+		defer func() { execCommand = exec.CommandContext }()
+
+		drush := CLI{
+			logger: logger,
+		}
+
+		modules, err := drush.GetUnsupportedModules(t.Context(), "/tmp", "site1")
+
+		require.Error(t, err)
+		assert.Nil(t, modules)
+	})
+}
+
 func TestInstallSite(t *testing.T) {
 	logger := zap.NewNop()
 	cache, _ := otter.MustBuilder[string, string](100).Build()

--- a/scripts/unsupported-modules.php
+++ b/scripts/unsupported-modules.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+if (!\Drupal::moduleHandler()->moduleExists('update')) {
+    echo json_encode([]);
+    return;
+}
+
+\Drupal::moduleHandler()->loadInclude('update', 'inc', 'update.compare');
+\Drupal::moduleHandler()->loadInclude('update', 'inc', 'update.fetch');
+
+$available = update_get_available(TRUE);
+$data = update_calculate_project_data($available);
+
+$unsupported = [];
+foreach ($data as $name => $project) {
+    if (($project['status'] ?? NULL) !== UPDATE_NOT_SUPPORTED) {
+        continue;
+    }
+    $unsupported[] = [
+        'name' => $name,
+        'installed_version' => $project['existing_version'] ?? 'unknown',
+        'recommended_version' => $project['recommended'] ?? 'None',
+    ];
+}
+
+echo json_encode($unsupported);


### PR DESCRIPTION
Adds an opt-in unsupported_modules addon that runs a bundled Drush
php:script per site to query Drupal's update status service for
modules with a NOT_SUPPORTED status, and surfaces them as a dedicated
section in the MR/PR description. Results are deduplicated by module
name across sites in multisite runs, and failures are logged rather
than aborting the run since this check is purely informational.

Fixes #128

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R8e5bxCWvAqnEdGt8Yse71