### PR TITLE
feat: use CI env vars as primary code hosting provider detection

### DIFF
--- a/internal/codehosting/factory.go
+++ b/internal/codehosting/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"go.uber.org/zap"
@@ -43,12 +44,30 @@ func (vpf *DefaultVcsProviderFactory) Create(repositoryURL string, token string,
 		return nil, err
 	}
 
-	switch providerFromHost(host) {
+	provider := providerFromEnv()
+	if provider == "" {
+		provider = providerFromHost(host)
+	}
+
+	switch provider {
 	case "github":
 		return newGithub(path, token, logger)
 	default:
 		return newGitlab(host, path, token, logger)
 	}
+}
+
+// providerFromEnv returns the VCS provider from CI environment variables, which are
+// authoritative and work for self-hosted instances whose hostnames don't contain the
+// provider name. Returns "" when no CI environment is detected.
+func providerFromEnv() string {
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		return "github"
+	}
+	if os.Getenv("GITLAB_CI") == "true" {
+		return "gitlab"
+	}
+	return ""
 }
 
 // providerFromHost determines the VCS provider type from the repository host. Matching on the

--- a/internal/codehosting/factory_test.go
+++ b/internal/codehosting/factory_test.go
@@ -45,6 +45,9 @@ func TestDefaultVcsProviderFactory_Create(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_ACTIONS", "")
+			t.Setenv("GITLAB_CI", "")
+
 			factory := NewDefaultVcsProviderFactory()
 
 			provider, err := factory.Create(tt.repositoryURL, "dummy-token", zap.NewNop())
@@ -95,6 +98,8 @@ func TestDefaultVcsProviderFactory_Create_CIEnvVars(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_ACTIONS", "")
+			t.Setenv("GITLAB_CI", "")
 			t.Setenv(tt.envKey, tt.envValue)
 
 			factory := NewDefaultVcsProviderFactory()
@@ -158,6 +163,9 @@ func TestProviderFromEnv(t *testing.T) {
 }
 
 func TestDefaultVcsProviderFactory_Create_InvalidURL(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+
 	factory := NewDefaultVcsProviderFactory()
 
 	_, err := factory.Create("", "dummy-token", zap.NewNop())

--- a/internal/codehosting/factory_test.go
+++ b/internal/codehosting/factory_test.go
@@ -55,6 +55,108 @@ func TestDefaultVcsProviderFactory_Create(t *testing.T) {
 	}
 }
 
+func TestDefaultVcsProviderFactory_Create_CIEnvVars(t *testing.T) {
+	tests := []struct {
+		name          string
+		repositoryURL string
+		envKey        string
+		envValue      string
+		expectedType  any
+	}{
+		{
+			name:          "GITHUB_ACTIONS overrides hostname detection for self-hosted GitHub",
+			repositoryURL: "https://git.company.com/owner/repo",
+			envKey:        "GITHUB_ACTIONS",
+			envValue:      "true",
+			expectedType:  &Github{},
+		},
+		{
+			name:          "GITLAB_CI overrides hostname detection for self-hosted GitLab",
+			repositoryURL: "https://git.company.com/group/repo",
+			envKey:        "GITLAB_CI",
+			envValue:      "true",
+			expectedType:  &Gitlab{},
+		},
+		{
+			name:          "GITHUB_ACTIONS wins over gitlab.com URL",
+			repositoryURL: "https://gitlab.com/owner/repo",
+			envKey:        "GITHUB_ACTIONS",
+			envValue:      "true",
+			expectedType:  &Github{},
+		},
+		{
+			name:          "GITLAB_CI wins over github.com URL",
+			repositoryURL: "https://github.com/owner/repo",
+			envKey:        "GITLAB_CI",
+			envValue:      "true",
+			expectedType:  &Gitlab{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.envKey, tt.envValue)
+
+			factory := NewDefaultVcsProviderFactory()
+			provider, err := factory.Create(tt.repositoryURL, "dummy-token", zap.NewNop())
+
+			require.NoError(t, err)
+			assert.IsType(t, tt.expectedType, provider)
+		})
+	}
+}
+
+func TestProviderFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      map[string]string
+		expected string
+	}{
+		{
+			name:     "returns github when GITHUB_ACTIONS is true",
+			env:      map[string]string{"GITHUB_ACTIONS": "true"},
+			expected: "github",
+		},
+		{
+			name:     "returns gitlab when GITLAB_CI is true",
+			env:      map[string]string{"GITLAB_CI": "true"},
+			expected: "gitlab",
+		},
+		{
+			name:     "returns empty when no CI env vars are set",
+			env:      map[string]string{},
+			expected: "",
+		},
+		{
+			name:     "GITHUB_ACTIONS=false does not trigger github detection",
+			env:      map[string]string{"GITHUB_ACTIONS": "false"},
+			expected: "",
+		},
+		{
+			name:     "GITLAB_CI=false does not trigger gitlab detection",
+			env:      map[string]string{"GITLAB_CI": "false"},
+			expected: "",
+		},
+		{
+			name:     "GITHUB_ACTIONS takes priority over GITLAB_CI",
+			env:      map[string]string{"GITHUB_ACTIONS": "true", "GITLAB_CI": "true"},
+			expected: "github",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_ACTIONS", "")
+			t.Setenv("GITLAB_CI", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			assert.Equal(t, tt.expected, providerFromEnv())
+		})
+	}
+}
+
 func TestDefaultVcsProviderFactory_Create_InvalidURL(t *testing.T) {
 	factory := NewDefaultVcsProviderFactory()
 


### PR DESCRIPTION
Check GITHUB_ACTIONS and GITLAB_CI environment variables before falling
back to hostname matching. CI variables are authoritative and allow
correct provider detection for self-hosted instances with custom hostnames
that don't contain "github" or "gitlab".

Closes #23