### PR TITLE
feat: implement auto-merge of merge requests (#32)

### DIFF
--- a/.claude/rules/addons.md
+++ b/.claude/rules/addons.md
@@ -8,5 +8,5 @@ When adding a new addon:
 
 1. Implement the `internal.Addon` interface and subscribe to events via `gookit/event` — no direct calls between addons.
 2. Register it in `addonRegistry` in `cmd/root.go` (name → constructor).
-3. Decide: mandatory (add to `mandatoryAddons`) or configurable (add to the appropriate `addons.normal`/`addons.security` defaults in `.drupdater.yaml` and document in CLAUDE.md).
+3. Decide: mandatory (add to `mandatoryAddons`) or configurable (add to the appropriate `run_types.normal.addons`/`run_types.security.addons` defaults in `.drupdater.yaml` and document in CLAUDE.md).
 4. Unknown names in the active addon list abort the run — make sure the name in `addonRegistry` matches exactly what users put in `.drupdater.yaml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The site databases are SQLite files written beside the working directory (`{dir}
 
 Addons implement the `Addon` interface and subscribe to workflow events via `gookit/event`. They hook into pre/post composer update and pre/post site update events.
 
-Which addons run is data-driven: `cmd/root.go` holds an `addonRegistry` (name → constructor) and `mandatoryAddons`. Four addons always run — `composer_allow_plugins`, `composer_patches`, `composer_diff`, `update_hooks` — and `composer_audit` is additionally mandatory in security mode. The rest are *configurable* and listed per mode in `.drupdater.yaml` under `addons.normal` / `addons.security`; `--security` selects which list is used. Configurable addon names: `code_beautifier`, `deprecations_remover`, `translations_updater`, `composer_normalizer`, `unsupported_modules`. An unknown name in the active list aborts the run.
+Which addons run is data-driven: `cmd/root.go` holds an `addonRegistry` (name → constructor) and `mandatoryAddons`. Four addons always run — `composer_allow_plugins`, `composer_patches`, `composer_diff`, `update_hooks` — and `composer_audit` is additionally mandatory in security mode. The rest are *configurable* and listed per mode in `.drupdater.yaml` under `run_types.normal.addons` / `run_types.security.addons`; `--security` selects which block is used. Configurable addon names: `code_beautifier`, `deprecations_remover`, `translations_updater`, `composer_normalizer`, `unsupported_modules`. An unknown name in the active list aborts the run.
 
 Addons use Go templates in `internal/addon/templates/` to render the MR description sections.
 
@@ -84,7 +84,7 @@ Events fired during the workflow: `PreComposerUpdateEvent`, `PostComposerUpdateE
 Config is split into two tiers, with no overlap:
 
 - **CLI flags** — how a given run is invoked (volatile): token (positional arg, or the `DRUPDATER_TOKEN` env var when the arg is omitted), plus the flags below.
-- **`.drupdater.yaml`** — what the project needs (committed at the repo root, read from `<working-dir>/.drupdater.yaml` or `--config`). Loaded by `internal/configfile.go`; a missing file falls back to built-in defaults, absent keys keep their default, and unknown keys are rejected (strict decode). Keys: `sites`, `timeout` (Go duration string, e.g. `30m`), and `addons.normal` / `addons.security`. Addon names in both lists are validated up front via `validateAddons`; `drupdater addons` lists valid names.
+- **`.drupdater.yaml`** — what the project needs (committed at the repo root, read from `<working-dir>/.drupdater.yaml` or `--config`). Loaded by `internal/configfile.go`; a missing file falls back to built-in defaults, absent keys keep their default, and unknown keys are rejected (strict decode). Keys: `sites`, `timeout` (Go duration string, e.g. `30m`), and `run_types.<normal|security>.{addons,auto_merge}`. Addon names in both run types are validated up front via `validateAddons`; `drupdater addons` lists valid names.
 
 ### CLI Flags
 
@@ -94,7 +94,7 @@ Config is split into two tiers, with no overlap:
 | `--working-dir` | `.` | Existing checkout to update in place (also where `.drupdater.yaml` is read from) |
 | `--clone` | false | Clone instead of using the checkout (needs `--repository-url`); for testing |
 | `--repository-url` | _(from `origin`)_ | Repo URL; required with `--clone`, else read from `origin` |
-| `--security` | false | Only apply security updates; selects the `addons.security` list |
+| `--security` | false | Only apply security updates; selects the `run_types.security` block |
 | `--concurrency` | `GOMAXPROCS(0)` | Max concurrent per-site work in `forEachSite`; describes the machine, not the project, so it's a flag rather than a `.drupdater.yaml` key |
 | `--dry-run` | false | Skip pushing the branch and creating the MR (branch and commits are still made locally) |
 | `--report` | _(disabled)_ | Write the machine-readable JSON run report to this path (`internal/report`). Emitted on every exit path — success, failure and `--dry-run` — from `StartUpdate`'s defer. Also applies to `drupdater check`, which writes a `report.Check` instead |
@@ -106,15 +106,34 @@ Config is split into two tiers, with no overlap:
 ```yaml
 sites: [default]      # Drupal site names; at least one is required
 timeout: 30m          # overall run timeout (Go duration; 0 disables)
-addons:               # configurable addons per mode; mandatory addons always run
+
+run_types:            # everything that differs between a normal and a security run
   normal:
-    - code_beautifier
-    - deprecations_remover
-    - translations_updater
-    - composer_normalizer
-    - unsupported_modules
-  security: []            # minimal by default; composer_audit is added automatically
+    addons:               # configurable addons; mandatory addons always run
+      - code_beautifier
+      - deprecations_remover
+      - translations_updater
+      - composer_normalizer
+      - unsupported_modules
+    auto_merge: false     # ask the platform to merge the MR/PR once its pipeline passes
+  security:
+    addons: []            # minimal by default; composer_audit is added automatically
+    auto_merge: false
 ```
+
+Global keys (`sites`, `timeout`) sit at the root; per-run-type keys live under `run_types`.
+`Config.ActiveRunType()` resolves `--security` to the right block and is the single place that
+mapping is stated — consumers call it rather than branching on `config.Security` themselves.
+
+The pre-`run_types` layout (top-level `addons` / `auto_merge`, each split by mode) is rejected
+by `checkLegacyLayout` with a message naming the replacement, since strict decode alone would
+only say "field addons not found".
+
+Auto-merge is off in both run types unless enabled. `publishWork` calls
+`Platform.EnableAutoMerge` after the MR/PR is created; failure is logged as a warning and
+does **not** fail the run, since by that point the branch is pushed and the MR exists. The
+outcome is recorded on the run report via `Recorder.SetAutoMerge` (`merge_request.auto_merge`),
+so a best-effort failure is still machine-readable.
 
 ## Mocking
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ required for a run that clones or pushes/opens a PR/MR (see
 | `--working-dir` | `.` | Path to the existing checkout to update in place. |
 | `--clone` | `false` | Clone instead of using the checkout. Requires `--repository-url`. For local testing. |
 | `--repository-url` | _(from `origin`)_ | Repo URL. Required with `--clone`; otherwise read from the `origin` remote. |
-| `--security` | `false` | Update only packages with known vulnerabilities. Selects the `addons.security` list. |
+| `--security` | `false` | Update only packages with known vulnerabilities. Selects the `run_types.security` block. |
 | `--concurrency` | `GOMAXPROCS(0)` | Maximum number of sites to install/update concurrently. Site installs are as much I/O-bound as CPU-bound, so raise or lower this from the CPU-derived default to match the runner (constrained runner, slow disk, or fast NVMe with many small sites). |
 | `--dry-run` | `false` | Run everything but skip pushing the branch and creating the PR/MR (the branch and commits are still created locally). In checkout mode this also means no token is required. |
 | `--report` | _(disabled)_ | Write a machine-readable JSON report of the run to this path. Written on every outcome, including failures and `--dry-run`. See [Run report](#run-report). |
@@ -221,21 +221,66 @@ required for a run that clones or pushes/opens a PR/MR (see
 Optional file at the repo root. Missing file or omitted keys fall back to the
 defaults below; unknown keys are rejected so typos fail fast.
 
+Global keys describe the whole run; everything that differs between a normal
+and a security update lives under `run_types`:
+
 ```yaml
 sites: [default]      # Drupal site directories to update (must not be empty)
 timeout: 30m          # overall run timeout (Go duration; 0 disables)
-addons:               # configurable addons per mode (mandatory addons always run)
+
+run_types:            # per-run-type settings; --security picks which block applies
   normal:
-    - code_beautifier        # phpcbf code-style fixes
-    - deprecations_remover   # drupal-rector deprecation removal
-    - translations_updater   # interface translations
-    - composer_normalizer    # normalize composer.json
-    - unsupported_modules    # report modules with no supported release
-  security: []               # minimal by default — don't interfere with the fix
+    addons:                      # configurable addons (mandatory ones always run)
+      - code_beautifier          # phpcbf code-style fixes
+      - deprecations_remover     # drupal-rector deprecation removal
+      - translations_updater     # interface translations
+      - composer_normalizer      # normalize composer.json
+      - unsupported_modules      # report modules with no supported release
+    auto_merge: false            # merge the PR/MR once its pipeline passes
+  security:
+    addons: []                   # minimal by default — don't interfere with the fix
+    auto_merge: false
 ```
 
-`--security` selects `addons.security`; otherwise `addons.normal` runs. Run
+`--security` selects the `security` block; otherwise `normal` runs. Run
 `drupdater addons` to list valid addon names.
+
+Keying on the run type rather than on the setting means configuring a security
+run is reading one stanza, instead of picking the `security` field out of every
+setting in the file.
+
+> [!NOTE]
+> **Changed layout.** `addons` and `auto_merge` used to be top-level keys, each
+> split by mode. They now live under `run_types.<mode>`. A config in the old
+> shape fails at startup with a message showing the replacement.
+
+#### Auto-merge
+
+`auto_merge` is off for both run types unless you turn it on. When enabled,
+drupdater asks the platform to merge the MR/PR as soon as its pipeline
+succeeds — on GitLab via auto-merge, on GitHub via the repository's auto-merge
+feature. Nothing is merged while checks are failing or pending; if the project
+has no pipeline at all, the merge happens immediately.
+
+The two run types are separate on purpose: auto-merging routine dependency
+bumps is a different risk decision from auto-merging a security fix, and you may
+well want one without the other.
+
+Requirements and behaviour:
+
+- **GitHub** — "Allow auto-merge" must be enabled in the repository settings,
+  and the token needs write access to pull requests. drupdater picks a merge
+  method the repository actually permits (merge commit, else squash, else
+  rebase). Whether the branch is deleted afterwards is the repository's
+  *Automatically delete head branches* setting.
+- **GitLab** — the token needs the Developer role or higher. The source branch
+  is deleted on merge.
+- Enabling auto-merge is best-effort: if it fails (feature disabled, token
+  lacks the scope, platform error) drupdater logs a warning and the run still
+  succeeds. The MR/PR is left in place for you to merge by hand. The outcome is
+  also recorded under `merge_request.auto_merge` in the
+  [run report](#run-report), so a failure is visible to tooling and not only in
+  the log.
 
 ### Environment variables
 
@@ -268,7 +313,10 @@ drupdater --dry-run --report ./drupdater-report.json
   "repository": "https://github.com/org/site.git",
   "base_branch": "main",
   "update_branch": "drupdater-3f81a2c",
-  "merge_request": { "url": "https://github.com/org/site/pull/42" },
+  "merge_request": {
+    "url": "https://github.com/org/site/pull/42",
+    "auto_merge": { "enabled": true }
+  },
   "sites": ["default"],
   "packages": [
     { "action": "Upgrade", "package": "drupal/core", "from": "10.1.8", "to": "10.2.0" }
@@ -300,6 +348,12 @@ whether a run is dominated by `composer install`, by site installs, or by Rector
 report (`composer_audit`, `update_hooks`, `unsupported_modules`,
 `composer_patches`). Addons with nothing to say are omitted rather than present
 and empty.
+
+**`merge_request.auto_merge`** is present only when the active run type asked
+for auto-merge, so "never requested" is distinguishable from "requested and
+failed". A failure sets `enabled: false` and an `error` while the run itself
+still reports `success` — which is exactly why it is here and not only in the
+log.
 
 Credentials never appear in the report: the repository URL is stripped of any
 embedded userinfo, and the finished document passes through the same redactor

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -60,7 +60,7 @@ func TestCheckConfigAndAddons(t *testing.T) {
 
 	t.Run("an unknown addon name fails the second check only", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), ".drupdater.yaml")
-		require.NoError(t, os.WriteFile(path, []byte("addons:\n  normal: [no_such_addon]\n"), 0o600))
+		require.NoError(t, os.WriteFile(path, []byte("run_types:\n  normal:\n    addons: [no_such_addon]\n"), 0o600))
 
 		cfg := internal.Config{}
 		results := checkConfigAndAddons(path, &cfg)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -301,8 +301,10 @@ func loadProjectConfig(logger *zap.Logger, path string, cfg *internal.Config) er
 		zap.Bool("file_found", found),
 		zap.Strings("sites", cfg.Sites),
 		zap.Duration("timeout", cfg.Timeout),
-		zap.Strings("addons.normal", cfg.Addons.Normal),
-		zap.Strings("addons.security", cfg.Addons.Security),
+		zap.Strings("run_types.normal.addons", cfg.RunTypes.Normal.Addons),
+		zap.Bool("run_types.normal.auto_merge", cfg.RunTypes.Normal.AutoMerge),
+		zap.Strings("run_types.security.addons", cfg.RunTypes.Security.Addons),
+		zap.Bool("run_types.security.auto_merge", cfg.RunTypes.Security.AutoMerge),
 	)
 	return nil
 }
@@ -411,10 +413,7 @@ func createAddons(
 ) ([]internal.Addon, error) {
 	deps := addonDeps{logger: logger, drush: drush, composer: composer, drupalOrg: drupalOrg, git: git}
 
-	names := config.Addons.Normal
-	if config.Security {
-		names = config.Addons.Security
-	}
+	names := config.ActiveRunType().Addons
 
 	var addons []internal.Addon
 	added := map[string]bool{}
@@ -451,10 +450,10 @@ func createAddons(
 	return addons, nil
 }
 
-// validateAddons checks every addon named in either list is known, regardless of which mode
-// will run, so a typo in addons.security is caught even on a normal run (and vice versa).
+// validateAddons checks every addon named in either run type is known, regardless of which one
+// will run, so a typo under run_types.security is caught even on a normal run (and vice versa).
 func validateAddons(config internal.Config) error {
-	for _, name := range append(append([]string{}, config.Addons.Normal...), config.Addons.Security...) {
+	for _, name := range append(append([]string{}, config.RunTypes.Normal.Addons...), config.RunTypes.Security.Addons...) {
 		if _, ok := addonRegistry[name]; !ok {
 			return fmt.Errorf("unknown addon %q (run \"drupdater addons\" to list valid names)", name)
 		}
@@ -486,7 +485,7 @@ var addonsCmd = &cobra.Command{
 	Short: "List the addon names that can be set in .drupdater.yaml",
 	Run: func(cmd *cobra.Command, _ []string) {
 		out := cmd.OutOrStdout()
-		fmt.Fprintln(out, "Addons you can set under addons.normal / addons.security in .drupdater.yaml:")
+		fmt.Fprintln(out, "Addons you can set under run_types.normal.addons / run_types.security.addons in .drupdater.yaml:")
 		for _, n := range configurableAddons() {
 			fmt.Fprintf(out, "  %s\n", n)
 		}

--- a/cmd/root_extra_test.go
+++ b/cmd/root_extra_test.go
@@ -209,7 +209,7 @@ func TestLoadProjectConfig(t *testing.T) {
 
 	t.Run("an unknown addon name is an error", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), ".drupdater.yaml")
-		require.NoError(t, os.WriteFile(path, []byte("addons:\n  normal: [no_such_addon]\n"), 0o600))
+		require.NoError(t, os.WriteFile(path, []byte("run_types:\n  normal:\n    addons: [no_such_addon]\n"), 0o600))
 
 		cfg := internal.Config{}
 		err := loadProjectConfig(logger, path, &cfg)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -106,7 +106,7 @@ func TestCreateDispatcher(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	t.Run("returns a non-nil dispatcher with addons subscribed", func(t *testing.T) {
-		config := internal.Config{Addons: internal.AddonsConfig{Normal: []string{"composer_normalizer"}}}
+		config := internal.Config{RunTypes: internal.RunTypesConfig{Normal: internal.RunTypeConfig{Addons: []string{"composer_normalizer"}}}}
 		addons, err := createAddons(logger, config, nil, nil, nil, nil)
 		require.NoError(t, err)
 		dispatcher := createDispatcher(addons)
@@ -124,7 +124,7 @@ func TestCreateAddons(t *testing.T) {
 
 	t.Run("mandatory addons plus the normal list", func(t *testing.T) {
 		config := internal.Config{
-			Addons: internal.AddonsConfig{Normal: []string{"code_beautifier"}},
+			RunTypes: internal.RunTypesConfig{Normal: internal.RunTypeConfig{Addons: []string{"code_beautifier"}}},
 		}
 		addons, err := createAddons(logger, config, nil, nil, nil, nil)
 		require.NoError(t, err)
@@ -135,9 +135,9 @@ func TestCreateAddons(t *testing.T) {
 	t.Run("security mode adds composer_audit even when not listed", func(t *testing.T) {
 		config := internal.Config{
 			Security: true,
-			Addons: internal.AddonsConfig{
-				Normal:   []string{"code_beautifier"},
-				Security: []string{"code_beautifier"}, // composer_audit intentionally omitted
+			RunTypes: internal.RunTypesConfig{
+				Normal:   internal.RunTypeConfig{Addons: []string{"code_beautifier"}},
+				Security: internal.RunTypeConfig{Addons: []string{"code_beautifier"}}, // composer_audit intentionally omitted
 			},
 		}
 		addons, err := createAddons(logger, config, nil, nil, nil, nil)
@@ -147,14 +147,14 @@ func TestCreateAddons(t *testing.T) {
 	})
 
 	t.Run("a mandatory addon listed in the YAML is not duplicated", func(t *testing.T) {
-		config := internal.Config{Addons: internal.AddonsConfig{Normal: []string{"update_hooks"}}}
+		config := internal.Config{RunTypes: internal.RunTypesConfig{Normal: internal.RunTypeConfig{Addons: []string{"update_hooks"}}}}
 		addons, err := createAddons(logger, config, nil, nil, nil, nil)
 		require.NoError(t, err)
 		assert.Len(t, addons, 4) // update_hooks is already mandatory
 	})
 
 	t.Run("an unknown addon name is an error", func(t *testing.T) {
-		config := internal.Config{Addons: internal.AddonsConfig{Normal: []string{"does_not_exist"}}}
+		config := internal.Config{RunTypes: internal.RunTypesConfig{Normal: internal.RunTypeConfig{Addons: []string{"does_not_exist"}}}}
 		_, err := createAddons(logger, config, nil, nil, nil, nil)
 		require.Error(t, err)
 	})
@@ -162,15 +162,15 @@ func TestCreateAddons(t *testing.T) {
 
 func TestValidateAddons(t *testing.T) {
 	t.Run("known names pass, including mandatory ones", func(t *testing.T) {
-		config := internal.Config{Addons: internal.AddonsConfig{
-			Normal:   []string{"code_beautifier", "update_hooks"},
-			Security: []string{"composer_normalizer"},
+		config := internal.Config{RunTypes: internal.RunTypesConfig{
+			Normal:   internal.RunTypeConfig{Addons: []string{"code_beautifier", "update_hooks"}},
+			Security: internal.RunTypeConfig{Addons: []string{"composer_normalizer"}},
 		}}
 		require.NoError(t, validateAddons(config))
 	})
 
 	t.Run("unknown name in the normal list is an error", func(t *testing.T) {
-		config := internal.Config{Addons: internal.AddonsConfig{Normal: []string{"nope"}}}
+		config := internal.Config{RunTypes: internal.RunTypesConfig{Normal: internal.RunTypeConfig{Addons: []string{"nope"}}}}
 		err := validateAddons(config)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nope")
@@ -178,7 +178,7 @@ func TestValidateAddons(t *testing.T) {
 
 	t.Run("unknown name in the security list is caught regardless of mode", func(t *testing.T) {
 		// Security: false, yet a bad security-list name must still be rejected.
-		config := internal.Config{Addons: internal.AddonsConfig{Security: []string{"typo"}}}
+		config := internal.Config{RunTypes: internal.RunTypesConfig{Security: internal.RunTypeConfig{Addons: []string{"typo"}}}}
 		require.Error(t, validateAddons(config))
 	})
 }

--- a/internal/addon_test.go
+++ b/internal/addon_test.go
@@ -7,48 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBasicAddonRender(t *testing.T) {
-	var ba BasicAddon
+func TestBasicAddon_Render(t *testing.T) {
+	ba := &BasicAddon{}
 
-	t.Run("renders an embedded addon template", func(t *testing.T) {
-		out, err := ba.Render("composer_diff.go.tmpl", "| package | from | to |")
+	t.Run("renders a known template", func(t *testing.T) {
+		out, err := ba.Render("update_hooks.go.tmpl", map[string]any{})
 		require.NoError(t, err)
-		assert.Contains(t, out, "Dependency updates")
-		assert.Contains(t, out, "| package | from | to |")
+		assert.NotEmpty(t, out)
 	})
 
-	t.Run("escapes pipes and newlines in table cells", func(t *testing.T) {
-		// The cell helper keeps a value containing "|" or a newline from breaking the markdown
-		// table it is interpolated into.
-		out, err := ba.Render("unsupported_modules.go.tmpl", []struct {
-			Name               string
-			InstalledVersion   string
-			RecommendedVersion string
-		}{
-			{Name: "a|b\nc", InstalledVersion: "1.0", RecommendedVersion: "None"},
-		})
-		require.NoError(t, err)
-		assert.Contains(t, out, `a\|b c`)
-		assert.NotContains(t, out, "a|b")
-	})
-
-	t.Run("errors for an unknown template name", func(t *testing.T) {
-		_, err := ba.Render("does_not_exist.go.tmpl", nil)
+	t.Run("unknown template returns error", func(t *testing.T) {
+		_, err := ba.Render("nonexistent.go.tmpl", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to execute template")
 	})
-
-	t.Run("errors when the template cannot be executed with the given data", func(t *testing.T) {
-		// update_hooks.go.tmpl ranges over a map of sites; a string has no such shape.
-		_, err := ba.Render("update_hooks.go.tmpl", "not-a-map")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to execute template")
-	})
-}
-
-func TestCellReplacer(t *testing.T) {
-	assert.Equal(t, `a\|b`, cellReplacer.Replace("a|b"))
-	assert.Equal(t, "a b", cellReplacer.Replace("a\nb"))
-	assert.Equal(t, "ab", cellReplacer.Replace("a\rb"))
-	assert.Equal(t, "plain", cellReplacer.Replace("plain"))
 }

--- a/internal/codehosting/factory.go
+++ b/internal/codehosting/factory.go
@@ -20,6 +20,9 @@ type Platform interface {
 
 	// GetUser returns the user name and email from the platform.
 	GetUser(ctx context.Context) (name string, email string)
+
+	// EnableAutoMerge sets the merge/pull request to merge automatically when all conditions are met.
+	EnableAutoMerge(ctx context.Context, mr MergeRequest) error
 }
 
 // MergeRequest represents a merge or pull request on a code hosting platform.

--- a/internal/codehosting/github.go
+++ b/internal/codehosting/github.go
@@ -85,6 +85,78 @@ func (g *Github) GetUser(ctx context.Context) (name string, email string) {
 	return user.GetName(), email
 }
 
+// EnableAutoMerge enables auto-merge on a GitHub pull request via the GraphQL API.
+// When all required status checks pass the PR is merged automatically.
+//
+// Note on the endpoint: go-github's base URL is the REST root, so "graphql" resolves to
+// https://api.github.com/graphql, which is correct for github.com. GitHub Enterprise serves
+// GraphQL at /api/graphql — outside the /api/v3/ REST prefix — so this path would need
+// adjusting if newGithub ever gains enterprise support.
+func (g *Github) EnableAutoMerge(ctx context.Context, mr MergeRequest) error {
+	pr, _, err := g.client.PullRequests.Get(ctx, g.owner, g.repo, int(mr.ID))
+	if err != nil {
+		return fmt.Errorf("could not enable auto merge for PR %d: %w", mr.ID, err)
+	}
+
+	body := struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}{
+		Query: `mutation($prId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+			enablePullRequestAutoMerge(input: {pullRequestId: $prId, mergeMethod: $mergeMethod}) {
+				pullRequest { autoMergeRequest { mergeMethod } }
+			}
+		}`,
+		Variables: map[string]any{
+			"prId":        pr.GetNodeID(),
+			"mergeMethod": mergeMethodFor(pr.GetBase().GetRepo()),
+		},
+	}
+
+	req, err := g.client.NewRequest("POST", "graphql", body)
+	if err != nil {
+		return fmt.Errorf("could not enable auto merge for PR %d: %w", mr.ID, err)
+	}
+
+	var result struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if _, err = g.client.Do(ctx, req, &result); err != nil {
+		return fmt.Errorf("could not enable auto merge for PR %d: %w", mr.ID, err)
+	}
+	if len(result.Errors) > 0 {
+		messages := make([]string, 0, len(result.Errors))
+		for _, e := range result.Errors {
+			messages = append(messages, e.Message)
+		}
+		return fmt.Errorf("could not enable auto merge for PR %d: %s", mr.ID, strings.Join(messages, "; "))
+	}
+	return nil
+}
+
+// mergeMethodFor picks a merge method the repository actually permits. Requesting a disallowed
+// method makes the mutation fail, and many repositories allow only squash or only rebase. The
+// repo carried on the PR's base ref reports which methods are enabled; when none of the flags
+// come back set, MERGE is used as before, since GitHub rejects the request anyway if it is
+// not allowed and the resulting error names the problem.
+//
+// Note: unlike GitLab, GitHub has no per-request "delete source branch" option — that is the
+// repository's delete_branch_on_merge setting and cannot be driven from here.
+func mergeMethodFor(repo *github.Repository) string {
+	switch {
+	case repo.GetAllowMergeCommit():
+		return "MERGE"
+	case repo.GetAllowSquashMerge():
+		return "SQUASH"
+	case repo.GetAllowRebaseMerge():
+		return "REBASE"
+	default:
+		return "MERGE"
+	}
+}
+
 // isGitHubActionsToken403 reports whether the error is the specific 403 returned
 // by GitHub for an Actions integration token (GITHUB_TOKEN) that cannot access
 // the /user endpoint. Such responses carry the message

--- a/internal/codehosting/github_test.go
+++ b/internal/codehosting/github_test.go
@@ -2,6 +2,7 @@ package codehosting
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -205,6 +206,128 @@ func TestGithub_DeleteBranch_HonorsContext(t *testing.T) {
 	cancel()
 
 	err := gh.DeleteBranch(ctx, "some-branch")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// newAutoMergePRServer serves the PR endpoint with the given base repo JSON (the merge-method
+// flags) and a successful GraphQL mutation, capturing the mergeMethod variable that was sent.
+// Note the GraphQL path: WithEnterpriseURLs puts the REST root at /api/v3/, so "graphql"
+// resolves under it. Real GHES serves GraphQL at /api/graphql instead — see EnableAutoMerge.
+func newAutoMergePRServer(t *testing.T, baseRepoJSON string, gotMethod *string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/owner/repo/pulls/1":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"number":1,"node_id":"PR_kwDOABCDEF123","base":{"repo":` + baseRepoJSON + `}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/graphql":
+			var body struct {
+				Variables struct {
+					MergeMethod string `json:"mergeMethod"`
+				} `json:"variables"`
+			}
+			// A decode failure leaves gotMethod empty, which fails the caller's assertion;
+			// testifylint forbids require inside an HTTP handler.
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			*gotMethod = body.Variables.MergeMethod
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"enablePullRequestAutoMerge":{"pullRequest":{"autoMergeRequest":{"mergeMethod":"MERGE"}}}}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestGithub_EnableAutoMerge_Success(t *testing.T) {
+	var gotMethod string
+	mockServer := newAutoMergePRServer(t, `{"allow_merge_commit":true}`, &gotMethod)
+
+	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
+	gh := &Github{client: client, owner: "owner", repo: "repo"}
+
+	err := gh.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+	require.NoError(t, err)
+	assert.Equal(t, "MERGE", gotMethod)
+}
+
+// TestGithub_EnableAutoMerge_UsesPermittedMergeMethod covers repositories that disable merge
+// commits: requesting a method the repository forbids makes the mutation fail outright.
+func TestGithub_EnableAutoMerge_UsesPermittedMergeMethod(t *testing.T) {
+	tests := map[string]struct {
+		baseRepo string
+		want     string
+	}{
+		"squash only":     {`{"allow_merge_commit":false,"allow_squash_merge":true}`, "SQUASH"},
+		"rebase only":     {`{"allow_merge_commit":false,"allow_rebase_merge":true}`, "REBASE"},
+		"merge preferred": {`{"allow_merge_commit":true,"allow_squash_merge":true}`, "MERGE"},
+		"flags absent":    {`{}`, "MERGE"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var gotMethod string
+			mockServer := newAutoMergePRServer(t, tt.baseRepo, &gotMethod)
+
+			client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
+			gh := &Github{client: client, owner: "owner", repo: "repo"}
+
+			require.NoError(t, gh.EnableAutoMerge(context.Background(), MergeRequest{ID: 1}))
+			assert.Equal(t, tt.want, gotMethod)
+		})
+	}
+}
+
+func TestGithub_EnableAutoMerge_GraphQLError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/owner/repo/pulls/1":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"number":1,"node_id":"PR_kwDOABCDEF123"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/graphql":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"Auto-merge is not allowed for this repository"},{"message":"second problem"}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
+	gh := &Github{client: client, owner: "owner", repo: "repo"}
+
+	err := gh.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Auto-merge is not allowed for this repository")
+	assert.Contains(t, err.Error(), "second problem", "every GraphQL error should be surfaced")
+}
+
+func TestGithub_EnableAutoMerge_GetPRError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer mockServer.Close()
+
+	client, _ := github.NewClient(nil).WithEnterpriseURLs(mockServer.URL, "")
+	gh := &Github{client: client, owner: "owner", repo: "repo"}
+
+	err := gh.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not enable auto merge for PR 1")
+}
+
+func TestGithub_EnableAutoMerge_HonorsContext(t *testing.T) {
+	client, _ := github.NewClient(nil).WithEnterpriseURLs("http://example.invalid", "")
+	gh := &Github{client: client, owner: "o", repo: "r"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := gh.EnableAutoMerge(ctx, MergeRequest{ID: 1})
 	require.ErrorIs(t, err, context.Canceled)
 }
 

--- a/internal/codehosting/gitlab.go
+++ b/internal/codehosting/gitlab.go
@@ -3,6 +3,8 @@ package codehosting
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.uber.org/zap"
@@ -10,9 +12,10 @@ import (
 
 // Gitlab implements the Platform interface for GitLab repositories.
 type Gitlab struct {
-	client      *gitlab.Client
-	projectPath string
-	logger      *zap.Logger
+	client        *gitlab.Client
+	projectPath   string
+	logger        *zap.Logger
+	retryInterval time.Duration
 }
 
 // newGitlab creates a new GitLab client for the given host and "group/project" path.
@@ -27,9 +30,10 @@ func newGitlab(host string, path string, token string, logger *zap.Logger) (*Git
 	}
 
 	return &Gitlab{
-		client:      gitlabClient,
-		projectPath: path,
-		logger:      logger,
+		client:        gitlabClient,
+		projectPath:   path,
+		logger:        logger,
+		retryInterval: 5 * time.Second,
 	}, nil
 }
 
@@ -59,6 +63,105 @@ func (g *Gitlab) DeleteBranch(ctx context.Context, branch string) error {
 		return fmt.Errorf("failed to delete branch: %w", err)
 	}
 	return nil
+}
+
+// Attempt budgets for EnableAutoMerge. GitLab computes mergeability asynchronously, so the
+// status right after MR creation is usually still pending; the accept call can also lose a
+// race with that computation and answer 405. Both waits are bounded so a run can't hang —
+// worst case is (maxMergeStatusChecks + maxAcceptAttempts - 2) * retryInterval.
+const (
+	maxMergeStatusChecks = 7
+	maxAcceptAttempts    = 4
+)
+
+// pendingMergeStatuses are the detailed_merge_status values that mean GitLab has not finished
+// working out whether the MR can merge. These are the only four of the documented values whose
+// meaning is "still computing" (see the merge status section of the merge requests API docs):
+//
+//	preparing          merge request diff is being created
+//	checking           Git is testing if a valid merge is possible
+//	unchecked          Git has not yet tested if a valid merge is possible
+//	approvals_syncing  the merge request's approvals are syncing
+//
+// Every other value is a settled answer and is safe to act on — including ci_must_pass and
+// ci_still_running, which are precisely the states auto-merge exists for: the MR is not
+// mergeable *yet*, and GitLab should merge it once the pipeline goes green. Waiting for
+// "mergeable" instead would defeat the feature, because a pipeline-gated MR only reports
+// "mergeable" once it could already be merged outright.
+var pendingMergeStatuses = map[string]bool{
+	"preparing":         true,
+	"checking":          true,
+	"unchecked":         true,
+	"approvals_syncing": true,
+}
+
+// EnableAutoMerge sets the MR to merge automatically once its pipeline succeeds. It first
+// waits for GitLab to settle the merge status (at most maxMergeStatusChecks polls), then
+// accepts with auto_merge. GitLab decides from there whether to queue the merge or perform
+// it immediately, so an MR with no pipeline is merged straight away.
+func (g *Gitlab) EnableAutoMerge(ctx context.Context, mr MergeRequest) error {
+	status, err := g.waitForSettledMergeStatus(ctx, mr.ID)
+	if err != nil {
+		return err
+	}
+	return g.acceptWithAutoMerge(ctx, mr.ID, status)
+}
+
+// waitForSettledMergeStatus polls the MR until detailed_merge_status is no longer one of the
+// pending values, and returns that settled status. It deliberately does not require a
+// mergeable status: see pendingMergeStatuses.
+func (g *Gitlab) waitForSettledMergeStatus(ctx context.Context, iid int64) (string, error) {
+	for i := 0; i < maxMergeStatusChecks; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(g.retryInterval):
+			}
+		}
+		details, _, err := g.client.MergeRequests.GetMergeRequest(g.projectPath, iid, nil, gitlab.WithContext(ctx))
+		if err != nil {
+			return "", fmt.Errorf("could not set auto merge for MR %d: %w", iid, err)
+		}
+		if !pendingMergeStatuses[details.DetailedMergeStatus] {
+			return details.DetailedMergeStatus, nil
+		}
+	}
+	return "", fmt.Errorf("could not set auto merge for MR %d: merge status was still pending after %d checks", iid, maxMergeStatusChecks)
+}
+
+// acceptWithAutoMerge accepts the MR with auto_merge set. GitLab documents HTTP 405 on this
+// endpoint as "the merge request cannot merge" — a draft, a conflict, or missing approvals all
+// land there — but it can also appear briefly right after the merge status settles, so the call
+// is retried up to maxAcceptAttempts times in total. status is the settled
+// detailed_merge_status and is reported on failure, since it usually names the real blocker.
+func (g *Gitlab) acceptWithAutoMerge(ctx context.Context, iid int64, status string) error {
+	autoMerge := true
+	removeSourceBranch := true
+	opts := &gitlab.AcceptMergeRequestOptions{
+		AutoMerge:                &autoMerge,
+		ShouldRemoveSourceBranch: &removeSourceBranch,
+	}
+
+	var lastErr error
+	for i := 0; i < maxAcceptAttempts; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(g.retryInterval):
+			}
+		}
+		_, resp, err := g.client.MergeRequests.AcceptMergeRequest(g.projectPath, iid, opts, gitlab.WithContext(ctx))
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if resp == nil || resp.StatusCode != http.StatusMethodNotAllowed {
+			break
+		}
+	}
+	return fmt.Errorf("could not set auto merge for MR %d (merge status %q): %w", iid, status, lastErr)
 }
 
 func (g *Gitlab) GetUser(ctx context.Context) (name string, email string) {

--- a/internal/codehosting/gitlab_test.go
+++ b/internal/codehosting/gitlab_test.go
@@ -141,6 +141,163 @@ func TestGitlab_GetUser_HonorsContext(t *testing.T) {
 	assert.Empty(t, email)
 }
 
+// newAutoMergeServer serves the GetMergeRequest endpoint with the given sequence of
+// detailed_merge_status values (the last one repeats once exhausted) and accepts the merge.
+// It returns the server plus counters for the GET and PUT calls.
+func newAutoMergeServer(t *testing.T, statuses ...string) (*httptest.Server, *int, *int) {
+	t.Helper()
+	var getCount, putCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/test_project/merge_requests/1":
+			status := statuses[min(getCount, len(statuses)-1)]
+			getCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"iid":1,"detailed_merge_status":"` + status + `"}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v4/projects/test_project/merge_requests/1/merge":
+			putCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"iid":1,"state":"merged"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &getCount, &putCount
+}
+
+func TestGitlab_EnableAutoMerge_WaitsOutPendingStatus(t *testing.T) {
+	// GitLab computes mergeability asynchronously; the first reads are still pending.
+	mockServer, getCount, putCount := newAutoMergeServer(t, "preparing", "checking", "mergeable")
+
+	client, _ := gitlab.NewClient("", gitlab.WithBaseURL(mockServer.URL))
+	g := &Gitlab{client: client, projectPath: "test_project", retryInterval: 0}
+
+	err := g.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+	require.NoError(t, err)
+	assert.Equal(t, 3, *getCount, "should poll while the merge status is still being computed")
+	assert.Equal(t, 1, *putCount)
+}
+
+// TestGitlab_EnableAutoMerge_AcceptsWhileCIRunning is the regression test for the feature's
+// central case: a pipeline-gated MR never reports "mergeable" before the pipeline finishes, so
+// waiting for that status would make auto-merge unusable on exactly the projects that want it.
+// A CI status is a settled answer and must be accepted straight away.
+func TestGitlab_EnableAutoMerge_AcceptsWhileCIRunning(t *testing.T) {
+	for _, status := range []string{"ci_still_running", "ci_must_pass"} {
+		t.Run(status, func(t *testing.T) {
+			mockServer, getCount, putCount := newAutoMergeServer(t, status)
+
+			client, _ := gitlab.NewClient("", gitlab.WithBaseURL(mockServer.URL))
+			g := &Gitlab{client: client, projectPath: "test_project", retryInterval: 0}
+
+			err := g.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+			require.NoError(t, err)
+			assert.Equal(t, 1, *getCount, "a CI status is settled — no reason to keep polling")
+			assert.Equal(t, 1, *putCount, "auto-merge must be enabled while the pipeline runs")
+		})
+	}
+}
+
+func TestGitlab_EnableAutoMerge_StatusNeverSettles(t *testing.T) {
+	mockServer, getCount, putCount := newAutoMergeServer(t, "checking")
+
+	client, _ := gitlab.NewClient("", gitlab.WithBaseURL(mockServer.URL))
+	g := &Gitlab{client: client, projectPath: "test_project", retryInterval: 0}
+
+	err := g.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge status was still pending after 7 checks")
+	assert.Equal(t, maxMergeStatusChecks, *getCount)
+	assert.Zero(t, *putCount, "must not attempt the merge when the status never settled")
+}
+
+func TestGitlab_EnableAutoMerge_MergeRetryOn405(t *testing.T) {
+	putCount := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/test_project/merge_requests/1":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"iid":1,"detailed_merge_status":"mergeable"}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v4/projects/test_project/merge_requests/1/merge":
+			putCount++
+			if putCount < 3 {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				_, _ = w.Write([]byte(`{"message":"405 Method Not Allowed"}`))
+			} else {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"iid":1,"state":"merged"}`))
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	client, _ := gitlab.NewClient("", gitlab.WithBaseURL(mockServer.URL))
+	g := &Gitlab{client: client, projectPath: "test_project", retryInterval: 0}
+
+	err := g.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+	require.NoError(t, err)
+	assert.Equal(t, 3, putCount, "should retry merge on 405")
+}
+
+func TestGitlab_EnableAutoMerge_MergeFailsAfterMaxRetries(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/test_project/merge_requests/1":
+			w.WriteHeader(http.StatusOK)
+			// GitLab documents 405 as "the merge request cannot merge"; a draft is one
+			// settled status that produces it, and naming it makes the warning actionable.
+			_, _ = w.Write([]byte(`{"iid":1,"detailed_merge_status":"draft_status"}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v4/projects/test_project/merge_requests/1/merge":
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"message":"405 Method Not Allowed"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	client, _ := gitlab.NewClient("", gitlab.WithBaseURL(mockServer.URL))
+	g := &Gitlab{client: client, projectPath: "test_project", retryInterval: 0}
+
+	err := g.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not set auto merge for MR 1")
+	assert.Contains(t, err.Error(), `draft_status`, "the settled status names the real blocker")
+}
+
+func TestGitlab_EnableAutoMerge_GetMRError(t *testing.T) {
+	// Use 403 (not 5xx) to avoid retries by the underlying retryable HTTP client.
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"403 Forbidden"}`))
+	}))
+	defer mockServer.Close()
+
+	client, _ := gitlab.NewClient("bad-token", gitlab.WithBaseURL(mockServer.URL))
+	g := &Gitlab{client: client, projectPath: "test_project", retryInterval: 0}
+
+	err := g.EnableAutoMerge(context.Background(), MergeRequest{ID: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not set auto merge for MR 1")
+}
+
+func TestGitlab_EnableAutoMerge_HonorsContext(t *testing.T) {
+	g := newTestGitlab(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := g.EnableAutoMerge(ctx, MergeRequest{ID: 1})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestGetUser_ReturnsEmptyStringsOnError(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/codehosting/mocks_test.go
+++ b/internal/codehosting/mocks_test.go
@@ -178,6 +178,63 @@ func (_c *MockPlatform_DeleteBranch_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// EnableAutoMerge provides a mock function for the type MockPlatform
+func (_mock *MockPlatform) EnableAutoMerge(ctx context.Context, mr MergeRequest) error {
+	ret := _mock.Called(ctx, mr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnableAutoMerge")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, MergeRequest) error); ok {
+		r0 = returnFunc(ctx, mr)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockPlatform_EnableAutoMerge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnableAutoMerge'
+type MockPlatform_EnableAutoMerge_Call struct {
+	*mock.Call
+}
+
+// EnableAutoMerge is a helper method to define mock.On call
+//   - ctx context.Context
+//   - mr MergeRequest
+func (_e *MockPlatform_Expecter) EnableAutoMerge(ctx any, mr any) *MockPlatform_EnableAutoMerge_Call {
+	return &MockPlatform_EnableAutoMerge_Call{Call: _e.mock.On("EnableAutoMerge", ctx, mr)}
+}
+
+func (_c *MockPlatform_EnableAutoMerge_Call) Run(run func(ctx context.Context, mr MergeRequest)) *MockPlatform_EnableAutoMerge_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 MergeRequest
+		if args[1] != nil {
+			arg1 = args[1].(MergeRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPlatform_EnableAutoMerge_Call) Return(err error) *MockPlatform_EnableAutoMerge_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockPlatform_EnableAutoMerge_Call) RunAndReturn(run func(ctx context.Context, mr MergeRequest) error) *MockPlatform_EnableAutoMerge_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUser provides a mock function for the type MockPlatform
 func (_mock *MockPlatform) GetUser(ctx context.Context) (string, string) {
 	ret := _mock.Called(ctx)

--- a/internal/config.go
+++ b/internal/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	DryRun        bool
 	Verbose       bool
 	Timeout       time.Duration
-	Addons        AddonsConfig
+	RunTypes      RunTypesConfig
 	// Concurrency bounds how many sites are installed/updated at once. It describes the
 	// machine the run happens on, not the project, so it's a CLI flag rather than a
 	// .drupdater.yaml key. A value <= 0 means "use GOMAXPROCS(0)".
@@ -29,10 +29,32 @@ type Config struct {
 	ReportPath string
 }
 
-// AddonsConfig lists which configurable addons run in each mode. Mandatory addons
-// (composer_allow_plugins, composer_patches, composer_diff, update_hooks) always run and are
-// not listed here.
-type AddonsConfig struct {
-	Normal   []string `yaml:"normal"`
-	Security []string `yaml:"security"`
+// RunTypesConfig groups the settings that differ between a normal and a security run. Keying
+// on the run type rather than on the setting keeps everything one mode does in one block, so
+// configuring a security run means reading one stanza instead of picking the `security` field
+// out of every setting in the file.
+type RunTypesConfig struct {
+	Normal   RunTypeConfig `yaml:"normal"`
+	Security RunTypeConfig `yaml:"security"`
+}
+
+// RunTypeConfig is what a single run type configures.
+type RunTypeConfig struct {
+	// Addons lists the configurable addons to run. Mandatory addons
+	// (composer_allow_plugins, composer_patches, composer_diff, update_hooks) always run and
+	// are not listed here, nor is composer_audit, which is added automatically in security mode.
+	Addons []string `yaml:"addons"`
+
+	// AutoMerge asks the platform to merge the MR/PR once its pipeline passes.
+	AutoMerge bool `yaml:"auto_merge"`
+}
+
+// ActiveRunType returns the settings for the run type this invocation selected. Every consumer
+// of a per-run-type setting goes through here, so the mapping from --security to a config block
+// is stated once.
+func (c Config) ActiveRunType() RunTypeConfig {
+	if c.Security {
+		return c.RunTypes.Security
+	}
+	return c.RunTypes.Normal
 }

--- a/internal/configfile.go
+++ b/internal/configfile.go
@@ -35,10 +35,22 @@ func (t *flexTimeout) UnmarshalYAML(node *yaml.Node) error {
 
 // fileConfig mirrors the YAML-settable keys of .drupdater.yaml. Timeout is captured as a raw
 // scalar because yaml.v3 cannot decode a duration like "30m" into a time.Duration.
+//
+// Keys are split by scope: sites and timeout describe the whole run, everything that differs
+// between a normal and a security update lives under run_types. Nesting the run types under
+// their own key keeps them from ever colliding with a future global key.
 type fileConfig struct {
-	Sites   []string     `yaml:"sites"`
-	Timeout flexTimeout  `yaml:"timeout"`
-	Addons  AddonsConfig `yaml:"addons"`
+	Sites    []string       `yaml:"sites"`
+	Timeout  flexTimeout    `yaml:"timeout"`
+	RunTypes RunTypesConfig `yaml:"run_types"`
+}
+
+// legacyProbe detects the pre-run_types layout, where addons and auto_merge were top-level
+// keys each split by mode. Strict decoding already rejects them, but as "field addons not
+// found in type internal.fileConfig" — which says nothing about what to write instead.
+type legacyProbe struct {
+	Addons    *struct{} `yaml:"addons"`
+	AutoMerge *struct{} `yaml:"auto_merge"`
 }
 
 // defaultFileConfig returns a fileConfig pre-populated with defaults. Unmarshaling a YAML file
@@ -48,9 +60,11 @@ func defaultFileConfig() fileConfig {
 	return fileConfig{
 		Sites:   []string{"default"},
 		Timeout: "30m",
-		Addons: AddonsConfig{
-			Normal:   defaultNormalAddons,
-			Security: nil, // minimal by default; composer_audit is added automatically
+		RunTypes: RunTypesConfig{
+			Normal: RunTypeConfig{Addons: defaultNormalAddons},
+			// Security defaults to no configurable addons: it should be a minimal, focused
+			// fix, with only the mandatory ones and the automatic composer_audit running.
+			Security: RunTypeConfig{},
 		},
 	}
 }
@@ -69,6 +83,10 @@ func LoadConfigFile(path string, c *Config) (found bool, err error) {
 		return false, err
 	}
 
+	if err := checkLegacyLayout(data); err != nil {
+		return true, fmt.Errorf("in %s: %w", path, err)
+	}
+
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	// A file that is empty or contains only comments has no YAML document, which Decode
@@ -82,6 +100,35 @@ func LoadConfigFile(path string, c *Config) (found bool, err error) {
 		return true, fmt.Errorf("in %s: %w", path, err)
 	}
 	return true, nil
+}
+
+// checkLegacyLayout reports a config still written in the pre-run_types layout, naming the
+// replacement. Without it the run fails on the strict decode with "field addons not found in
+// type internal.fileConfig", which is accurate but leaves the reader to guess the new shape.
+func checkLegacyLayout(data []byte) error {
+	var probe legacyProbe
+	// Deliberately lenient: this asks only whether the legacy keys are present, so the decode
+	// is consulted just when it parsed. A malformed document is not this function's business —
+	// the strict decode in LoadConfigFile reports that, with proper context.
+	parsed := yaml.Unmarshal(data, &probe) == nil
+	if !parsed || (probe.Addons == nil && probe.AutoMerge == nil) {
+		return nil
+	}
+	return errors.New(`"addons" and "auto_merge" are now grouped per run type. Replace:
+  addons:
+    normal: [code_beautifier, ...]
+    security: []
+  auto_merge:
+    normal: false
+    security: true
+with:
+  run_types:
+    normal:
+      addons: [code_beautifier, ...]
+      auto_merge: false
+    security:
+      addons: []
+      auto_merge: true`)
 }
 
 func applyFileConfig(fc fileConfig, c *Config) error {
@@ -98,6 +145,6 @@ func applyFileConfig(fc fileConfig, c *Config) error {
 	}
 	c.Sites = fc.Sites
 	c.Timeout = timeout
-	c.Addons = fc.Addons
+	c.RunTypes = fc.RunTypes
 	return nil
 }

--- a/internal/configfile_test.go
+++ b/internal/configfile_test.go
@@ -26,20 +26,20 @@ func TestLoadConfigFile(t *testing.T) {
 
 		assert.Equal(t, []string{"default"}, c.Sites)
 		assert.Equal(t, 30*time.Minute, c.Timeout)
-		assert.Equal(t, defaultNormalAddons, c.Addons.Normal)
-		assert.Empty(t, c.Addons.Security) // security is minimal by default
+		assert.Equal(t, defaultNormalAddons, c.RunTypes.Normal.Addons)
+		assert.Empty(t, c.RunTypes.Security.Addons) // security is minimal by default
 	})
 
 	t.Run("partial file keeps defaults for absent keys", func(t *testing.T) {
 		var c Config
-		found, err := LoadConfigFile(writeConfig(t, "addons:\n  normal: [code_beautifier]\n"), &c)
+		found, err := LoadConfigFile(writeConfig(t, "run_types:\n  normal:\n    addons: [code_beautifier]\n"), &c)
 		require.NoError(t, err)
 		assert.True(t, found)
 
-		assert.Equal(t, []string{"code_beautifier"}, c.Addons.Normal) // overridden
-		assert.Empty(t, c.Addons.Security)                            // default kept (minimal)
-		assert.Equal(t, []string{"default"}, c.Sites)                 // default kept
-		assert.Equal(t, 30*time.Minute, c.Timeout)                    // default kept
+		assert.Equal(t, []string{"code_beautifier"}, c.RunTypes.Normal.Addons) // overridden
+		assert.Empty(t, c.RunTypes.Security.Addons)                            // default kept (minimal)
+		assert.Equal(t, []string{"default"}, c.Sites)                          // default kept
+		assert.Equal(t, 30*time.Minute, c.Timeout)                             // default kept
 	})
 
 	t.Run("timeout string parses into a duration", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestLoadConfigFile(t *testing.T) {
 		assert.True(t, found)
 		assert.Equal(t, []string{"default"}, c.Sites)
 		assert.Equal(t, 30*time.Minute, c.Timeout)
-		assert.Equal(t, defaultNormalAddons, c.Addons.Normal)
+		assert.Equal(t, defaultNormalAddons, c.RunTypes.Normal.Addons)
 	})
 
 	t.Run("a comments-only file applies defaults", func(t *testing.T) {
@@ -117,5 +117,59 @@ func TestLoadConfigFile(t *testing.T) {
 		_, err := LoadConfigFile(writeConfig(t, "sites: [default, subsite_a]\n"), &c)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"default", "subsite_a"}, c.Sites)
+	})
+
+	t.Run("a run type sets its addons and auto_merge together", func(t *testing.T) {
+		var c Config
+		_, err := LoadConfigFile(writeConfig(t, `run_types:
+  normal:
+    addons: [code_beautifier]
+    auto_merge: false
+  security:
+    addons: []
+    auto_merge: true
+`), &c)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"code_beautifier"}, c.RunTypes.Normal.Addons)
+		assert.False(t, c.RunTypes.Normal.AutoMerge)
+		assert.Empty(t, c.RunTypes.Security.Addons)
+		assert.True(t, c.RunTypes.Security.AutoMerge)
+	})
+
+	t.Run("auto_merge defaults to false for both run types", func(t *testing.T) {
+		var c Config
+		found, err := LoadConfigFile(filepath.Join(t.TempDir(), "absent.yaml"), &c)
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.False(t, c.RunTypes.Normal.AutoMerge)
+		assert.False(t, c.RunTypes.Security.AutoMerge)
+	})
+
+	t.Run("ActiveRunType follows the security flag", func(t *testing.T) {
+		c := Config{RunTypes: RunTypesConfig{
+			Normal:   RunTypeConfig{Addons: []string{"code_beautifier"}, AutoMerge: false},
+			Security: RunTypeConfig{Addons: []string{"composer_audit"}, AutoMerge: true},
+		}}
+		assert.Equal(t, []string{"code_beautifier"}, c.ActiveRunType().Addons)
+		assert.False(t, c.ActiveRunType().AutoMerge)
+
+		c.Security = true
+		assert.Equal(t, []string{"composer_audit"}, c.ActiveRunType().Addons)
+		assert.True(t, c.ActiveRunType().AutoMerge)
+	})
+
+	t.Run("the pre-run_types layout fails with a migration message", func(t *testing.T) {
+		// Strict decoding alone would say "field addons not found in type internal.fileConfig",
+		// which does not tell the reader what to write instead.
+		for _, body := range []string{
+			"addons:\n  normal: [code_beautifier]\n",
+			"auto_merge:\n  normal: true\n",
+		} {
+			var c Config
+			_, err := LoadConfigFile(writeConfig(t, body), &c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "grouped per run type")
+			assert.Contains(t, err.Error(), "run_types:")
+		}
 	})
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -98,6 +98,22 @@ type Report struct {
 // MergeRequest identifies the merge/pull request a successful run opened.
 type MergeRequest struct {
 	URL string `json:"url"`
+	// AutoMerge is nil when the active run type did not ask for auto-merge, so a consumer can
+	// tell "not requested" apart from "requested and failed".
+	AutoMerge *AutoMerge `json:"auto_merge,omitempty"`
+}
+
+// AutoMerge is the outcome of asking the platform to merge the MR/PR once its pipeline passes.
+//
+// It is reported because enabling auto-merge is best-effort: a failure is logged and the run
+// still succeeds, since the branch is pushed and the MR exists by then. That makes the log the
+// only other place the outcome appears, so without this a consumer reading the report would see
+// a clean success and never learn that the MR it is waiting on will not merge itself.
+type AutoMerge struct {
+	// Enabled is true when the platform accepted the request.
+	Enabled bool `json:"enabled"`
+	// Error is why the request failed, empty when it succeeded.
+	Error string `json:"error,omitempty"`
 }
 
 // PackageChange is one dependency change made by composer update.
@@ -229,6 +245,22 @@ func (r *Recorder) SetMergeRequest(url string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.report.MergeRequest = &MergeRequest{URL: SanitizeURL(url)}
+}
+
+// SetAutoMerge records the outcome of the auto-merge request. err is nil when the platform
+// accepted it. It is a no-op when no merge request was recorded, since auto-merge is only ever
+// requested for one that exists.
+func (r *Recorder) SetAutoMerge(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.report.MergeRequest == nil {
+		return
+	}
+	am := &AutoMerge{Enabled: err == nil}
+	if err != nil {
+		am.Error = err.Error()
+	}
+	r.report.MergeRequest.AutoMerge = am
 }
 
 // AddAddons collects a structured section from every addon that implements Reporter. Addons that

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -110,6 +110,64 @@ func TestRecorderMergeRequestIsNilWhenNoneWasCreated(t *testing.T) {
 	assert.Nil(t, rep.MergeRequest)
 }
 
+func TestRecorderAutoMergeOutcome(t *testing.T) {
+	t.Run("absent until requested", func(t *testing.T) {
+		rec := newTestRecorder()
+		rec.SetMergeRequest("https://example.com/mr/1")
+
+		rep := rec.Finish()
+		require.NotNil(t, rep.MergeRequest)
+		assert.Nil(t, rep.MergeRequest.AutoMerge, "nil distinguishes not-requested from failed")
+	})
+
+	t.Run("success records enabled with no error", func(t *testing.T) {
+		rec := newTestRecorder()
+		rec.SetMergeRequest("https://example.com/mr/1")
+		rec.SetAutoMerge(nil)
+
+		rep := rec.Finish()
+		require.NotNil(t, rep.MergeRequest.AutoMerge)
+		assert.True(t, rep.MergeRequest.AutoMerge.Enabled)
+		assert.Empty(t, rep.MergeRequest.AutoMerge.Error)
+	})
+
+	t.Run("failure records the reason", func(t *testing.T) {
+		rec := newTestRecorder()
+		rec.SetMergeRequest("https://example.com/mr/1")
+		rec.SetAutoMerge(errors.New("auto-merge is not allowed for this repository"))
+
+		rep := rec.Finish()
+		require.NotNil(t, rep.MergeRequest.AutoMerge)
+		assert.False(t, rep.MergeRequest.AutoMerge.Enabled)
+		assert.Equal(t, "auto-merge is not allowed for this repository", rep.MergeRequest.AutoMerge.Error)
+	})
+
+	t.Run("no merge request means nothing to attach to", func(t *testing.T) {
+		// A --dry-run never opens one, so there is no MR whose auto-merge state could be set.
+		rec := newTestRecorder()
+		rec.SetAutoMerge(errors.New("boom"))
+
+		assert.Nil(t, rec.Finish().MergeRequest)
+	})
+}
+
+// The auto_merge key must be omitted entirely when it was never requested, so a consumer can
+// test for its presence rather than having to distinguish false-because-failed from
+// false-because-unset.
+func TestAutoMergeOmittedFromJSONWhenNotRequested(t *testing.T) {
+	rec := newTestRecorder()
+	rec.SetMergeRequest("https://example.com/mr/1")
+
+	encoded, err := json.Marshal(rec.Finish().MergeRequest)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "auto_merge")
+
+	rec.SetAutoMerge(nil)
+	encoded, err = json.Marshal(rec.Finish().MergeRequest)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"auto_merge":{"enabled":true}`)
+}
+
 // reportingAddon implements both internal.Addon and Reporter.
 type reportingAddon struct {
 	key  string

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -47,6 +47,7 @@ type Platform interface {
 	CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (codehosting.MergeRequest, error)
 	DeleteBranch(ctx context.Context, branch string) error
 	GetUser(ctx context.Context) (name string, email string)
+	EnableAutoMerge(ctx context.Context, mr codehosting.MergeRequest) error
 }
 
 // EventDispatcher abstracts the event bus so it can be injected and tested independently.

--- a/internal/services/mocks_test.go
+++ b/internal/services/mocks_test.go
@@ -2033,6 +2033,63 @@ func (_c *MockPlatform_DeleteBranch_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// EnableAutoMerge provides a mock function for the type MockPlatform
+func (_mock *MockPlatform) EnableAutoMerge(ctx context.Context, mr codehosting.MergeRequest) error {
+	ret := _mock.Called(ctx, mr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnableAutoMerge")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, codehosting.MergeRequest) error); ok {
+		r0 = returnFunc(ctx, mr)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockPlatform_EnableAutoMerge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnableAutoMerge'
+type MockPlatform_EnableAutoMerge_Call struct {
+	*mock.Call
+}
+
+// EnableAutoMerge is a helper method to define mock.On call
+//   - ctx context.Context
+//   - mr codehosting.MergeRequest
+func (_e *MockPlatform_Expecter) EnableAutoMerge(ctx any, mr any) *MockPlatform_EnableAutoMerge_Call {
+	return &MockPlatform_EnableAutoMerge_Call{Call: _e.mock.On("EnableAutoMerge", ctx, mr)}
+}
+
+func (_c *MockPlatform_EnableAutoMerge_Call) Run(run func(ctx context.Context, mr codehosting.MergeRequest)) *MockPlatform_EnableAutoMerge_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 codehosting.MergeRequest
+		if args[1] != nil {
+			arg1 = args[1].(codehosting.MergeRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPlatform_EnableAutoMerge_Call) Return(err error) *MockPlatform_EnableAutoMerge_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockPlatform_EnableAutoMerge_Call) RunAndReturn(run func(ctx context.Context, mr codehosting.MergeRequest) error) *MockPlatform_EnableAutoMerge_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUser provides a mock function for the type MockPlatform
 func (_mock *MockPlatform) GetUser(ctx context.Context) (string, string) {
 	ret := _mock.Called(ctx)

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -571,6 +571,23 @@ func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRe
 	ws.logger.Info("merge request created", zap.String("url", mr.URL))
 	rec.SetMergeRequest(mr.URL)
 
+	// Auto-merge is a convenience on top of work that has already succeeded: the branch is
+	// pushed and the MR exists. Failing the run here (repository forbids auto-merge, token
+	// lacks the scope, platform hiccup) would report a red job for a perfectly good MR, so
+	// the error is logged and the run still succeeds. The MR is deliberately left in place.
+	//
+	// It is recorded either way, because a warning in the log is easy to miss and the report
+	// would otherwise show a clean success for a run whose MR will never merge itself.
+	if ws.config.ActiveRunType().AutoMerge {
+		err := ws.platform.EnableAutoMerge(ctx, mr)
+		rec.SetAutoMerge(err)
+		if err != nil {
+			ws.logger.Warn("failed to enable auto merge", zap.String("url", mr.URL), zap.Error(err))
+		} else {
+			ws.logger.Info("auto merge enabled", zap.String("url", mr.URL))
+		}
+	}
+
 	return nil
 }
 

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -1047,6 +1047,190 @@ func TestStartUpdateExportConfigurationError(t *testing.T) {
 	repository.AssertNotCalled(t, "Push", mock.Anything)
 }
 
+func TestStartUpdateWithAutoMerge(t *testing.T) {
+	// When AutoMerge.Normal is true and Security is false, EnableAutoMerge must be called.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Clone:         true,
+		Sites:         []string{"site1"},
+		DryRun:        false,
+		RunTypes:      internal.RunTypesConfig{Normal: internal.RunTypeConfig{AutoMerge: true}},
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil)
+
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
+	repository.EXPECT().Push(mock.Anything).Return(nil)
+
+	fixture, err := os.ReadFile("testdata/dependency_update.md")
+	require.NoError(t, err)
+
+	createdMR := codehosting.MergeRequest{ID: 42, URL: "http://example.com/mr/42"}
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, string(fixture), mock.Anything, config.Branch).Return(createdMR, nil)
+	vcsProvider.EXPECT().EnableAutoMerge(mock.Anything, createdMR).Return(nil)
+
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
+		{Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err = workflowService.StartUpdate(ctx, nil)
+
+	require.NoError(t, err)
+	vcsProvider.AssertExpectations(t)
+}
+
+func TestStartUpdateAutoMergeError(t *testing.T) {
+	// Auto-merge is a convenience on top of work that already succeeded: the branch is pushed
+	// and the MR exists. A failure here must be logged as a warning, not fail the run.
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Clone:         true,
+		Sites:         []string{"site1"},
+		DryRun:        false,
+		RunTypes:      internal.RunTypesConfig{Normal: internal.RunTypeConfig{AutoMerge: true}},
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil)
+
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
+	repository.EXPECT().Push(mock.Anything).Return(nil)
+
+	createdMR := codehosting.MergeRequest{ID: 42, URL: "http://example.com/mr/42"}
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything, config.Branch).Return(createdMR, nil)
+	autoMergeErr := errors.New("auto-merge not allowed")
+	vcsProvider.EXPECT().EnableAutoMerge(mock.Anything, createdMR).Return(autoMergeErr)
+
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
+		{Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(ctx, nil)
+
+	require.NoError(t, err, "a failed auto-merge must not fail the run — the MR was created")
+
+	warnings := logs.FilterMessage("failed to enable auto merge").All()
+	require.Len(t, warnings, 1, "the failure must still be reported to the operator")
+	assert.Contains(t, warnings[0].ContextMap()["error"], autoMergeErr.Error())
+}
+
+func TestStartUpdateAutoMergeSkippedWhenDisabled(t *testing.T) {
+	// With AutoMerge zero value (all false), EnableAutoMerge must NOT be called.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Clone:         true,
+		Sites:         []string{"site1"},
+		DryRun:        false,
+		RunTypes:      internal.RunTypesConfig{},
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil)
+
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
+	repository.EXPECT().Push(mock.Anything).Return(nil)
+
+	fixture, err := os.ReadFile("testdata/dependency_update.md")
+	require.NoError(t, err)
+
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, string(fixture), mock.Anything, config.Branch).Return(codehosting.MergeRequest{}, nil)
+
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
+		{Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err = workflowService.StartUpdate(ctx, nil)
+
+	require.NoError(t, err)
+	vcsProvider.AssertNotCalled(t, "EnableAutoMerge", mock.Anything, mock.Anything)
+}
+
 func TestGenerateDescription_UnknownTemplate(t *testing.T) {
 	logger := zap.NewNop()
 	ws := NewWorkflowBaseService(logger, internal.Config{}, nil, nil, nil, nil, nil, nil)

--- a/internal/services/workflow_report_test.go
+++ b/internal/services/workflow_report_test.go
@@ -238,3 +238,54 @@ func phaseNames(phases []report.Phase) []string {
 
 	return names
 }
+
+// Auto-merge is best-effort: a failure only warns, so the report is the one machine-readable
+// place a consumer can learn that the MR it is waiting on will not merge itself.
+func TestReportRecordsAutoMergeOutcome(t *testing.T) {
+	t.Run("not requested leaves auto_merge absent", func(t *testing.T) {
+		h := newReportHarness(t, false)
+		h.expectFullRun(t)
+		h.repository.EXPECT().Push(mock.Anything).Return(nil)
+		h.vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "main").
+			Return(codehosting.MergeRequest{URL: "https://example.com/mr/1"}, nil)
+
+		require.NoError(t, h.run(t))
+
+		require.NotNil(t, h.got.MergeRequest)
+		assert.Nil(t, h.got.MergeRequest.AutoMerge, "absent means never asked for")
+	})
+
+	t.Run("success is recorded as enabled", func(t *testing.T) {
+		h := newReportHarness(t, false)
+		h.config.RunTypes.Normal.AutoMerge = true
+		h.expectFullRun(t)
+		h.repository.EXPECT().Push(mock.Anything).Return(nil)
+		h.vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "main").
+			Return(codehosting.MergeRequest{URL: "https://example.com/mr/1"}, nil)
+		h.vcsProvider.EXPECT().EnableAutoMerge(mock.Anything, mock.Anything).Return(nil)
+
+		require.NoError(t, h.run(t))
+
+		require.NotNil(t, h.got.MergeRequest.AutoMerge)
+		assert.True(t, h.got.MergeRequest.AutoMerge.Enabled)
+		assert.Empty(t, h.got.MergeRequest.AutoMerge.Error)
+	})
+
+	t.Run("failure is recorded without failing the run", func(t *testing.T) {
+		h := newReportHarness(t, false)
+		h.config.RunTypes.Normal.AutoMerge = true
+		h.expectFullRun(t)
+		h.repository.EXPECT().Push(mock.Anything).Return(nil)
+		h.vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "main").
+			Return(codehosting.MergeRequest{URL: "https://example.com/mr/1"}, nil)
+		h.vcsProvider.EXPECT().EnableAutoMerge(mock.Anything, mock.Anything).
+			Return(errors.New("auto-merge is not allowed for this repository"))
+
+		require.NoError(t, h.run(t), "a failed auto-merge must not fail the run")
+
+		assert.Equal(t, report.StatusSuccess, h.got.Status)
+		require.NotNil(t, h.got.MergeRequest.AutoMerge)
+		assert.False(t, h.got.MergeRequest.AutoMerge.Enabled)
+		assert.Contains(t, h.got.MergeRequest.AutoMerge.Error, "not allowed")
+	})
+}


### PR DESCRIPTION
Add auto-merge for the created MR/PR, and regroup `.drupdater.yaml` so everything
a run type configures lives in one block.

### Config layout

`sites` and `timeout` stay global; `addons` and `auto_merge` move under
`run_types.<normal|security>`:

```yaml
sites: [default]
timeout: 30m

run_types:
  normal:
    addons: [code_beautifier, deprecations_remover, ...]
    auto_merge: false
  security:
    addons: []
    auto_merge: false
```

Configuring a security run is now reading one stanza, rather than picking the
`security` field out of every setting in the file. `Config.ActiveRunType()`
resolves `--security` to a block once, so consumers stop branching on
`config.Security` themselves.

> [!WARNING]
> **Breaking.** The previous layout — top-level `addons` / `auto_merge`, each
> split by mode — is rejected at startup with a message naming the replacement,
> since strict decode alone would only say `field addons not found`.

### Auto-merge

- `EnableAutoMerge` joins the `Platform` interface and is called from
  `publishWork` after the MR/PR is created, for the active run type.
- **GitLab** — waits for `detailed_merge_status` to *settle*, not for
  `mergeable`. A pipeline-gated MR reports `ci_still_running` and only becomes
  `mergeable` once it could already be merged outright, so requiring that would
  make auto-merge unusable on exactly the projects that want it. The four
  "still computing" values match the API docs. Accepts with `auto_merge: true`
  and `should_remove_source_branch: true`.
- **GitHub** — `enablePullRequestAutoMerge`, picking a merge method the
  repository permits rather than hardcoding `MERGE`, which squash-only and
  rebase-only repositories reject.
- Best-effort: a failure logs a warning and the run still succeeds, since the
  branch is pushed and the MR exists by then. Because of that it is also
  recorded on the run report as `merge_request.auto_merge` — otherwise a
  consumer would see a clean success for an MR that will never merge itself.

Both run types default to auto-merge off.

Rebased onto `main` (through #176) and squashed to one commit.