### PR TITLE
fix: address findings from full code review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ The site databases are SQLite files written beside the working directory (`{dir}
 
 Addons implement the `Addon` interface and subscribe to workflow events via `gookit/event`. They hook into pre/post composer update and pre/post site update events.
 
-Which addons run is data-driven: `cmd/root.go` holds an `addonRegistry` (name → constructor) and `mandatoryAddons`. Four addons always run — `composer_allow_plugins`, `composer_patches`, `composer_diff`, `update_hooks` — and `composer_audit` is additionally mandatory in security mode. The rest are *configurable* and listed per mode in `.drupdater.yaml` under `addons.regular` / `addons.security`; `--security` selects which list is used. Configurable addon names: `code_beautifier`, `deprecations_remover`, `translations_updater`, `composer_normalizer`, `unsupported_modules`. An unknown name in the active list aborts the run.
+Which addons run is data-driven: `cmd/root.go` holds an `addonRegistry` (name → constructor) and `mandatoryAddons`. Four addons always run — `composer_allow_plugins`, `composer_patches`, `composer_diff`, `update_hooks` — and `composer_audit` is additionally mandatory in security mode. The rest are *configurable* and listed per mode in `.drupdater.yaml` under `addons.normal` / `addons.security`; `--security` selects which list is used. Configurable addon names: `code_beautifier`, `deprecations_remover`, `translations_updater`, `composer_normalizer`, `unsupported_modules`. An unknown name in the active list aborts the run.
 
 Addons use Go templates in `internal/addon/templates/` to render the MR description sections.
 
@@ -98,7 +98,7 @@ Config is split into two tiers, with no overlap:
 ### `.drupdater.yaml`
 
 ```yaml
-sites: [default]      # Drupal site names
+sites: [default]      # Drupal site names; at least one is required
 timeout: 30m          # overall run timeout (Go duration; 0 disables)
 addons:               # configurable addons per mode; mandatory addons always run
   normal:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Optional file at the repo root. Missing file or omitted keys fall back to the
 defaults below; unknown keys are rejected so typos fail fast.
 
 ```yaml
-sites: [default]      # Drupal site directories to update
+sites: [default]      # Drupal site directories to update (must not be empty)
 timeout: 30m          # overall run timeout (Go duration; 0 disables)
 addons:               # configurable addons per mode (mandatory addons always run)
   normal:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -57,10 +56,12 @@ names you can set there. See the README for the full file format.`,
 		if config.Clone && config.RepositoryURL == "" {
 			return errors.New("--repository-url is required with --clone")
 		}
-		// Validate the URL format when one is given.
+		// Validate the URL format when one is given, against what the provider factory accepts
+		// (HTTP(S) and SCP-style git URLs) rather than a stricter URL parser that would reject
+		// git@host:owner/repo.git even though cloning and provider detection handle it.
 		if config.RepositoryURL != "" {
-			if _, err := url.ParseRequestURI(config.RepositoryURL); err != nil {
-				return errors.New("invalid repository URL")
+			if err := codehosting.ValidateRepositoryURL(config.RepositoryURL); err != nil {
+				return fmt.Errorf("invalid repository URL: %w", err)
 			}
 		}
 		return nil
@@ -71,49 +72,37 @@ names you can set there. See the README for the full file format.`,
 		cmd.SilenceErrors = true
 
 		// Initialize the logger first so config errors are reported (errors are silenced by Cobra).
-		logger := NewLogger(config)
-
-		// The token comes from the positional argument, or DRUPDATER_TOKEN when it's omitted.
-		if len(args) == 1 {
-			config.Token = args[0]
-		} else {
-			config.Token = os.Getenv("DRUPDATER_TOKEN")
+		logger, err := NewLogger(config)
+		if err != nil {
+			// No logger yet, so this one report has to go straight to stderr.
+			fmt.Fprintln(cmd.ErrOrStderr(), "failed to initialize logger:", err)
+			return err
 		}
-		if config.Token == "" {
-			err := errors.New("no token provided: pass it as the argument or set DRUPDATER_TOKEN")
+
+		config.Token, err = resolveToken(args)
+		if err != nil {
 			logger.Error("missing token", zap.Error(err))
 			return err
 		}
 
 		// Load per-project config from .drupdater.yaml (sites, timeout, addons). A missing file
 		// falls back to built-in defaults.
-		cfgPath := configFile
-		if cfgPath == "" {
-			cfgPath = filepath.Join(config.WorkingDir, ".drupdater.yaml")
-		}
-		found, err := internal.LoadConfigFile(cfgPath, &config)
-		if err != nil {
-			logger.Error("invalid configuration", zap.Error(err))
+		if err := loadProjectConfig(logger, configFilePath(configFile, config.WorkingDir), &config); err != nil {
 			return err
 		}
-		if err := validateAddons(config); err != nil {
-			logger.Error("invalid configuration", zap.String("path", cfgPath), zap.Error(err))
-			return err
-		}
-		logger.Debug("configuration loaded",
-			zap.String("path", cfgPath),
-			zap.Bool("file_found", found),
-			zap.Strings("sites", config.Sites),
-			zap.Duration("timeout", config.Timeout),
-			zap.Strings("addons.normal", config.Addons.Normal),
-			zap.Strings("addons.security", config.Addons.Security),
-		)
 
-		cache := NewCache()
+		cache, err := NewCache()
+		if err != nil {
+			logger.Error("failed to create cache", zap.Error(err))
+			return err
+		}
 
 		// Create core service instances
 		drush := drush.NewCLI(logger, cache)
 		composer := composer.NewCLI(logger)
+		// Patch-apply checks build a scratch composer project in a temp directory; drop it
+		// when the run ends rather than leaving a vendor tree behind on every invocation.
+		defer composer.Cleanup()
 		drupalOrg := drupalorg.NewHTTPClient(logger)
 		installer := drupal.NewInstaller(logger, drush, composer)
 		git := repo.NewGitRepositoryService(logger)
@@ -121,19 +110,9 @@ names you can set there. See the README for the full file format.`,
 		// In checkout mode the repository URL and target branch come from the checkout, so
 		// they don't have to be passed in. --branch only applies to --clone.
 		if !config.Clone {
-			if config.RepositoryURL == "" {
-				remoteURL, err := git.GetRemoteURL(config.WorkingDir)
-				if err != nil {
-					return fmt.Errorf("failed to determine repository URL from checkout (pass --repository-url or run inside a checkout): %w", err)
-				}
-				config.RepositoryURL = remoteURL
-			}
-
-			branch, err := resolveCheckoutBranch(git, config.WorkingDir)
-			if err != nil {
+			if err := resolveCheckoutSettings(git, &config); err != nil {
 				return err
 			}
-			config.Branch = branch
 			logger.Info("using checkout", zap.String("url", config.RepositoryURL), zap.String("branch", config.Branch))
 
 			// CI mounts the checkout owned by a different user than the container runs as, so
@@ -169,6 +148,71 @@ names you can set there. See the README for the full file format.`,
 		}
 		return nil
 	},
+}
+
+// resolveToken returns the access token: the positional argument when one is given, otherwise
+// DRUPDATER_TOKEN. The environment variable is the preferred form because it keeps the token
+// out of the process list and the shell history.
+func resolveToken(args []string) (string, error) {
+	if len(args) == 1 && args[0] != "" {
+		return args[0], nil
+	}
+	if token := os.Getenv("DRUPDATER_TOKEN"); token != "" {
+		return token, nil
+	}
+	return "", errors.New("no token provided: pass it as the argument or set DRUPDATER_TOKEN")
+}
+
+// configFilePath returns the .drupdater.yaml to read: --config when set, otherwise the one in
+// the working directory.
+func configFilePath(explicit string, workingDir string) string {
+	if explicit != "" {
+		return explicit
+	}
+	return filepath.Join(workingDir, ".drupdater.yaml")
+}
+
+// loadProjectConfig layers the project's .drupdater.yaml onto cfg and validates the addon
+// names it lists. A missing file is not an error — the built-in defaults apply.
+func loadProjectConfig(logger *zap.Logger, path string, cfg *internal.Config) error {
+	found, err := internal.LoadConfigFile(path, cfg)
+	if err != nil {
+		logger.Error("invalid configuration", zap.String("path", path), zap.Error(err))
+		return err
+	}
+	if err := validateAddons(*cfg); err != nil {
+		logger.Error("invalid configuration", zap.String("path", path), zap.Error(err))
+		return err
+	}
+	logger.Debug("configuration loaded",
+		zap.String("path", path),
+		zap.Bool("file_found", found),
+		zap.Strings("sites", cfg.Sites),
+		zap.Duration("timeout", cfg.Timeout),
+		zap.Strings("addons.normal", cfg.Addons.Normal),
+		zap.Strings("addons.security", cfg.Addons.Security),
+	)
+	return nil
+}
+
+// resolveCheckoutSettings fills in the repository URL and target branch from the checkout,
+// which is where checkout mode takes them from instead of flags. --branch only applies to
+// --clone, so it is overwritten here.
+func resolveCheckoutSettings(git *repo.GitRepositoryService, cfg *internal.Config) error {
+	if cfg.RepositoryURL == "" {
+		remoteURL, err := git.GetRemoteURL(cfg.WorkingDir)
+		if err != nil {
+			return fmt.Errorf("failed to determine repository URL from checkout (pass --repository-url or run inside a checkout): %w", err)
+		}
+		cfg.RepositoryURL = remoteURL
+	}
+
+	branch, err := resolveCheckoutBranch(git, cfg.WorkingDir)
+	if err != nil {
+		return err
+	}
+	cfg.Branch = branch
+	return nil
 }
 
 // resolveCheckoutBranch determines the MR target branch for checkout mode: the checkout's
@@ -214,7 +258,6 @@ func ensureGitSafeDirectory(ctx context.Context, logger *zap.Logger, dir string)
 // addonDeps carries everything the addon constructors need.
 type addonDeps struct {
 	logger    *zap.Logger
-	config    internal.Config
 	drush     addon.Drush
 	composer  addon.Composer
 	drupalOrg addon.DrupalOrg
@@ -225,10 +268,10 @@ type addonDeps struct {
 var addonRegistry = map[string]func(addonDeps) internal.Addon{
 	"composer_audit": func(d addonDeps) internal.Addon { return addon.NewComposerAudit(d.logger, d.composer) },
 	"code_beautifier": func(d addonDeps) internal.Addon {
-		return addon.NewCodeBeautifier(d.logger, phpcs.NewCLI(d.logger), d.config, d.composer)
+		return addon.NewCodeBeautifier(d.logger, phpcs.NewCLI(d.logger), d.composer)
 	},
 	"deprecations_remover": func(d addonDeps) internal.Addon {
-		return addon.NewDeprecationsRemover(d.logger, rector.NewCLI(d.logger), d.config, d.composer)
+		return addon.NewDeprecationsRemover(d.logger, rector.NewCLI(d.logger), d.composer)
 	},
 	"translations_updater":   func(d addonDeps) internal.Addon { return addon.NewTranslationsUpdater(d.logger, d.drush, d.git) },
 	"composer_allow_plugins": func(d addonDeps) internal.Addon { return addon.NewComposerAllowPlugins(d.logger, d.composer) },
@@ -254,7 +297,7 @@ func createAddons(
 	drupalOrg addon.DrupalOrg,
 	git addon.Repository,
 ) ([]internal.Addon, error) {
-	deps := addonDeps{logger: logger, config: config, drush: drush, composer: composer, drupalOrg: drupalOrg, git: git}
+	deps := addonDeps{logger: logger, drush: drush, composer: composer, drupalOrg: drupalOrg, git: git}
 
 	names := config.Addons.Normal
 	if config.Security {
@@ -380,12 +423,11 @@ func Execute() {
 	}
 }
 
-func NewCache() otter.Cache[string, string] {
-	cache, _ := otter.MustBuilder[string, string](100).Build()
-	return cache
+func NewCache() (otter.Cache[string, string], error) {
+	return otter.MustBuilder[string, string](100).Build()
 }
 
-func NewLogger(config internal.Config) *zap.Logger {
+func NewLogger(config internal.Config) (*zap.Logger, error) {
 	loggerConfig := zap.NewDevelopmentConfig()
 	loggerConfig.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 
@@ -394,6 +436,5 @@ func NewLogger(config internal.Config) *zap.Logger {
 		loggerConfig.DisableCaller = true
 		loggerConfig.DisableStacktrace = true
 	}
-	log, _ := loggerConfig.Build(zap.AddStacktrace(zapcore.ErrorLevel))
-	return log
+	return loggerConfig.Build(zap.AddStacktrace(zapcore.ErrorLevel))
 }

--- a/cmd/root_extra_test.go
+++ b/cmd/root_extra_test.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/pkg/repo"
+	git "github.com/go-git/go-git/v5"
+	gitConfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestResolveToken(t *testing.T) {
+	t.Run("the positional argument wins", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "from-env")
+
+		token, err := resolveToken([]string{"from-arg"})
+		require.NoError(t, err)
+		assert.Equal(t, "from-arg", token)
+	})
+
+	t.Run("falls back to DRUPDATER_TOKEN", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "from-env")
+
+		token, err := resolveToken(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "from-env", token)
+	})
+
+	t.Run("an empty argument falls back to the environment", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "from-env")
+
+		token, err := resolveToken([]string{""})
+		require.NoError(t, err)
+		assert.Equal(t, "from-env", token)
+	})
+
+	t.Run("errors when neither is set", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "")
+
+		_, err := resolveToken(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DRUPDATER_TOKEN")
+	})
+}
+
+func TestConfigFilePath(t *testing.T) {
+	assert.Equal(t, "/explicit/config.yaml", configFilePath("/explicit/config.yaml", "/work"))
+	assert.Equal(t, filepath.Join("/work", ".drupdater.yaml"), configFilePath("", "/work"))
+}
+
+func TestLoadProjectConfig(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	t.Run("a missing file applies the defaults", func(t *testing.T) {
+		cfg := internal.Config{}
+		require.NoError(t, loadProjectConfig(logger, filepath.Join(t.TempDir(), ".drupdater.yaml"), &cfg))
+
+		assert.Equal(t, []string{"default"}, cfg.Sites)
+		assert.Equal(t, 30*time.Minute, cfg.Timeout)
+	})
+
+	t.Run("a file's values are applied", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".drupdater.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("sites: [default, sub]\ntimeout: 90s\n"), 0o600))
+
+		cfg := internal.Config{}
+		require.NoError(t, loadProjectConfig(logger, path, &cfg))
+		assert.Equal(t, []string{"default", "sub"}, cfg.Sites)
+		assert.Equal(t, 90*time.Second, cfg.Timeout)
+	})
+
+	t.Run("an invalid file is an error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".drupdater.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("timeout: nope\n"), 0o600))
+
+		cfg := internal.Config{}
+		require.Error(t, loadProjectConfig(logger, path, &cfg))
+	})
+
+	t.Run("an unknown addon name is an error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".drupdater.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("addons:\n  normal: [no_such_addon]\n"), 0o600))
+
+		cfg := internal.Config{}
+		err := loadProjectConfig(logger, path, &cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no_such_addon")
+	})
+}
+
+// initCheckout creates a repo with one commit and an origin remote.
+func initCheckout(t *testing.T, originURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	wt, err := r.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Commit("init", &git.CommitOptions{
+		AllowEmptyCommits: true,
+		Author:            &object.Signature{Name: "t", Email: "t@example.com"},
+	})
+	require.NoError(t, err)
+	if originURL != "" {
+		_, err = r.CreateRemote(&gitConfig.RemoteConfig{Name: "origin", URLs: []string{originURL}})
+		require.NoError(t, err)
+	}
+	return dir
+}
+
+func TestResolveCheckoutSettings(t *testing.T) {
+	svc := repo.NewGitRepositoryService(zap.NewNop())
+
+	t.Run("takes the URL and branch from the checkout", func(t *testing.T) {
+		dir := initCheckout(t, "https://token:secret@example.com/group/repo.git")
+
+		cfg := internal.Config{WorkingDir: dir, Branch: "main"}
+		require.NoError(t, resolveCheckoutSettings(svc, &cfg))
+
+		// Credentials embedded by CI are stripped.
+		assert.Equal(t, "https://example.com/group/repo.git", cfg.RepositoryURL)
+		// --branch is overridden by what the checkout actually has.
+		assert.Equal(t, "master", cfg.Branch)
+	})
+
+	t.Run("keeps an explicitly given repository URL", func(t *testing.T) {
+		dir := initCheckout(t, "https://example.com/group/repo.git")
+
+		cfg := internal.Config{WorkingDir: dir, RepositoryURL: "https://example.com/other/repo.git"}
+		require.NoError(t, resolveCheckoutSettings(svc, &cfg))
+		assert.Equal(t, "https://example.com/other/repo.git", cfg.RepositoryURL)
+	})
+
+	t.Run("errors when there is no origin remote", func(t *testing.T) {
+		cfg := internal.Config{WorkingDir: initCheckout(t, "")}
+		err := resolveCheckoutSettings(svc, &cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to determine repository URL from checkout")
+	})
+
+	t.Run("errors when the branch cannot be determined", func(t *testing.T) {
+		t.Setenv("GITHUB_REF_NAME", "")
+		t.Setenv("CI_COMMIT_REF_NAME", "")
+
+		dir := initCheckout(t, "https://example.com/group/repo.git")
+		r, err := git.PlainOpen(dir)
+		require.NoError(t, err)
+		head, err := r.Head()
+		require.NoError(t, err)
+		wt, err := r.Worktree()
+		require.NoError(t, err)
+		require.NoError(t, wt.Checkout(&git.CheckoutOptions{Hash: head.Hash()}))
+
+		cfg := internal.Config{WorkingDir: dir}
+		require.Error(t, resolveCheckoutSettings(svc, &cfg))
+	})
+}
+
+func TestEnsureGitSafeDirectory(t *testing.T) {
+	// Point git's global config at a scratch file so the test never touches the real one.
+	withScratchGitConfig := func(t *testing.T) string {
+		t.Helper()
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+		return filepath.Join(home, ".gitconfig")
+	}
+
+	readEntries := func(t *testing.T) string {
+		t.Helper()
+		out, err := exec.CommandContext(t.Context(), "git", "config", "--global", "--get-all", "safe.directory").Output()
+		if err != nil {
+			return ""
+		}
+		return string(out)
+	}
+
+	t.Run("adds the checkout once and does not duplicate it", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git binary not available")
+		}
+		gitconfig := withScratchGitConfig(t)
+		dir := t.TempDir()
+
+		ensureGitSafeDirectory(context.Background(), zap.NewNop(), dir)
+		first := readEntries(t)
+		assert.Contains(t, first, dir)
+
+		// A second run must not append the same entry again.
+		ensureGitSafeDirectory(context.Background(), zap.NewNop(), dir)
+		assert.Equal(t, first, readEntries(t))
+
+		assert.FileExists(t, gitconfig)
+	})
+
+	t.Run("a wildcard entry already covers the checkout", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git binary not available")
+		}
+		withScratchGitConfig(t)
+		dir := t.TempDir()
+
+		require.NoError(t, exec.CommandContext(t.Context(), "git", "config", "--global", "--add", "safe.directory", "*").Run())
+
+		ensureGitSafeDirectory(context.Background(), zap.NewNop(), dir)
+		assert.NotContains(t, readEntries(t), dir)
+	})
+
+	t.Run("an unresolvable path is reported, not fatal", func(t *testing.T) {
+		core, logs := observer.New(zap.WarnLevel)
+
+		// A cancelled context makes the git invocation fail; the run must continue regardless,
+		// because safe.directory is a convenience, not a requirement.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		ensureGitSafeDirectory(ctx, zap.New(core), t.TempDir())
+		assert.Positive(t, logs.Len())
+	})
+}
+
+func TestRootCommandPreRunE(t *testing.T) {
+	reset := func() {
+		config = internal.Config{}
+	}
+	t.Cleanup(reset)
+
+	t.Run("--clone without a repository URL is rejected", func(t *testing.T) {
+		reset()
+		config.Clone = true
+
+		err := rootCmd.PreRunE(rootCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--repository-url is required")
+	})
+
+	t.Run("an SCP-style repository URL is accepted", func(t *testing.T) {
+		reset()
+		config.RepositoryURL = "git@github.com:drupdater/drupdater.git"
+
+		require.NoError(t, rootCmd.PreRunE(rootCmd, nil))
+	})
+
+	t.Run("an HTTPS repository URL is accepted", func(t *testing.T) {
+		reset()
+		config.RepositoryURL = "https://github.com/drupdater/drupdater.git"
+
+		require.NoError(t, rootCmd.PreRunE(rootCmd, nil))
+	})
+
+	t.Run("a malformed repository URL is rejected", func(t *testing.T) {
+		reset()
+		config.RepositoryURL = "not a url"
+
+		err := rootCmd.PreRunE(rootCmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid repository URL")
+	})
+
+	t.Run("no repository URL is fine in checkout mode", func(t *testing.T) {
+		reset()
+		require.NoError(t, rootCmd.PreRunE(rootCmd, nil))
+	})
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -26,9 +26,10 @@ func TestNewLogger(t *testing.T) {
 		}
 
 		// Create logger
-		logger := NewLogger(config)
+		logger, err := NewLogger(config)
 
 		// Assert logger is in debug mode
+		require.NoError(t, err)
 		assert.NotNil(t, logger)
 		assert.True(t, logger.Core().Enabled(zapcore.DebugLevel))
 	})
@@ -40,9 +41,10 @@ func TestNewLogger(t *testing.T) {
 		}
 
 		// Create logger
-		logger := NewLogger(config)
+		logger, err := NewLogger(config)
 
 		// Assert logger is not in debug mode but is in info mode
+		require.NoError(t, err)
 		assert.NotNil(t, logger)
 		assert.False(t, logger.Core().Enabled(zapcore.DebugLevel))
 		assert.True(t, logger.Core().Enabled(zapcore.InfoLevel))
@@ -51,9 +53,10 @@ func TestNewLogger(t *testing.T) {
 
 func TestNewCache(t *testing.T) {
 	// Create cache
-	cache := NewCache()
+	cache, err := NewCache()
 
 	// Verify cache is initialized
+	require.NoError(t, err)
 	assert.NotNil(t, cache)
 
 	// Test basic cache operations

--- a/internal/addon/addons_extra_test.go
+++ b/internal/addon/addons_extra_test.go
@@ -1,0 +1,290 @@
+package addon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/drupdater/drupdater/internal/services"
+	"github.com/drupdater/drupdater/pkg/drush"
+	"github.com/drupdater/drupdater/pkg/rector"
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNewComposerPatches1(t *testing.T) {
+	t.Run("no token leaves the gitlab client unset", func(t *testing.T) {
+		t.Setenv("DRUPALCODE_ACCESS_TOKEN", "")
+
+		h := NewComposerPatches1(zap.NewNop(), NewMockComposer(t), NewMockDrupalOrg(t), nil)
+		require.NotNil(t, h)
+		assert.Nil(t, h.gitlab, "without a token there is no drupalcode client to look up issue forks with")
+	})
+
+	t.Run("a token configures the drupalcode gitlab client", func(t *testing.T) {
+		t.Setenv("DRUPALCODE_ACCESS_TOKEN", "secret")
+
+		h := NewComposerPatches1(zap.NewNop(), NewMockComposer(t), NewMockDrupalOrg(t), nil)
+		require.NotNil(t, h)
+		assert.NotNil(t, h.gitlab)
+	})
+}
+
+func TestComposerAllowPluginsNilMapIsNotAPanic(t *testing.T) {
+	// A project with no per-package allow-plugins entries yields an empty map. If the addon
+	// ever holds a nil map, assigning a newly discovered plugin into it panics.
+	composerService := NewMockComposer(t)
+	composerService.EXPECT().GetInstalledPlugins(mock.Anything, "/tmp").Return(map[string]any{"new/plugin": nil}, nil)
+	composerService.EXPECT().SetAllowPlugins(mock.Anything, "/tmp", map[string]bool{"new/plugin": false}).Return(nil)
+
+	ap := NewComposerAllowPlugins(zap.NewNop(), composerService)
+	ap.allowPlugins = nil // as if GetAllowPlugins had produced nothing
+
+	err := ap.postComposerUpdateHandler(services.NewPostComposerUpdateEvent(t.Context(), "/tmp", nil))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"new/plugin"}, ap.newAllowPlugins)
+}
+
+func TestComposerAllowPluginsErrors(t *testing.T) {
+	t.Run("reading the config fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().GetAllowPlugins(mock.Anything, "/tmp").Return(nil, assert.AnError)
+
+		ap := NewComposerAllowPlugins(zap.NewNop(), composerService)
+		err := ap.preComposerUpdateHandler(services.NewPreComposerUpdateEvent(t.Context(), "/tmp", nil, nil, nil, false))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get composer allow plugins")
+	})
+
+	t.Run("listing installed plugins fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().GetInstalledPlugins(mock.Anything, "/tmp").Return(nil, assert.AnError)
+
+		ap := NewComposerAllowPlugins(zap.NewNop(), composerService)
+		require.Error(t, ap.postComposerUpdateHandler(services.NewPostComposerUpdateEvent(t.Context(), "/tmp", nil)))
+	})
+
+	t.Run("writing the config back fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().GetInstalledPlugins(mock.Anything, "/tmp").Return(map[string]any{}, nil)
+		composerService.EXPECT().SetAllowPlugins(mock.Anything, "/tmp", mock.Anything).Return(assert.AnError)
+
+		ap := NewComposerAllowPlugins(zap.NewNop(), composerService)
+		ap.allowPlugins = map[string]bool{}
+		require.Error(t, ap.postComposerUpdateHandler(services.NewPostComposerUpdateEvent(t.Context(), "/tmp", nil)))
+	})
+}
+
+func TestComposerDiffLogFailureDoesNotFailTheRun(t *testing.T) {
+	// The link-free table only feeds the run log. Failing to produce it must be reported but
+	// must not abort an otherwise successful update.
+	core, logs := observer.New(zap.WarnLevel)
+
+	composerService := NewMockComposer(t)
+	composerService.EXPECT().Diff(mock.Anything, "/tmp", true).Return("| linked table |", nil)
+	composerService.EXPECT().Diff(mock.Anything, "/tmp", false).Return("", assert.AnError)
+
+	cd := NewComposerDiff(zap.New(core), composerService)
+	err := cd.postComposerUpdateHandler(services.NewPostComposerUpdateEvent(t.Context(), "/tmp", nil))
+
+	require.NoError(t, err)
+	assert.Equal(t, "| linked table |", cd.table, "the merge request still gets the linked table")
+	require.Equal(t, 1, logs.Len())
+	assert.Equal(t, "failed to render the dependency diff for the log", logs.All()[0].Message)
+}
+
+func TestComposerDiffFailure(t *testing.T) {
+	composerService := NewMockComposer(t)
+	composerService.EXPECT().Diff(mock.Anything, "/tmp", true).Return("", assert.AnError)
+
+	cd := NewComposerDiff(zap.NewNop(), composerService)
+	err := cd.postComposerUpdateHandler(services.NewPostComposerUpdateEvent(t.Context(), "/tmp", nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get diff")
+}
+
+func TestComposerNormalizerErrors(t *testing.T) {
+	t.Run("install check fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().IsPackageInstalled(mock.Anything, "/tmp", "ergebnis/composer-normalize").Return(false, assert.AnError)
+
+		cn := NewComposerNormalizer(zap.NewNop(), composerService)
+		require.Error(t, cn.postComposerUpdateHandler(services.NewPostComposerUpdateEvent(t.Context(), "/tmp", nil)))
+	})
+
+	t.Run("normalize fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().IsPackageInstalled(mock.Anything, "/tmp", "ergebnis/composer-normalize").Return(true, nil)
+		composerService.EXPECT().Normalize(mock.Anything, "/tmp").Return("", assert.AnError)
+
+		cn := NewComposerNormalizer(zap.NewNop(), composerService)
+		err := cn.postComposerUpdateHandler(services.NewPostComposerUpdateEvent(t.Context(), "/tmp", nil))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to normalize composer.json")
+	})
+}
+
+func TestDeprecationsRemoverErrors(t *testing.T) {
+	t.Run("installing rector fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().IsPackageInstalled(mock.Anything, "/tmp", "palantirnet/drupal-rector").Return(false, nil)
+		composerService.EXPECT().Require(mock.Anything, "/tmp", []string{"palantirnet/drupal-rector"}).Return("", assert.AnError)
+
+		dr := NewDeprecationsRemover(zap.NewNop(), NewMockRector(t), composerService)
+		require.Error(t, dr.postCodeUpdateHandler(services.NewPostCodeUpdateEvent(t.Context(), "/tmp", nil)))
+	})
+
+	t.Run("listing custom code directories fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().IsPackageInstalled(mock.Anything, "/tmp", "palantirnet/drupal-rector").Return(true, nil)
+		composerService.EXPECT().GetCustomCodeDirectories(mock.Anything, "/tmp").Return(nil, assert.AnError)
+
+		dr := NewDeprecationsRemover(zap.NewNop(), NewMockRector(t), composerService)
+		require.Error(t, dr.postCodeUpdateHandler(services.NewPostCodeUpdateEvent(t.Context(), "/tmp", nil)))
+	})
+
+	t.Run("removing the temporarily installed rector fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().IsPackageInstalled(mock.Anything, "/tmp", "palantirnet/drupal-rector").Return(false, nil)
+		composerService.EXPECT().Require(mock.Anything, "/tmp", []string{"palantirnet/drupal-rector"}).Return("", nil)
+		composerService.EXPECT().GetCustomCodeDirectories(mock.Anything, "/tmp").Return([]string{"web/modules/custom"}, nil)
+		composerService.EXPECT().Remove(mock.Anything, "/tmp", []string{"palantirnet/drupal-rector"}).Return("", assert.AnError)
+
+		runner := NewMockRector(t)
+		runner.EXPECT().Run(mock.Anything, "/tmp", []string{"web/modules/custom"}).Return(rector.ReturnOutput{}, nil)
+
+		dr := NewDeprecationsRemover(zap.NewNop(), runner, composerService)
+		require.Error(t, dr.postCodeUpdateHandler(services.NewPostCodeUpdateEvent(t.Context(), "/tmp", nil)))
+	})
+
+	t.Run("staging a changed file fails", func(t *testing.T) {
+		composerService := NewMockComposer(t)
+		composerService.EXPECT().IsPackageInstalled(mock.Anything, "/tmp", "palantirnet/drupal-rector").Return(true, nil)
+		composerService.EXPECT().GetCustomCodeDirectories(mock.Anything, "/tmp").Return([]string{"web/modules/custom"}, nil)
+
+		runner := NewMockRector(t)
+		runner.EXPECT().Run(mock.Anything, "/tmp", []string{"web/modules/custom"}).Return(rector.ReturnOutput{
+			Totals:       rector.ReturnOutputTotals{ChangedFiles: 1},
+			ChangedFiles: []string{"web/modules/custom/a.php"},
+		}, nil)
+
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Add("web/modules/custom/a.php").Return(plumbing.NewHash(""), assert.AnError)
+
+		dr := NewDeprecationsRemover(zap.NewNop(), runner, composerService)
+		require.Error(t, dr.postCodeUpdateHandler(services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)))
+	})
+}
+
+func TestTranslationsUpdaterErrors(t *testing.T) {
+	newEvent := func(worktree Worktree) *services.PostSiteUpdateEvent {
+		return services.NewPostSiteUpdateEvent(t.Context(), "/tmp", worktree, "site1")
+	}
+
+	t.Run("module check fails", func(t *testing.T) {
+		drushService := NewMockDrush(t)
+		drushService.EXPECT().IsModuleEnabled(mock.Anything, "/tmp", "site1", "locale_deploy").Return(false, assert.AnError)
+
+		tu := NewTranslationsUpdater(zap.NewNop(), drushService, NewMockRepository(t))
+		require.Error(t, tu.postSiteUpdateHandler(newEvent(nil)))
+	})
+
+	t.Run("localizing translations fails", func(t *testing.T) {
+		drushService := NewMockDrush(t)
+		drushService.EXPECT().IsModuleEnabled(mock.Anything, "/tmp", "site1", "locale_deploy").Return(true, nil)
+		drushService.EXPECT().LocalizeTranslations(mock.Anything, "/tmp", "site1").Return(assert.AnError)
+
+		tu := NewTranslationsUpdater(zap.NewNop(), drushService, NewMockRepository(t))
+		require.Error(t, tu.postSiteUpdateHandler(newEvent(nil)))
+	})
+
+	t.Run("an unresolvable translation path is skipped, not fatal", func(t *testing.T) {
+		// GetTranslationPath refuses to return an empty path, because handing that to
+		// Worktree.Add would stage the entire working tree.
+		drushService := NewMockDrush(t)
+		drushService.EXPECT().IsModuleEnabled(mock.Anything, "/tmp", "site1", "locale_deploy").Return(true, nil)
+		drushService.EXPECT().LocalizeTranslations(mock.Anything, "/tmp", "site1").Return(nil)
+		drushService.EXPECT().GetTranslationPath(mock.Anything, "/tmp", "site1", true).Return("", errors.New("does not resolve"))
+
+		tu := NewTranslationsUpdater(zap.NewNop(), drushService, NewMockRepository(t))
+		require.NoError(t, tu.postSiteUpdateHandler(newEvent(nil)))
+	})
+
+	t.Run("staging the translation path fails", func(t *testing.T) {
+		drushService := NewMockDrush(t)
+		drushService.EXPECT().IsModuleEnabled(mock.Anything, "/tmp", "site1", "locale_deploy").Return(true, nil)
+		drushService.EXPECT().LocalizeTranslations(mock.Anything, "/tmp", "site1").Return(nil)
+		drushService.EXPECT().GetTranslationPath(mock.Anything, "/tmp", "site1", true).Return("translations", nil)
+
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Add("translations").Return(plumbing.NewHash(""), assert.AnError)
+
+		tu := NewTranslationsUpdater(zap.NewNop(), drushService, NewMockRepository(t))
+		err := tu.postSiteUpdateHandler(newEvent(worktree))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to add translation path")
+	})
+
+	t.Run("committing the translations fails", func(t *testing.T) {
+		drushService := NewMockDrush(t)
+		drushService.EXPECT().IsModuleEnabled(mock.Anything, "/tmp", "site1", "locale_deploy").Return(true, nil)
+		drushService.EXPECT().LocalizeTranslations(mock.Anything, "/tmp", "site1").Return(nil)
+		drushService.EXPECT().GetTranslationPath(mock.Anything, "/tmp", "site1", true).Return("translations", nil)
+
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Add("translations").Return(plumbing.NewHash(""), nil)
+		worktree.EXPECT().Status().Return(git.Status{}, nil)
+		worktree.EXPECT().Commit("Update translations", &git.CommitOptions{}).Return(plumbing.NewHash(""), assert.AnError)
+
+		repository := NewMockRepository(t)
+		repository.EXPECT().IsSomethingStagedInPath(worktree, "translations").Return(true)
+
+		tu := NewTranslationsUpdater(zap.NewNop(), drushService, repository)
+		err := tu.postSiteUpdateHandler(newEvent(worktree))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to commit translation path")
+	})
+}
+
+func TestUpdateHooksHandlerError(t *testing.T) {
+	drushService := NewMockDrush(t)
+	drushService.EXPECT().GetUpdateHooks(mock.Anything, "/tmp", "site1").Return(nil, assert.AnError)
+
+	uh := NewUpdateHooks(zap.NewNop(), drushService)
+	err := uh.preSiteUpdateHandler(services.NewPreSiteUpdateEvent(t.Context(), "/tmp", nil, "site1"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get update hooks")
+}
+
+func TestUnsupportedModulesDeduplicatesAcrossSites(t *testing.T) {
+	// Multisite runs check every site; the same end-of-life module must be reported once.
+	module := drush.UnsupportedModule{Name: "old_module", InstalledVersion: "1.0", RecommendedVersion: "None"}
+
+	drushService := NewMockDrush(t)
+	drushService.EXPECT().GetUnsupportedModules(mock.Anything, "/tmp", "site1").Return([]drush.UnsupportedModule{module}, nil)
+	drushService.EXPECT().GetUnsupportedModules(mock.Anything, "/tmp", "site2").Return([]drush.UnsupportedModule{module}, nil)
+
+	um := NewUnsupportedModules(zap.NewNop(), drushService)
+	require.NoError(t, um.preSiteUpdateHandler(services.NewPreSiteUpdateEvent(t.Context(), "/tmp", nil, "site1")))
+	require.NoError(t, um.preSiteUpdateHandler(services.NewPreSiteUpdateEvent(t.Context(), "/tmp", nil, "site2")))
+
+	assert.Len(t, um.modules, 1)
+
+	out, err := um.RenderTemplate()
+	require.NoError(t, err)
+	assert.Equal(t, 1, countOccurrences(out, "old_module"))
+}
+
+func countOccurrences(haystack string, needle string) int {
+	count := 0
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -1,6 +1,7 @@
 package addon
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/services"
 
 	"github.com/go-git/go-git/v5"
@@ -21,16 +21,14 @@ import (
 type CodeBeautifier struct {
 	logger   *zap.Logger
 	phpcs    PHPCS
-	config   internal.Config
 	composer Composer
 }
 
 // NewCodeBeautifier creates a new code beautifier instance
-func NewCodeBeautifier(logger *zap.Logger, phpcs PHPCS, config internal.Config, composer Composer) *CodeBeautifier {
+func NewCodeBeautifier(logger *zap.Logger, phpcs PHPCS, composer Composer) *CodeBeautifier {
 	return &CodeBeautifier{
 		logger:   logger,
 		phpcs:    phpcs,
-		config:   config,
 		composer: composer,
 	}
 }
@@ -199,12 +197,6 @@ func (cb *CodeBeautifier) CreatePHPCSConfig(ctx context.Context, path string, wo
 		return false, fmt.Errorf("failed to parse phpcs template: %w", err)
 	}
 
-	outputFile, err := os.Create(filepath.Join(path, "phpcs.xml"))
-	if err != nil {
-		return false, fmt.Errorf("failed to create phpcs.xml: %w", err)
-	}
-	defer outputFile.Close()
-
 	drupalVersion, _ := cb.composer.GetInstalledPackageVersion(ctx, path, "drupal/core")
 	majorVersion := strings.Split(drupalVersion, ".")[0]
 
@@ -226,9 +218,25 @@ func (cb *CodeBeautifier) CreatePHPCSConfig(ctx context.Context, path string, wo
 		return false, nil
 	}
 
-	err = tmpl.Execute(outputFile, data)
-	if err != nil {
+	// Render before touching the filesystem. Creating the file up front would leave an empty
+	// phpcs.xml behind on any early return above, and the next run would then see that file,
+	// try to parse it for <file> definitions, and fail the whole run on the resulting XML
+	// syntax error.
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, data); err != nil {
 		return false, fmt.Errorf("failed to execute phpcs template: %w", err)
+	}
+
+	outputFile, err := os.Create(filepath.Join(path, "phpcs.xml"))
+	if err != nil {
+		return false, fmt.Errorf("failed to create phpcs.xml: %w", err)
+	}
+	if _, err := outputFile.Write(rendered.Bytes()); err != nil {
+		outputFile.Close() // ignore error; the write error takes precedence
+		return false, fmt.Errorf("failed to write phpcs.xml: %w", err)
+	}
+	if err := outputFile.Close(); err != nil {
+		return false, fmt.Errorf("failed to close phpcs.xml: %w", err)
 	}
 
 	if _, err := worktree.Add("phpcs.xml"); err != nil {

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/phpcs"
 
@@ -42,10 +41,14 @@ func TestCreatePHPCSConfig(t *testing.T) {
 		composer := NewMockComposer(t)
 		worktree := NewMockWorktree(t)
 
-		cb := NewCodeBeautifier(logger, nil, internal.Config{}, composer)
-
 		// Use a path that cannot be written to (root-owned directory)
-		_, err := cb.CreatePHPCSConfig(context.Background(), "/proc/nonexistent", worktree)
+		const badPath = "/proc/nonexistent"
+		composer.EXPECT().GetInstalledPackageVersion(mock.Anything, badPath, "drupal/core").Return("10.1.0", nil)
+		composer.EXPECT().GetCustomCodeDirectories(mock.Anything, badPath).Return([]string{"web/modules/custom"}, nil)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+
+		_, err := cb.CreatePHPCSConfig(context.Background(), badPath, worktree)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to create phpcs.xml")
 	})
@@ -59,11 +62,31 @@ func TestCreatePHPCSConfig(t *testing.T) {
 		composer.EXPECT().GetInstalledPackageVersion(mock.Anything, tmpDir, "drupal/core").Return("10.1.0", nil)
 		composer.EXPECT().GetCustomCodeDirectories(mock.Anything, tmpDir).Return([]string{}, nil)
 
-		cb := NewCodeBeautifier(logger, nil, internal.Config{}, composer)
+		cb := NewCodeBeautifier(logger, nil, composer)
 
 		created, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
 		require.NoError(t, err)
 		assert.False(t, created)
+
+		// No phpcs.xml may be left behind on this path. An empty one would be picked up by the
+		// next run as an existing config and fail hasPHPCSPathDefinitions with an XML error.
+		assert.NoFileExists(t, filepath.Join(tmpDir, "phpcs.xml"))
+	})
+
+	t.Run("Leaves no phpcs.xml behind when GetCustomCodeDirectories fails", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		worktree := NewMockWorktree(t)
+
+		tmpDir := t.TempDir()
+
+		composer.EXPECT().GetInstalledPackageVersion(mock.Anything, tmpDir, "drupal/core").Return("10.1.0", nil)
+		composer.EXPECT().GetCustomCodeDirectories(mock.Anything, tmpDir).Return(nil, assert.AnError)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+
+		_, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
+		require.Error(t, err)
+		assert.NoFileExists(t, filepath.Join(tmpDir, "phpcs.xml"))
 	})
 
 	t.Run("Creates phpcs.xml and commits when custom code directories found", func(t *testing.T) {
@@ -77,7 +100,7 @@ func TestCreatePHPCSConfig(t *testing.T) {
 		worktree.EXPECT().Add("phpcs.xml").Return(plumbing.NewHash(""), nil)
 		worktree.EXPECT().Commit("Add PHPCS config", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
 
-		cb := NewCodeBeautifier(logger, nil, internal.Config{}, composer)
+		cb := NewCodeBeautifier(logger, nil, composer)
 
 		created, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
 		require.NoError(t, err)
@@ -94,7 +117,7 @@ func TestCreatePHPCSConfig(t *testing.T) {
 		phpcsTemplateStr = "{{ invalid template syntax"
 		defer func() { phpcsTemplateStr = oldTemplate }()
 
-		cb := NewCodeBeautifier(logger, nil, internal.Config{}, composer)
+		cb := NewCodeBeautifier(logger, nil, composer)
 
 		_, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
 		require.Error(t, err)
@@ -102,6 +125,29 @@ func TestCreatePHPCSConfig(t *testing.T) {
 	})
 
 	t.Run("Returns error when template execution fails", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		worktree := NewMockWorktree(t)
+
+		tmpDir := t.TempDir()
+
+		// Parses fine, but fails at execution: Files is a []string with no such field.
+		oldTemplate := phpcsTemplateStr
+		phpcsTemplateStr = "{{ .Files.NoSuchField }}"
+		defer func() { phpcsTemplateStr = oldTemplate }()
+
+		composer.EXPECT().GetInstalledPackageVersion(mock.Anything, tmpDir, "drupal/core").Return("10.1.0", nil)
+		composer.EXPECT().GetCustomCodeDirectories(mock.Anything, tmpDir).Return([]string{"web/modules/custom"}, nil)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+
+		_, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to execute phpcs template")
+		// A failed render must not leave a partially written file for the next run to trip on.
+		assert.NoFileExists(t, filepath.Join(tmpDir, "phpcs.xml"))
+	})
+
+	t.Run("Returns error when writing phpcs.xml fails", func(t *testing.T) {
 		if _, statErr := os.Stat("/dev/full"); os.IsNotExist(statErr) {
 			t.Skip("/dev/full not available")
 		}
@@ -119,11 +165,11 @@ func TestCreatePHPCSConfig(t *testing.T) {
 		composer.EXPECT().GetInstalledPackageVersion(mock.Anything, tmpDir, "drupal/core").Return("10.1.0", nil)
 		composer.EXPECT().GetCustomCodeDirectories(mock.Anything, tmpDir).Return([]string{"web/modules/custom"}, nil)
 
-		cb := NewCodeBeautifier(logger, nil, internal.Config{}, composer)
+		cb := NewCodeBeautifier(logger, nil, composer)
 
 		_, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to execute phpcs template")
+		assert.Contains(t, err.Error(), "failed to write phpcs.xml")
 	})
 
 	t.Run("Returns error when GetCustomCodeDirectories fails", func(t *testing.T) {
@@ -135,7 +181,7 @@ func TestCreatePHPCSConfig(t *testing.T) {
 		composer.EXPECT().GetInstalledPackageVersion(mock.Anything, tmpDir, "drupal/core").Return("10.1.0", nil)
 		composer.EXPECT().GetCustomCodeDirectories(mock.Anything, tmpDir).Return(nil, assert.AnError)
 
-		cb := NewCodeBeautifier(logger, nil, internal.Config{}, composer)
+		cb := NewCodeBeautifier(logger, nil, composer)
 
 		_, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
 		require.Error(t, err)
@@ -152,7 +198,7 @@ func TestCreatePHPCSConfig(t *testing.T) {
 		composer.EXPECT().GetCustomCodeDirectories(mock.Anything, tmpDir).Return([]string{"web/modules/custom"}, nil)
 		worktree.EXPECT().Add("phpcs.xml").Return(plumbing.NewHash(""), assert.AnError)
 
-		cb := NewCodeBeautifier(logger, nil, internal.Config{}, composer)
+		cb := NewCodeBeautifier(logger, nil, composer)
 
 		_, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
 		require.Error(t, err)
@@ -170,7 +216,7 @@ func TestCreatePHPCSConfig(t *testing.T) {
 		worktree.EXPECT().Add("phpcs.xml").Return(plumbing.NewHash(""), nil)
 		worktree.EXPECT().Commit("Add PHPCS config", &git.CommitOptions{}).Return(plumbing.NewHash(""), assert.AnError)
 
-		cb := NewCodeBeautifier(logger, nil, internal.Config{}, composer)
+		cb := NewCodeBeautifier(logger, nil, composer)
 
 		_, err := cb.CreatePHPCSConfig(context.Background(), tmpDir, worktree)
 		require.Error(t, err)
@@ -284,7 +330,7 @@ func TestCodingStyles(t *testing.T) {
 		runner := NewMockPHPCS(t)
 		composer := NewMockComposer(t)
 
-		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{}, composer)
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)
 
 		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
@@ -307,7 +353,7 @@ func TestCodingStyles(t *testing.T) {
 		runner := NewMockPHPCS(t)
 		composer := NewMockComposer(t)
 
-		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{}, composer)
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)
 
 		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
@@ -340,7 +386,7 @@ func TestCodingStyles(t *testing.T) {
 		worktree.EXPECT().Commit("Add PHPCS config", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
 
 		// Create system under test
-		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{}, composer)
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(context.Background(), "/tmp", worktree)
 
 		// Execute and verify
@@ -378,7 +424,7 @@ func TestCodingStyles(t *testing.T) {
 		worktree.EXPECT().AddGlob("composer.*").Return(nil)
 		worktree.EXPECT().Commit("Install drupal/coder", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
 
-		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{}, composer)
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)
 		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
 		require.NoError(t, err)
@@ -407,7 +453,7 @@ func TestCodingStyles(t *testing.T) {
 		composer := NewMockComposer(t)
 		composer.EXPECT().IsPackageInstalled(mock.Anything, "/path/to/repo", "drupal/coder").Return(true, nil)
 
-		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{}, composer)
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/path/to/repo", worktree)
 		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
 		require.NoError(t, err)
@@ -475,7 +521,7 @@ func TestCodingStyles(t *testing.T) {
 		worktree.EXPECT().Status().Return(git.Status{"file1.php": &git.FileStatus{Staging: git.Modified}}, nil)
 		worktree.EXPECT().Commit("Update coding styles", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
 
-		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{}, composer)
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/path/to/repo", worktree)
 		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
 
@@ -506,7 +552,7 @@ func TestCodingStyles(t *testing.T) {
 		worktree.EXPECT().Status().Return(git.Status{}, nil)
 		// No Commit expectation: an empty index must not trigger a commit.
 
-		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{}, composer)
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/path/to/repo", worktree)
 		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
 
@@ -553,7 +599,7 @@ func TestCodingStyles(t *testing.T) {
 		composer := NewMockComposer(t)
 		composer.EXPECT().IsPackageInstalled(mock.Anything, "/path/to/repo", "drupal/coder").Return(true, nil)
 
-		updateCodingStyles := NewCodeBeautifier(logger, runner, internal.Config{}, composer)
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/path/to/repo", worktree)
 		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
 

--- a/internal/addon/composer_allow_plugins.go
+++ b/internal/addon/composer_allow_plugins.go
@@ -74,6 +74,12 @@ func (ap *ComposerAllowPlugins) postComposerUpdateHandler(e event.Event) error {
 		return err
 	}
 
+	// The map is written to below, so it must never be nil — a project with no allow-plugins
+	// entries yields an empty map, and assigning into a nil map panics.
+	if ap.allowPlugins == nil {
+		ap.allowPlugins = map[string]bool{}
+	}
+
 	// Add new plugins to allow-plugins
 	for key := range allPlugins {
 		if _, ok := ap.allowPlugins[key]; !ok {

--- a/internal/addon/composer_diff.go
+++ b/internal/addon/composer_diff.go
@@ -50,8 +50,15 @@ func (cd *ComposerDiff) postComposerUpdateHandler(e event.Event) error {
 	}
 	cd.table = table
 
-	table, _ = cd.composer.Diff(evt.Context(), evt.Path(), false)
-	cd.logger.Info("dependency diff\n" + table)
+	// The run log gets the link-free table: the linked variant is what goes in the merge
+	// request, but its markdown URLs make the same content unreadable in a terminal. A failure
+	// here only costs a log line, so it must not fail the run — but it is worth reporting.
+	plain, err := cd.composer.Diff(evt.Context(), evt.Path(), false)
+	if err != nil {
+		cd.logger.Warn("failed to render the dependency diff for the log", zap.Error(err))
+		return nil
+	}
+	cd.logger.Info("dependency diff\n" + plain)
 
 	return nil
 }

--- a/internal/addon/composer_patches_1.go
+++ b/internal/addon/composer_patches_1.go
@@ -214,6 +214,18 @@ func isRemotePatch(patchPath string) bool {
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
 }
 
+// dropPatchFile removes a patch's file from the worktree. A remote patch has no file in the
+// repository — its "path" is a URL — so there is nothing to remove and that is not an error.
+// Every removal path goes through here so a URL is never handed to worktree.Remove, which
+// would fail and leave the caller thinking the patch could not be dropped.
+func (h *ComposerPatches1) dropPatchFile(worktree Worktree, patchPath string) error {
+	if isRemotePatch(patchPath) {
+		return nil
+	}
+	_, err := worktree.Remove(patchPath)
+	return err
+}
+
 // removeDependencyProvidedPatches drops root patches whose patch file is already applied
 // by an installed dependency for the same package. composer-patches collects patches from
 // every package, so keeping the root copy makes it apply the same file twice (the second
@@ -257,10 +269,8 @@ func (h *ComposerPatches1) removeUninstalledPackagePatches(ctx context.Context, 
 			continue
 		}
 		for description, patchPath := range patches[packageName] {
-			if !isRemotePatch(patchPath) {
-				if _, err := worktree.Remove(patchPath); err != nil {
-					h.logger.Error("failed to remove patch", zap.String("patch", patchPath), zap.Error(err))
-				}
+			if err := h.dropPatchFile(worktree, patchPath); err != nil {
+				h.logger.Error("failed to remove patch", zap.String("patch", patchPath), zap.Error(err))
 			}
 			h.logger.Info("removing patch: package no longer installed", zap.String("package", packageName), zap.String("patch", patchPath))
 			removed = append(removed, RemovedPatch{Package: packageName, PatchPath: patchPath, PatchDescription: description, Reason: fmt.Sprintf("%s is not installed in the project", packageName)})
@@ -275,10 +285,8 @@ func (h *ComposerPatches1) removePackagePatches(worktree Worktree, op composer.P
 	for description, patchPath := range patches[op.Package] {
 		h.logger.Debug("removing patch", zap.String("package", op.Package), zap.String("patch", patchPath))
 		removed = append(removed, RemovedPatch{Package: op.Package, PatchPath: patchPath, PatchDescription: description, Reason: fmt.Sprintf("%s is no longer installed", op.Package)})
-		if !isRemotePatch(patchPath) {
-			if _, err := worktree.Remove(patchPath); err != nil {
-				h.logger.Error("failed to remove patch", zap.String("patch", patchPath), zap.Error(err))
-			}
+		if err := h.dropPatchFile(worktree, patchPath); err != nil {
+			h.logger.Error("failed to remove patch", zap.String("patch", patchPath), zap.Error(err))
 		}
 	}
 	delete(patches, op.Package)
@@ -311,15 +319,19 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 				h.logger.Error("failed to search commit history", zap.Error(err))
 			} else if len(commits) != 0 {
 				h.logger.Debug("issue is fixed", zap.String("issue", issue.ID))
-				if _, err := worktree.Remove(patchPath); err != nil {
+				if err := h.dropPatchFile(worktree, patchPath); err != nil {
+					// The entry was deleted from the map above. Put it back: a patch whose file
+					// could not be removed must stay declared rather than disappear from
+					// composer.json without ever being reported in the merge request.
 					h.logger.Error("failed to remove patch", zap.String("patch", patchPath), zap.Error(err))
-				} else {
-					if len(patches[op.Package]) == 0 {
-						delete(patches, op.Package)
-					}
-					h.logger.Info("removing patch: issue fixed in new version", zap.String("package", op.Package), zap.String("patch", patchPath))
-					updates.Removed = append(updates.Removed, RemovedPatch{Package: op.Package, PatchPath: patchPath, Reason: fmt.Sprintf("Issue [#%s](%s) is fixed in %s %s", issue.ID, issue.URL, op.Package, op.To), PatchDescription: description})
+					patches[op.Package][description] = patchPath
+					return
 				}
+				if len(patches[op.Package]) == 0 {
+					delete(patches, op.Package)
+				}
+				h.logger.Info("removing patch: issue fixed in new version", zap.String("package", op.Package), zap.String("patch", patchPath))
+				updates.Removed = append(updates.Removed, RemovedPatch{Package: op.Package, PatchPath: patchPath, Reason: fmt.Sprintf("Issue [#%s](%s) is fixed in %s %s", issue.ID, issue.URL, op.Package, op.To), PatchDescription: description})
 				return
 			}
 		}
@@ -392,11 +404,9 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 		h.logger.Debug("failed to check if patch applies", zap.String("patch", fullNewPath), zap.Error(err))
 		return
 	} else if ok {
-		if !externalPatch {
-			if _, err := worktree.Remove(patchPath); err != nil {
-				h.logger.Debug("failed to remove old patch file", zap.String("patch", patchPath), zap.Error(err))
-				return
-			}
+		if err := h.dropPatchFile(worktree, patchPath); err != nil {
+			h.logger.Debug("failed to remove old patch file", zap.String("patch", patchPath), zap.Error(err))
+			return
 		}
 		patches[op.Package][description] = fullNewPath
 		if _, err := worktree.Add(fullNewPath); err != nil {
@@ -414,8 +424,12 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 func (h *ComposerPatches1) validateCombinedPatches(ctx context.Context, path string, op composer.PackageChange, patches map[string]map[string]string, updates *PatchUpdates) {
 	patchPaths := make([]string, 0, len(patches[op.Package]))
 	for _, patchPath := range patches[op.Package] {
+		// Resolve local paths against the project, exactly as processSinglePatch does. This
+		// must use isRemotePatch, not url.ParseRequestURI: the latter accepts a bare absolute
+		// path like "/patches/x.diff", which would then be passed through unprefixed, fail to
+		// resolve, and report a false patch conflict that needlessly pins the package.
 		absolutePath := patchPath
-		if _, err := url.ParseRequestURI(patchPath); err != nil {
+		if !isRemotePatch(patchPath) {
 			absolutePath = path + "/" + patchPath
 		}
 		patchPaths = append(patchPaths, absolutePath)

--- a/internal/addon/composer_patches_1_handler_test.go
+++ b/internal/addon/composer_patches_1_handler_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 

--- a/internal/addon/composer_patches_1_removal_test.go
+++ b/internal/addon/composer_patches_1_removal_test.go
@@ -1,0 +1,187 @@
+package addon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/drupdater/drupdater/pkg/drupalorg"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+	"go.uber.org/zap"
+)
+
+// fixedIssueGitlab returns a gitlab client whose commit search reports the issue as fixed in
+// the target version.
+func fixedIssueGitlab(t *testing.T) *gitlab.Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		var body []byte
+		if r.URL.Path == "/api/v4/projects/project/drupal/-/search" {
+			body, _ = json.Marshal([]gitlab.Commit{{ID: "5678"}})
+		}
+		_, err := w.Write(body)
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := gitlab.NewClient("", gitlab.WithBaseURL(server.URL))
+	require.NoError(t, err)
+	return client
+}
+
+func fixedIssue() *drupalorg.Issue {
+	issue := &drupalorg.Issue{
+		ID:     "123456",
+		Title:  "Alot of problems",
+		Status: "7", // Closed (fixed)
+		URL:    "https://www.drupal.org/node/123456",
+	}
+	issue.Project.MaschineName = "drupal"
+	return issue
+}
+
+func upgradeCore() []composer.PackageChange {
+	return []composer.PackageChange{{
+		Action:  "Upgrade",
+		Package: "drupal/core",
+		From:    "8.7.0",
+		To:      "8.8.0",
+	}}
+}
+
+func TestUpdatePatchesRemovesRemotePatchForFixedIssue(t *testing.T) {
+	// A remote patch has no file in the repository, so there is nothing to remove from the
+	// worktree — passing its URL to worktree.Remove would fail, and the patch used to be
+	// dropped from composer.json without ever being reported in the merge request.
+	const patchURL = "https://www.drupal.org/files/issues/123456-1.patch"
+
+	composerService := NewMockComposer(t)
+	composerService.EXPECT().GetDependencyPatches(mock.Anything, "/tmp").Return(nil, nil).Maybe()
+	composerService.EXPECT().IsPackageInstalled(mock.Anything, "/tmp", "drupal/core").Return(true, nil)
+
+	drupalOrgService := NewMockDrupalOrg(t)
+	drupalOrgService.EXPECT().FindIssueNumber("Issue #123456").Return("123456", true)
+	drupalOrgService.EXPECT().GetIssue(mock.Anything, "123456").Return(fixedIssue(), nil)
+
+	// No worktree.Remove expectation: calling it with a URL is exactly the bug under test, and
+	// the mock fails the test if it is called.
+	worktree := NewMockWorktree(t)
+
+	updater := &ComposerPatches1{
+		logger:    zap.NewNop(),
+		composer:  composerService,
+		drupalOrg: drupalOrgService,
+		gitlab:    fixedIssueGitlab(t),
+	}
+
+	patches := map[string]map[string]string{
+		"drupal/core": {"Issue #123456": patchURL},
+	}
+
+	report, newPatches := updater.updatePatches(t.Context(), "/tmp", worktree, upgradeCore(), patches)
+
+	assert.Equal(t, map[string]map[string]string{}, newPatches, "the patch must be dropped from composer.json")
+	require.Len(t, report.Removed, 1, "and the removal must be reported in the merge request")
+	assert.Equal(t, patchURL, report.Removed[0].PatchPath)
+	assert.Equal(t, "drupal/core", report.Removed[0].Package)
+	assert.Contains(t, report.Removed[0].Reason, "is fixed in drupal/core 8.8.0")
+}
+
+func TestUpdatePatchesKeepsPatchWhenRemovalFails(t *testing.T) {
+	// If the patch file cannot be removed the entry must stay declared. Dropping it silently
+	// would change composer.json without any trace in the merge request description.
+	const patchPath = "patches/drupal/123456.patch"
+
+	composerService := NewMockComposer(t)
+	composerService.EXPECT().GetDependencyPatches(mock.Anything, "/tmp").Return(nil, nil).Maybe()
+	composerService.EXPECT().IsPackageInstalled(mock.Anything, "/tmp", "drupal/core").Return(true, nil)
+
+	drupalOrgService := NewMockDrupalOrg(t)
+	drupalOrgService.EXPECT().FindIssueNumber("Issue #123456").Return("123456", true)
+	drupalOrgService.EXPECT().GetIssue(mock.Anything, "123456").Return(fixedIssue(), nil)
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Remove(patchPath).Return(plumbing.NewHash(""), assert.AnError)
+
+	updater := &ComposerPatches1{
+		logger:    zap.NewNop(),
+		composer:  composerService,
+		drupalOrg: drupalOrgService,
+		gitlab:    fixedIssueGitlab(t),
+	}
+
+	patches := map[string]map[string]string{
+		"drupal/core": {"Issue #123456": patchPath},
+	}
+
+	report, newPatches := updater.updatePatches(t.Context(), "/tmp", worktree, upgradeCore(), patches)
+
+	assert.Empty(t, report.Removed)
+	assert.Equal(t, map[string]map[string]string{
+		"drupal/core": {"Issue #123456": patchPath},
+	}, newPatches, "the patch must still be declared")
+}
+
+func TestDropPatchFile(t *testing.T) {
+	updater := &ComposerPatches1{logger: zap.NewNop()}
+
+	t.Run("skips remote patches", func(t *testing.T) {
+		// A mock with no Remove expectation fails the test if Remove is called.
+		worktree := NewMockWorktree(t)
+		require.NoError(t, updater.dropPatchFile(worktree, "https://example.com/a.patch"))
+	})
+
+	t.Run("removes local patches", func(t *testing.T) {
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Remove("patches/a.patch").Return(plumbing.NewHash(""), nil)
+		require.NoError(t, updater.dropPatchFile(worktree, "patches/a.patch"))
+	})
+
+	t.Run("propagates the removal error", func(t *testing.T) {
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Remove("patches/a.patch").Return(plumbing.NewHash(""), assert.AnError)
+		require.Error(t, updater.dropPatchFile(worktree, "patches/a.patch"))
+	})
+}
+
+func TestValidateCombinedPatchesResolvesAbsoluteLocalPaths(t *testing.T) {
+	// An absolute local path is not a remote patch. url.ParseRequestURI accepts it, so the
+	// previous check passed it through unprefixed, composer could not find it, and the package
+	// was pinned on a patch conflict that did not exist.
+	composerService := NewMockComposer(t)
+	composerService.EXPECT().
+		CheckIfPatchesApply(mock.Anything, "drupal/core", "8.8.0", mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, paths []string) (bool, error) {
+			assert.ElementsMatch(t, []string{
+				"/tmp/patches/local.patch",
+				"/tmp//absolute/local.patch",
+				"https://example.com/remote.patch",
+			}, paths)
+			return true, nil
+		})
+
+	updater := &ComposerPatches1{logger: zap.NewNop(), composer: composerService}
+
+	patches := map[string]map[string]string{
+		"drupal/core": {
+			"relative": "patches/local.patch",
+			"absolute": "/absolute/local.patch",
+			"remote":   "https://example.com/remote.patch",
+		},
+	}
+	updates := PatchUpdates{}
+
+	updater.validateCombinedPatches(t.Context(), "/tmp", upgradeCore()[0], patches, &updates)
+
+	assert.Empty(t, updates.Conflicts)
+}

--- a/internal/addon/deprecations_remover.go
+++ b/internal/addon/deprecations_remover.go
@@ -1,7 +1,6 @@
 package addon
 
 import (
-	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/gookit/event"
 
@@ -13,16 +12,14 @@ import (
 type DeprecationsRemover struct {
 	logger   *zap.Logger
 	rector   Rector
-	config   internal.Config
 	composer Composer
 }
 
 // NewDeprecationsRemover creates a new deprecations remover instance
-func NewDeprecationsRemover(logger *zap.Logger, rector Rector, config internal.Config, composer Composer) *DeprecationsRemover {
+func NewDeprecationsRemover(logger *zap.Logger, rector Rector, composer Composer) *DeprecationsRemover {
 	return &DeprecationsRemover{
 		logger:   logger,
 		rector:   rector,
-		config:   config,
 		composer: composer,
 	}
 }

--- a/internal/addon/deprecations_remover_test.go
+++ b/internal/addon/deprecations_remover_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"testing"
 
-	internal "github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/rector"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -36,7 +35,6 @@ func TestRemoveDeprecations(t *testing.T) {
 	// Common test setup
 	logger := zap.NewNop()
 	worktree := NewMockWorktree(t)
-	config := internal.Config{}
 
 	t.Run("Rector is not installed", func(t *testing.T) {
 		// Setup
@@ -57,7 +55,7 @@ func TestRemoveDeprecations(t *testing.T) {
 		composer.EXPECT().Remove(mock.Anything, "/path/to/repo", []string{"palantirnet/drupal-rector"}).Return("", nil)
 
 		// Execute
-		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, config, composer)
+		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(context.Background(), "/path/to/repo", worktree)
 		err := updateRemoveDeprecations.postCodeUpdateHandler(postCodeUpdate)
 
@@ -97,7 +95,7 @@ func TestRemoveDeprecations(t *testing.T) {
 		worktree.EXPECT().Commit("Remove deprecations", mock.Anything).Return(plumbing.NewHash(""), nil)
 
 		// Execute
-		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, config, composer)
+		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(context.Background(), "/path/to/repo", worktree)
 		err := updateRemoveDeprecations.postCodeUpdateHandler(postCodeUpdate)
 
@@ -125,7 +123,7 @@ func TestRemoveDeprecations(t *testing.T) {
 		}, nil)
 
 		// Execute
-		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, config, composer)
+		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(context.Background(), "/path/to/repo", worktree)
 		err := updateRemoveDeprecations.postCodeUpdateHandler(postCodeUpdate)
 
@@ -146,7 +144,7 @@ func TestRemoveDeprecations(t *testing.T) {
 		runner.EXPECT().Run(mock.Anything, "/path/to/repo", []string{"web/modules/custom"}).Return(rector.ReturnOutput{}, assert.AnError)
 
 		// Execute
-		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, config, composer)
+		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(context.Background(), "/path/to/repo", worktree)
 		err := updateRemoveDeprecations.postCodeUpdateHandler(postCodeUpdate)
 

--- a/internal/addon/translations_updater_test.go
+++ b/internal/addon/translations_updater_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 

--- a/internal/addon_test.go
+++ b/internal/addon_test.go
@@ -1,0 +1,54 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicAddonRender(t *testing.T) {
+	var ba BasicAddon
+
+	t.Run("renders an embedded addon template", func(t *testing.T) {
+		out, err := ba.Render("composer_diff.go.tmpl", "| package | from | to |")
+		require.NoError(t, err)
+		assert.Contains(t, out, "Dependency updates")
+		assert.Contains(t, out, "| package | from | to |")
+	})
+
+	t.Run("escapes pipes and newlines in table cells", func(t *testing.T) {
+		// The cell helper keeps a value containing "|" or a newline from breaking the markdown
+		// table it is interpolated into.
+		out, err := ba.Render("unsupported_modules.go.tmpl", []struct {
+			Name               string
+			InstalledVersion   string
+			RecommendedVersion string
+		}{
+			{Name: "a|b\nc", InstalledVersion: "1.0", RecommendedVersion: "None"},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, out, `a\|b c`)
+		assert.NotContains(t, out, "a|b")
+	})
+
+	t.Run("errors for an unknown template name", func(t *testing.T) {
+		_, err := ba.Render("does_not_exist.go.tmpl", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to execute template")
+	})
+
+	t.Run("errors when the template cannot be executed with the given data", func(t *testing.T) {
+		// update_hooks.go.tmpl ranges over a map of sites; a string has no such shape.
+		_, err := ba.Render("update_hooks.go.tmpl", "not-a-map")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to execute template")
+	})
+}
+
+func TestCellReplacer(t *testing.T) {
+	assert.Equal(t, `a\|b`, cellReplacer.Replace("a|b"))
+	assert.Equal(t, "a b", cellReplacer.Replace("a\nb"))
+	assert.Equal(t, "ab", cellReplacer.Replace("a\rb"))
+	assert.Equal(t, "plain", cellReplacer.Replace("plain"))
+}

--- a/internal/codehosting/factory.go
+++ b/internal/codehosting/factory.go
@@ -85,6 +85,14 @@ func providerFromHost(host string) string {
 	}
 }
 
+// ValidateRepositoryURL reports whether raw is a repository URL this tool can route to a
+// provider. It exists so callers validate against what Create actually accepts — including
+// SCP-style git URLs, which url.ParseRequestURI rejects because they carry no scheme.
+func ValidateRepositoryURL(raw string) error {
+	_, _, err := parseGitURL(raw)
+	return err
+}
+
 // parseGitURL extracts the host and "owner/repo" path from a repository URL, accepting both
 // HTTP(S) URLs (https://host/owner/repo.git) and SCP-style git URLs (git@host:owner/repo.git).
 // Any trailing ".git" and surrounding slashes are stripped.

--- a/internal/codehosting/factory_test.go
+++ b/internal/codehosting/factory_test.go
@@ -203,3 +203,27 @@ func TestParseGitURL(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRepositoryURL(t *testing.T) {
+	t.Run("accepts HTTPS URLs", func(t *testing.T) {
+		require.NoError(t, ValidateRepositoryURL("https://github.com/drupdater/drupdater.git"))
+	})
+
+	t.Run("accepts SCP-style git URLs", func(t *testing.T) {
+		// url.ParseRequestURI rejects these because they have no scheme, but Create routes
+		// them fine, so the flag validation must accept them too.
+		require.NoError(t, ValidateRepositoryURL("git@github.com:drupdater/drupdater.git"))
+	})
+
+	t.Run("rejects an empty URL", func(t *testing.T) {
+		require.Error(t, ValidateRepositoryURL(""))
+	})
+
+	t.Run("rejects a URL with no host", func(t *testing.T) {
+		require.Error(t, ValidateRepositoryURL("https:///drupdater"))
+	})
+
+	t.Run("rejects a bare word", func(t *testing.T) {
+		require.Error(t, ValidateRepositoryURL("not-a-url"))
+	})
+}

--- a/internal/codehosting/github.go
+++ b/internal/codehosting/github.go
@@ -33,7 +33,7 @@ func newGithub(path string, token string, logger *zap.Logger) (*Github, error) {
 	}, nil
 }
 
-func (g Github) CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error) {
+func (g *Github) CreateMergeRequest(ctx context.Context, title string, description string, sourceBranch string, targetBranch string) (MergeRequest, error) {
 	mr, _, err := g.client.PullRequests.Create(ctx, g.owner, g.repo, &github.NewPullRequest{
 		Head:  &sourceBranch,
 		Base:  &targetBranch,

--- a/internal/configfile.go
+++ b/internal/configfile.go
@@ -2,7 +2,9 @@ package internal
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -69,7 +71,10 @@ func LoadConfigFile(path string, c *Config) (found bool, err error) {
 
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
-	if err := dec.Decode(&fc); err != nil {
+	// A file that is empty or contains only comments has no YAML document, which Decode
+	// reports as io.EOF. That is the same intent as an absent file — no keys are set — so it
+	// resolves to the defaults rather than failing the run.
+	if err := dec.Decode(&fc); err != nil && !errors.Is(err, io.EOF) {
 		return true, fmt.Errorf("parsing %s: %w", path, err)
 	}
 
@@ -83,6 +88,13 @@ func applyFileConfig(fc fileConfig, c *Config) error {
 	timeout, err := time.ParseDuration(string(fc.Timeout))
 	if err != nil {
 		return fmt.Errorf("invalid timeout %q (use a Go duration like \"30m\" or \"2h\", or 0 to disable): %w", string(fc.Timeout), err)
+	}
+	// Reject an empty site list instead of running with it. Every per-site phase — installing
+	// the baseline database, running update hooks, exporting configuration — iterates this
+	// list, so an empty one would silently skip all of them and still open a merge request for
+	// an update that was never validated against a site.
+	if len(fc.Sites) == 0 {
+		return errors.New(`no sites configured: "sites" must list at least one Drupal site name`)
 	}
 	c.Sites = fc.Sites
 	c.Timeout = timeout

--- a/internal/configfile_test.go
+++ b/internal/configfile_test.go
@@ -68,4 +68,54 @@ func TestLoadConfigFile(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "timout")
 	})
+
+	t.Run("an empty file applies defaults", func(t *testing.T) {
+		// An empty document decodes to io.EOF. That means "no keys set", the same as an absent
+		// file — it must not fail the run.
+		var c Config
+		found, err := LoadConfigFile(writeConfig(t, ""), &c)
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, []string{"default"}, c.Sites)
+		assert.Equal(t, 30*time.Minute, c.Timeout)
+		assert.Equal(t, defaultNormalAddons, c.Addons.Normal)
+	})
+
+	t.Run("a comments-only file applies defaults", func(t *testing.T) {
+		var c Config
+		found, err := LoadConfigFile(writeConfig(t, "# everything is commented out\n# sites: [a]\n"), &c)
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, []string{"default"}, c.Sites)
+	})
+
+	t.Run("an unreadable path is an error", func(t *testing.T) {
+		var c Config
+		// A directory is not os.IsNotExist, so it must surface rather than fall back.
+		_, err := LoadConfigFile(t.TempDir(), &c)
+		require.Error(t, err)
+	})
+
+	t.Run("an explicitly empty site list is rejected", func(t *testing.T) {
+		// Every per-site phase iterates this list, so an empty one would skip installing,
+		// updating and exporting for all sites while still opening a merge request.
+		var c Config
+		_, err := LoadConfigFile(writeConfig(t, "sites: []\n"), &c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no sites configured")
+	})
+
+	t.Run("a null site list is rejected", func(t *testing.T) {
+		var c Config
+		_, err := LoadConfigFile(writeConfig(t, "sites:\n"), &c)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no sites configured")
+	})
+
+	t.Run("sites are applied when set", func(t *testing.T) {
+		var c Config
+		_, err := LoadConfigFile(writeConfig(t, "sites: [default, subsite_a]\n"), &c)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"default", "subsite_a"}, c.Sites)
+	})
 }

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -174,8 +174,14 @@ func (ws *WorkflowBaseService) cleanup(path string) {
 	parent := filepath.Dir(path)
 	for _, site := range ws.config.Sites {
 		os.Remove(filepath.Join(parent, site+".sqlite"))
+		// Remove only the per-site directory the installer created, never the whole "private"
+		// tree: a private files directory next to the checkout is a standard Drupal layout, so
+		// that parent can hold real project data this run does not own.
+		os.RemoveAll(filepath.Join(parent, "private", site))
 	}
-	os.RemoveAll(filepath.Join(parent, "private"))
+	// Drop the parent too, but only if removing the per-site directories left it empty —
+	// os.Remove refuses a non-empty directory, which is exactly the guard we want here.
+	os.Remove(filepath.Join(parent, "private"))
 }
 
 func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository GitRepository, worktree Worktree, path string) (string, error) {

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -147,7 +147,7 @@ func (s *CLI) Install(ctx context.Context, dir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to install dependencies: %w, output: %s", err, out)
 	}
-	return err
+	return nil
 }
 
 func (s *CLI) Require(ctx context.Context, dir string, args ...string) (string, error) {
@@ -362,15 +362,33 @@ func (s *CLI) GetInstalledPackageVersion(ctx context.Context, dir string, packag
 	return composerShow.Versions[0], nil
 }
 
+// GetAllowPlugins returns composer's allow-plugins config as a package -> allowed map.
+//
+// The setting is polymorphic: composer accepts an object of per-package entries, the boolean
+// `true` ("allow every plugin"), `false`, or nothing at all (reported as `[]`, `null`, or a
+// non-zero exit). Only the object form carries per-package entries, so every other shape
+// resolves to an empty map. The result is never nil — callers add newly discovered plugins to
+// it, and writing to a nil map panics.
 func (s *CLI) GetAllowPlugins(ctx context.Context, dir string) (map[string]bool, error) {
 	allowPluginsJSON, err := s.GetConfig(ctx, dir, "allow-plugins")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get composer allow-plugins config: %w", err)
+		// `composer config allow-plugins` exits non-zero when the key is not set at all. That
+		// is a legitimate project state, not a failure: there are simply no entries yet.
+		s.logger.Debug("no composer allow-plugins config found", zap.Error(err))
+		return map[string]bool{}, nil
 	}
 
-	var allowPlugins map[string]bool
+	allowPlugins := map[string]bool{}
 	if err := json.Unmarshal([]byte(allowPluginsJSON), &allowPlugins); err != nil {
-		return nil, err
+		switch strings.TrimSpace(allowPluginsJSON) {
+		case "true", "false", "[]", "":
+			return map[string]bool{}, nil
+		}
+		return nil, fmt.Errorf("failed to parse composer allow-plugins config %q: %w", allowPluginsJSON, err)
+	}
+	if allowPlugins == nil {
+		// JSON null decodes successfully but sets the map to nil.
+		return map[string]bool{}, nil
 	}
 
 	return allowPlugins, nil
@@ -470,6 +488,20 @@ func (s *CLI) initTempDir() {
 
 	// Write the composer.json file to the temporary directory
 	s.initErr = afero.WriteFile(s.fs, s.tempDir+"/composer.json", []byte(composerJSON), 0644)
+}
+
+// Cleanup removes the scratch composer project used for patch-apply checks. It is a no-op
+// when no check ever ran, and safe to call more than once. Callers should defer it for the
+// lifetime of the CLI: without it every run leaves a scratch project (with a full vendor
+// tree) behind in the temp directory.
+func (s *CLI) Cleanup() {
+	if s.tempDir == "" {
+		return
+	}
+	if err := s.fs.RemoveAll(s.tempDir); err != nil {
+		s.logger.Warn("failed to remove composer scratch directory", zap.String("dir", s.tempDir), zap.Error(err))
+	}
+	s.tempDir = ""
 }
 
 type patchTestConfig struct {

--- a/pkg/composer/composer_extra_test.go
+++ b/pkg/composer/composer_extra_test.go
@@ -1,0 +1,311 @@
+package composer
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// stubComposerOutput makes the next composer invocations print out on stdout and exit 0. It
+// restores the real exec.CommandContext when the test ends.
+func stubComposerOutput(t *testing.T, out string) {
+	t.Helper()
+	execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", out}
+		cs = append(cs, arg...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GOCOVERDIR=/tmp"}
+		return cmd
+	}
+	t.Cleanup(func() { execCommand = exec.CommandContext })
+}
+
+// stubComposerFailure makes the next composer invocations exit non-zero.
+func stubComposerFailure(t *testing.T) {
+	t.Helper()
+	execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--"}
+		cs = append(cs, arg...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GO_HELPER_PROCESS_ERROR=1", "GOCOVERDIR=/tmp"}
+		return cmd
+	}
+	t.Cleanup(func() { execCommand = exec.CommandContext })
+}
+
+func TestNewCLI(t *testing.T) {
+	logger := zap.NewNop()
+	cli := NewCLI(logger)
+
+	require.NotNil(t, cli)
+	assert.Equal(t, logger, cli.logger)
+	assert.NotNil(t, cli.fs)
+}
+
+func TestGetAllowPluginsPolymorphicShapes(t *testing.T) {
+	// composer accepts several shapes for allow-plugins. Only the object form carries
+	// per-package entries; the rest mean "nothing to merge" and must not fail the run, because
+	// composer_allow_plugins is mandatory and would abort every update on such a project.
+	for _, shape := range []string{"true", "false", "[]", "null", ""} {
+		t.Run("shape "+shape, func(t *testing.T) {
+			stubComposerOutput(t, shape)
+
+			service := &CLI{logger: zap.NewNop()}
+			plugins, err := service.GetAllowPlugins(t.Context(), "/tmp")
+			require.NoError(t, err)
+			require.NotNil(t, plugins, "the result is written to by callers and must never be nil")
+			assert.Empty(t, plugins)
+		})
+	}
+
+	t.Run("an unset key is not a failure", func(t *testing.T) {
+		// `composer config allow-plugins` exits non-zero when the key is absent.
+		stubComposerFailure(t)
+
+		service := &CLI{logger: zap.NewNop()}
+		plugins, err := service.GetAllowPlugins(t.Context(), "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, plugins)
+		assert.Empty(t, plugins)
+	})
+
+	t.Run("malformed JSON is still an error", func(t *testing.T) {
+		stubComposerOutput(t, `{"broken": `)
+
+		service := &CLI{logger: zap.NewNop()}
+		_, err := service.GetAllowPlugins(t.Context(), "/tmp")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse composer allow-plugins config")
+	})
+}
+
+func TestSetAllowPluginsPropagatesError(t *testing.T) {
+	stubComposerFailure(t)
+
+	service := &CLI{logger: zap.NewNop()}
+	err := service.SetAllowPlugins(t.Context(), "/tmp", map[string]bool{"a/b": true})
+	require.Error(t, err)
+}
+
+func TestCleanup(t *testing.T) {
+	t.Run("removes the scratch project", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		service := &CLI{logger: zap.NewNop(), fs: fs}
+
+		service.initOnce.Do(service.initTempDir)
+		require.NoError(t, service.initErr)
+		dir := service.tempDir
+		require.NotEmpty(t, dir)
+		exists, err := afero.DirExists(fs, dir)
+		require.NoError(t, err)
+		require.True(t, exists)
+
+		service.Cleanup()
+
+		exists, err = afero.DirExists(fs, dir)
+		require.NoError(t, err)
+		assert.False(t, exists)
+		assert.Empty(t, service.tempDir)
+	})
+
+	t.Run("is a no-op when no scratch project was created", func(t *testing.T) {
+		service := &CLI{logger: zap.NewNop(), fs: afero.NewMemMapFs()}
+		service.Cleanup()
+		assert.Empty(t, service.tempDir)
+	})
+
+	t.Run("is safe to call twice", func(t *testing.T) {
+		service := &CLI{logger: zap.NewNop(), fs: afero.NewMemMapFs()}
+		service.initOnce.Do(service.initTempDir)
+		require.NoError(t, service.initErr)
+
+		service.Cleanup()
+		service.Cleanup()
+		assert.Empty(t, service.tempDir)
+	})
+}
+
+func TestInstallReturnsNilOnSuccess(t *testing.T) {
+	stubComposerOutput(t, "Nothing to install")
+
+	service := &CLI{logger: zap.NewNop()}
+	require.NoError(t, service.Install(t.Context(), "/tmp"))
+}
+
+func TestUpdatePropagatesFailure(t *testing.T) {
+	stubComposerFailure(t)
+
+	service := &CLI{logger: zap.NewNop()}
+	changes, err := service.Update(t.Context(), "/tmp", nil, nil, false, false)
+	require.Error(t, err)
+	assert.Empty(t, changes)
+	assert.Contains(t, err.Error(), "failed to update dependencies")
+}
+
+func TestUpdateBuildsArgs(t *testing.T) {
+	// The flags that shape a run are assembled here, so assert they reach composer: package
+	// filters, --with pins, --minimal-changes, and --dry-run vs --bump-after-update.
+	var captured []string
+	execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+		captured = arg
+		cs := []string{"-test.run=TestHelperProcess", "--", ""}
+		cs = append(cs, arg...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GOCOVERDIR=/tmp"}
+		return cmd
+	}
+	t.Cleanup(func() { execCommand = exec.CommandContext })
+
+	service := &CLI{logger: zap.NewNop()}
+
+	_, err := service.Update(t.Context(), "/tmp", []string{"drupal/core"}, []string{"drupal/foo:1.2.3"}, true, true)
+	require.NoError(t, err)
+	assert.Contains(t, captured, "drupal/core")
+	assert.Contains(t, captured, "--with=drupal/foo:1.2.3")
+	assert.Contains(t, captured, "--minimal-changes")
+	assert.Contains(t, captured, "--dry-run")
+	assert.NotContains(t, captured, "--bump-after-update")
+
+	_, err = service.Update(t.Context(), "/tmp", nil, nil, false, false)
+	require.NoError(t, err)
+	assert.Contains(t, captured, "--bump-after-update")
+	assert.NotContains(t, captured, "--dry-run")
+	assert.NotContains(t, captured, "--minimal-changes")
+}
+
+func TestGetLockHashErrors(t *testing.T) {
+	t.Run("missing composer.lock", func(t *testing.T) {
+		service := &CLI{logger: zap.NewNop(), fs: afero.NewMemMapFs()}
+		_, err := service.GetLockHash("/nowhere")
+		require.Error(t, err)
+	})
+
+	t.Run("malformed composer.lock", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/tmp/composer.lock", []byte("not json"), 0o644))
+
+		service := &CLI{logger: zap.NewNop(), fs: fs}
+		_, err := service.GetLockHash("/tmp")
+		require.Error(t, err)
+	})
+}
+
+func TestGetInstalledPackageVersionErrors(t *testing.T) {
+	t.Run("composer failure", func(t *testing.T) {
+		stubComposerFailure(t)
+		service := &CLI{logger: zap.NewNop()}
+		_, err := service.GetInstalledPackageVersion(t.Context(), "/tmp", "drupal/core")
+		require.Error(t, err)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		stubComposerOutput(t, "not-json")
+		service := &CLI{logger: zap.NewNop()}
+		_, err := service.GetInstalledPackageVersion(t.Context(), "/tmp", "drupal/core")
+		require.Error(t, err)
+	})
+
+	t.Run("no versions reported", func(t *testing.T) {
+		stubComposerOutput(t, `{"versions":[]}`)
+		service := &CLI{logger: zap.NewNop()}
+		_, err := service.GetInstalledPackageVersion(t.Context(), "/tmp", "drupal/core")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no versions found")
+	})
+}
+
+func TestDiffFailure(t *testing.T) {
+	stubComposerFailure(t)
+
+	service := &CLI{logger: zap.NewNop()}
+	out, err := service.Diff(t.Context(), "/tmp", true)
+	require.Error(t, err)
+	assert.Empty(t, out)
+}
+
+func TestGetInstalledPluginsFailure(t *testing.T) {
+	stubComposerFailure(t)
+
+	service := &CLI{logger: zap.NewNop()}
+	_, err := service.GetInstalledPlugins(t.Context(), "/tmp")
+	require.Error(t, err)
+}
+
+func TestAuditMalformedOutput(t *testing.T) {
+	stubComposerOutput(t, "not-json")
+
+	service := &CLI{logger: zap.NewNop()}
+	_, err := service.Audit(t.Context(), "/tmp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse composer audit output")
+}
+
+func TestAuditUnmarshalShapes(t *testing.T) {
+	t.Run("no advisories key yields an empty report", func(t *testing.T) {
+		var a Audit
+		require.NoError(t, a.UnmarshalJSON([]byte(`{"abandoned":{}}`)))
+		assert.Empty(t, a.Advisories)
+	})
+
+	t.Run("top-level JSON must be an object", func(t *testing.T) {
+		var a Audit
+		require.Error(t, a.UnmarshalJSON([]byte(`[]`)))
+	})
+
+	t.Run("a malformed advisory entry is an error", func(t *testing.T) {
+		var a Audit
+		require.Error(t, a.UnmarshalJSON([]byte(`{"advisories":{"drupal/core":["not-an-object"]}}`)))
+	})
+
+	t.Run("a malformed nested advisory entry is an error", func(t *testing.T) {
+		var a Audit
+		require.Error(t, a.UnmarshalJSON([]byte(`{"advisories":{"drupal/core":{"a":"not-an-object"}}}`)))
+	})
+
+	t.Run("an advisories value of an unexpected type is ignored", func(t *testing.T) {
+		var a Audit
+		require.NoError(t, a.UnmarshalJSON([]byte(`{"advisories":{"drupal/core":"unexpected"}}`)))
+		assert.Empty(t, a.Advisories)
+	})
+}
+
+func TestCheckIfPatchAppliesInitError(t *testing.T) {
+	// A read-only filesystem makes the scratch project impossible to create; the error must
+	// surface rather than being reported as "the patch does not apply".
+	service := &CLI{logger: zap.NewNop(), fs: afero.NewReadOnlyFs(afero.NewMemMapFs())}
+
+	_, err := service.CheckIfPatchApplies(t.Context(), "drupal/core", "10.1.0", "/patches/a.diff")
+	require.Error(t, err)
+}
+
+func TestCheckIfPatchesApplyInitError(t *testing.T) {
+	service := &CLI{logger: zap.NewNop(), fs: afero.NewReadOnlyFs(afero.NewMemMapFs())}
+
+	_, err := service.CheckIfPatchesApply(t.Context(), "drupal/core", "10.1.0", []string{"/patches/a.diff"})
+	require.Error(t, err)
+}
+
+func TestGetDependencyPatchesErrors(t *testing.T) {
+	t.Run("missing composer.lock", func(t *testing.T) {
+		service := &CLI{logger: zap.NewNop(), fs: afero.NewMemMapFs()}
+		_, err := service.GetDependencyPatches(t.Context(), "/nowhere")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read composer.lock")
+	})
+
+	t.Run("malformed composer.lock", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/tmp/composer.lock", []byte("not json"), 0o644))
+
+		service := &CLI{logger: zap.NewNop(), fs: fs}
+		_, err := service.GetDependencyPatches(t.Context(), "/tmp")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal composer.lock")
+	})
+}

--- a/pkg/drupal/installer.go
+++ b/pkg/drupal/installer.go
@@ -58,6 +58,13 @@ func (is *Installer) Install(ctx context.Context, path string, site string) erro
 	return nil
 }
 
+// settingsMarker tags the block ConfigureDatabase appends to a site's settings.php. The run
+// configures each site twice — once to build the baseline database, once before the update
+// hooks — and both calls target the same file now that old and new code share one working
+// directory. The marker makes the append idempotent instead of stacking duplicate database,
+// hash_salt and private-path settings.
+const settingsMarker = "// Added by drupdater: test database settings."
+
 func (is *Installer) ConfigureDatabase(ctx context.Context, dir string, site string) error {
 
 	siteLogger := is.logger.With(zap.String("site", site))
@@ -69,11 +76,17 @@ func (is *Installer) ConfigureDatabase(ctx context.Context, dir string, site str
 	}
 	webroot = strings.TrimSuffix(webroot, "/")
 
+	settingsPath := dir + "/" + webroot + "/sites/" + site + "/settings.php"
+	if existing, err := afero.ReadFile(is.fs, settingsPath); err == nil && strings.Contains(string(existing), settingsMarker) {
+		siteLogger.Debug("database already configured, skipping", zap.String("path", settingsPath))
+		return nil
+	}
+
 	sqliteFile, _ := filepath.Abs(fmt.Sprintf("%s/../%s.sqlite", dir, site))
 	privatesDir, _ := filepath.Abs(fmt.Sprintf("%s/../private/%s", dir, site))
 
-	settingsPath := dir + "/" + webroot + "/sites/" + site + "/settings.php"
 	settings := `
+` + settingsMarker + `
 $databases['default']['default'] = [
 	'database' => '` + sqliteFile + `',
 	'prefix' => '',

--- a/pkg/drupal/installer_extra_test.go
+++ b/pkg/drupal/installer_extra_test.go
@@ -1,0 +1,264 @@
+package drupal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const coreExtensionWithSqlite = `
+module:
+  node: 0
+  sqlite: 0
+theme:
+  stark: 0
+profile: standard
+`
+
+const coreExtensionWithoutSqlite = `
+module:
+  node: 0
+theme:
+  stark: 0
+profile: standard
+`
+
+// newTestInstaller wires an Installer onto an in-memory filesystem with the given
+// core.extension.yml and an (optionally pre-existing) settings.php.
+func newTestInstaller(t *testing.T, coreExtension string, settings string) (*Installer, afero.Fs, *MockDrush, *MockComposer) {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/config/sync/core.extension.yml", []byte(coreExtension), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/project/web/sites/site1/settings.php", []byte(settings), 0o644))
+
+	drush := NewMockDrush(t)
+	composer := NewMockComposer(t)
+
+	return &Installer{
+		logger:   zap.NewNop(),
+		drush:    drush,
+		composer: composer,
+		fs:       fs,
+	}, fs, drush, composer
+}
+
+func TestNewInstaller(t *testing.T) {
+	logger := zap.NewNop()
+	drush := NewMockDrush(t)
+	composer := NewMockComposer(t)
+
+	installer := NewInstaller(logger, drush, composer)
+
+	require.NotNil(t, installer)
+	assert.Equal(t, logger, installer.logger)
+	assert.Equal(t, drush, installer.drush)
+	assert.Equal(t, composer, installer.composer)
+	assert.NotNil(t, installer.fs)
+}
+
+func TestConfigureDatabaseIsIdempotent(t *testing.T) {
+	// The run configures each site twice — once for the baseline install, once before the
+	// update hooks — against the same settings.php. The second call must not append a second
+	// copy of the database, hash_salt and private-path settings.
+	installer, fs, drush, composer := newTestInstaller(t, coreExtensionWithSqlite, "<?php\n")
+
+	composer.EXPECT().GetConfig(mock.Anything, "/project", "extra.drupal-scaffold.locations.web-root").Return("web", nil)
+	drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+	require.NoError(t, installer.ConfigureDatabase(t.Context(), "/project", "site1"))
+
+	after, err := afero.ReadFile(fs, "/project/web/sites/site1/settings.php")
+	require.NoError(t, err)
+	first := string(after)
+	assert.Equal(t, 1, strings.Count(first, settingsMarker))
+	assert.Equal(t, 1, strings.Count(first, "$settings['hash_salt']"))
+
+	// Second call: the marker is present, so it must return early without touching the file.
+	// GetConfig is still needed to locate settings.php; GetConfigSyncDir is not reached.
+	require.NoError(t, installer.ConfigureDatabase(t.Context(), "/project", "site1"))
+
+	after, err = afero.ReadFile(fs, "/project/web/sites/site1/settings.php")
+	require.NoError(t, err)
+	assert.Equal(t, first, string(after), "settings.php must be unchanged by the second call")
+}
+
+func TestConfigureDatabaseEnablesSqliteWhenMissing(t *testing.T) {
+	installer, fs, drush, composer := newTestInstaller(t, coreExtensionWithoutSqlite, "<?php\n")
+
+	composer.EXPECT().GetConfig(mock.Anything, "/project", "extra.drupal-scaffold.locations.web-root").Return("web/", nil)
+	drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+	require.NoError(t, installer.ConfigureDatabase(t.Context(), "/project", "site1"))
+
+	// sqlite is added to core.extension.yml...
+	core, err := afero.ReadFile(fs, "/config/sync/core.extension.yml")
+	require.NoError(t, err)
+	assert.Contains(t, string(core), "sqlite: 0")
+
+	// ...and excluded from config export so it does not leak into the merge request.
+	settings, err := afero.ReadFile(fs, "/project/web/sites/site1/settings.php")
+	require.NoError(t, err)
+	assert.Contains(t, string(settings), "config_exclude_modules")
+}
+
+func TestConfigureDatabaseErrors(t *testing.T) {
+	t.Run("web root lookup fails", func(t *testing.T) {
+		installer, _, _, composer := newTestInstaller(t, coreExtensionWithSqlite, "<?php\n")
+		composer.EXPECT().GetConfig(mock.Anything, "/project", "extra.drupal-scaffold.locations.web-root").
+			Return("", assert.AnError)
+
+		err := installer.ConfigureDatabase(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get Drupal web dir")
+	})
+
+	t.Run("enabling sqlite fails", func(t *testing.T) {
+		installer, _, drush, composer := newTestInstaller(t, coreExtensionWithoutSqlite, "<?php\n")
+		composer.EXPECT().GetConfig(mock.Anything, "/project", "extra.drupal-scaffold.locations.web-root").Return("web", nil)
+		// The first lookup (isSqliteModuleEnabled) succeeds, addSqliteModule then fails.
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil).Once()
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("", assert.AnError).Once()
+
+		err := installer.ConfigureDatabase(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to enable sqlite module")
+	})
+
+	t.Run("settings.php does not exist", func(t *testing.T) {
+		// The snippet is an append to an existing settings.php; on its own it is not a valid
+		// settings file, so a missing one is an error rather than something to create.
+		installer, fs, drush, composer := newTestInstaller(t, coreExtensionWithSqlite, "<?php\n")
+		require.NoError(t, fs.Remove("/project/web/sites/site1/settings.php"))
+
+		composer.EXPECT().GetConfig(mock.Anything, "/project", "extra.drupal-scaffold.locations.web-root").Return("web", nil)
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+		err := installer.ConfigureDatabase(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to open settings file")
+	})
+}
+
+func TestIsSqliteModuleEnabled(t *testing.T) {
+	t.Run("reports enabled when listed with weight 0", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, coreExtensionWithSqlite, "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+		enabled, err := installer.isSqliteModuleEnabled(t.Context(), "/project", "site1")
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("reports not enabled when absent", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, coreExtensionWithoutSqlite, "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+		enabled, err := installer.isSqliteModuleEnabled(t.Context(), "/project", "site1")
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("errors when the config sync dir cannot be resolved", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, coreExtensionWithSqlite, "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("", assert.AnError)
+
+		_, err := installer.isSqliteModuleEnabled(t.Context(), "/project", "site1")
+		require.Error(t, err)
+	})
+
+	t.Run("errors when core.extension.yml is missing", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, coreExtensionWithSqlite, "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/nowhere", nil)
+
+		_, err := installer.isSqliteModuleEnabled(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read core extension file")
+	})
+
+	t.Run("errors on malformed YAML", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, "\tnot: [valid", "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+		_, err := installer.isSqliteModuleEnabled(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal core extension file")
+	})
+
+	t.Run("errors when there is no module section", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, "theme:\n  stark: 0\n", "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+		_, err := installer.isSqliteModuleEnabled(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has no module section")
+	})
+}
+
+func TestAddSqliteModuleErrors(t *testing.T) {
+	t.Run("config sync dir lookup fails", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, coreExtensionWithoutSqlite, "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("", assert.AnError)
+
+		require.Error(t, installer.addSqliteModule(t.Context(), "/project", "site1"))
+	})
+
+	t.Run("core.extension.yml is missing", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, coreExtensionWithoutSqlite, "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/nowhere", nil)
+
+		err := installer.addSqliteModule(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read core extension file")
+	})
+
+	t.Run("malformed YAML", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, "\tnot: [valid", "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+		err := installer.addSqliteModule(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal core extension file")
+	})
+
+	t.Run("no module section", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, "theme:\n  stark: 0\n", "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+		err := installer.addSqliteModule(t.Context(), "/project", "site1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has no module section")
+	})
+}
+
+func TestRemoveProfileErrors(t *testing.T) {
+	t.Run("config sync dir lookup fails", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, coreExtensionWithSqlite, "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("", assert.AnError)
+
+		require.Error(t, installer.RemoveProfile(t.Context(), "/project", "site1"))
+	})
+
+	t.Run("core.extension.yml is missing", func(t *testing.T) {
+		installer, _, drush, _ := newTestInstaller(t, coreExtensionWithSqlite, "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/nowhere", nil)
+
+		require.Error(t, installer.RemoveProfile(t.Context(), "/project", "site1"))
+	})
+
+	t.Run("a profile line that is not the configured one is kept", func(t *testing.T) {
+		installer, fs, drush, _ := newTestInstaller(t, "module:\n  node: 0\n  thunder: 1000\nprofile: thunder\n", "")
+		drush.EXPECT().GetConfigSyncDir(mock.Anything, "/project", "site1", false).Return("/config/sync", nil)
+
+		require.NoError(t, installer.RemoveProfile(t.Context(), "/project", "site1"))
+
+		out, err := afero.ReadFile(fs, "/config/sync/core.extension.yml")
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "profile: thunder")
+	})
+}

--- a/pkg/drupal/installer_test.go
+++ b/pkg/drupal/installer_test.go
@@ -70,6 +70,7 @@ profile: thunder
 			t.Fatalf("Failed to read updated content from settings.php: %v", err)
 		}
 		updatedContent := `
+` + settingsMarker + `
 $databases['default']['default'] = [
 	'database' => '/site1.sqlite',
 	'prefix' => '',

--- a/pkg/drupalorg/drupalorg.go
+++ b/pkg/drupalorg/drupalorg.go
@@ -46,6 +46,13 @@ func (s *HTTPClient) GetIssue(ctx context.Context, issueID string) (*Issue, erro
 	}
 	defer resp.Body.Close()
 
+	// Check the status before decoding: drupal.org answers an unknown node or an outage with
+	// an HTML error page, which would otherwise surface as an opaque "failed to decode
+	// response" instead of naming the real problem.
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch issue %s: unexpected status %s", issueID, resp.Status)
+	}
+
 	var apiResp Issue
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)

--- a/pkg/drupalorg/drupalorg_test.go
+++ b/pkg/drupalorg/drupalorg_test.go
@@ -123,3 +123,41 @@ func TestFindIssueNumber(t *testing.T) {
 		assert.Equal(t, tc.found, found)
 	}
 }
+
+func TestGetIssue_NonOKStatus(t *testing.T) {
+	// drupal.org answers an unknown node or an outage with an HTML error page. Checking the
+	// status first turns that into a message that names the real problem instead of an opaque
+	// JSON decode failure.
+	for _, status := range []int{http.StatusNotFound, http.StatusServiceUnavailable} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte("<html>error</html>"))
+			}))
+			defer mockServer.Close()
+
+			service := &HTTPClient{
+				DrupalOrgBaseURL: mockServer.URL,
+				logger:           zaptest.NewLogger(t),
+				client:           mockServer.Client(),
+			}
+
+			issue, err := service.GetIssue(context.Background(), "12345")
+			require.Error(t, err)
+			assert.Nil(t, issue)
+			assert.Contains(t, err.Error(), "unexpected status")
+		})
+	}
+}
+
+func TestGetIssue_InvalidURL(t *testing.T) {
+	service := &HTTPClient{
+		DrupalOrgBaseURL: "://not-a-url",
+		logger:           zaptest.NewLogger(t),
+		client:           &http.Client{},
+	}
+
+	issue, err := service.GetIssue(context.Background(), "12345")
+	require.Error(t, err)
+	assert.Nil(t, issue)
+}

--- a/pkg/drush/drush.go
+++ b/pkg/drush/drush.go
@@ -68,7 +68,7 @@ func (e *CLI) InstallSite(ctx context.Context, dir string, site string) error {
 	if err != nil {
 		return fmt.Errorf("failed to install %s: %w, output: %s", site, err, out)
 	}
-	return err
+	return nil
 }
 
 func (e *CLI) GetConfigSyncDir(ctx context.Context, dir string, site string, relative bool) (string, error) {

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -71,7 +71,7 @@ func (rs *GitRepositoryService) CloneRepository(repository string, branch string
 		return nil, nil, "", fmt.Errorf("git clone: %w", err)
 	}
 
-	return prepareCheckout(checkout, username, email)
+	return rs.prepareCheckout(checkout, username, email)
 }
 
 // OpenRepository opens an existing checkout (e.g. the one CI already provides) instead of
@@ -82,7 +82,7 @@ func (rs *GitRepositoryService) OpenRepository(path string, username string, ema
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("git open %q: %w", path, err)
 	}
-	return prepareCheckout(checkout, username, email)
+	return rs.prepareCheckout(checkout, username, email)
 }
 
 // GetRemoteURL returns the "origin" remote URL of the checkout at path. It is how checkout
@@ -128,8 +128,11 @@ func (rs *GitRepositoryService) GetCurrentBranch(path string) (string, error) {
 
 // prepareCheckout sets the commit identity and removes the prepare-commit-msg hook, then
 // returns the repository, worktree and working-tree root. Shared by clone and open.
-func prepareCheckout(checkout *git.Repository, username string, email string) (Repository, Worktree, string, error) {
-	config, _ := checkout.Config()
+func (rs *GitRepositoryService) prepareCheckout(checkout *git.Repository, username string, email string) (Repository, Worktree, string, error) {
+	config, err := checkout.Config()
+	if err != nil {
+		return checkout, nil, "", fmt.Errorf("failed to read git config: %w", err)
+	}
 	config.User.Name = username
 	config.User.Email = email
 	if err := checkout.SetConfig(config); err != nil {
@@ -140,16 +143,24 @@ func prepareCheckout(checkout *git.Repository, username string, email string) (R
 	if err != nil {
 		return checkout, nil, "", err
 	}
+	root := w.Filesystem.Root()
 
-	// @TODO: Verify if this is necessary
-	// Remove prepare-commit-msg hook because it does not work with the --no-verify option.
-	if _, err := w.Filesystem.Stat(".git/hooks/prepare-commit-msg"); err == nil {
-		if err := w.Filesystem.Remove(".git/hooks/prepare-commit-msg"); err != nil {
+	// Remove the project's prepare-commit-msg hook. go-git's own commits never run hooks, but
+	// `drush config:export --commit` shells out to the real git binary, which does — and a
+	// hook that prompts or rejects a machine-written message would wedge a non-interactive
+	// run that cannot pass --no-verify.
+	//
+	// This goes through the OS filesystem, not w.Filesystem: go-git's bound worktree
+	// filesystem rejects every path containing a ".git" component ("invalid path component"),
+	// so a Stat through it can never find the hook.
+	hookPath := filepath.Join(root, ".git", "hooks", "prepare-commit-msg")
+	if _, err := rs.fs.Stat(hookPath); err == nil {
+		if err := rs.fs.Remove(hookPath); err != nil {
 			return checkout, w, "", fmt.Errorf("failed to remove prepare-commit-msg hook: %w", err)
 		}
 	}
 
-	return checkout, w, w.Filesystem.Root(), nil
+	return checkout, w, root, nil
 }
 
 // BranchExists checks the actual remote for the branch, not the checkout's cached
@@ -189,10 +200,24 @@ func (rs *GitRepositoryService) IsSomethingStagedInPath(worktree Worktree, dir s
 	}
 
 	for filePath, s := range status {
-		if s.Staging != git.Unmodified && strings.Contains(filePath, dir) {
+		if s.Staging != git.Unmodified && pathWithin(filePath, dir) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// pathWithin reports whether filePath is dir itself or lives underneath it. Git status paths
+// are slash-separated and relative to the worktree root. A plain substring test would also
+// match siblings that merely share a prefix — for dir "translations" it would match
+// "translations-backup/de.po" — and report changes that are not in the directory at all.
+// An empty dir matches everything, which is what "no path filter" means.
+func pathWithin(filePath string, dir string) bool {
+	dir = strings.Trim(filepath.ToSlash(dir), "/")
+	if dir == "" {
+		return true
+	}
+	filePath = strings.Trim(filepath.ToSlash(filePath), "/")
+	return filePath == dir || strings.HasPrefix(filePath, dir+"/")
 }

--- a/pkg/repo/repo_extra_test.go
+++ b/pkg/repo/repo_extra_test.go
@@ -1,0 +1,155 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	gitConfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestPathWithin(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		dir      string
+		expected bool
+	}{
+		{name: "file directly in the directory", filePath: "translations/de.po", dir: "translations", expected: true},
+		{name: "file nested deeper in the directory", filePath: "translations/custom/de.po", dir: "translations", expected: true},
+		{name: "the directory itself", filePath: "translations", dir: "translations", expected: true},
+		{name: "an empty dir matches everything", filePath: "any/file.txt", dir: "", expected: true},
+		{name: "unrelated directory", filePath: "modules/custom/x.php", dir: "translations", expected: false},
+		// The reason pathWithin exists: a substring test would call these a match.
+		{name: "sibling sharing a name prefix", filePath: "translations-backup/de.po", dir: "translations", expected: false},
+		{name: "prefix match inside a longer segment", filePath: "web/translationsx/de.po", dir: "web/translations", expected: false},
+		{name: "leading and trailing slashes are ignored", filePath: "/translations/de.po", dir: "translations/", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, pathWithin(tt.filePath, tt.dir))
+		})
+	}
+}
+
+func TestIsSomethingStagedInPathIgnoresPrefixSiblings(t *testing.T) {
+	service := NewGitRepositoryService(zap.NewNop())
+
+	// A staged file in "translations-backup" must not be reported as a change in
+	// "translations": the translations addon commits based on this answer, and a false
+	// positive there makes it create a commit with no translation changes in it.
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Status().Return(git.Status{
+		"translations-backup/de.po": &git.FileStatus{Staging: git.Modified},
+	}, nil)
+
+	assert.False(t, service.IsSomethingStagedInPath(worktree, "translations"))
+}
+
+// initRepoWithCommit creates a repo containing a single empty commit.
+func initRepoWithCommit(t *testing.T) (string, *git.Repository) {
+	t.Helper()
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	wt, err := r.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Commit("init", &git.CommitOptions{
+		AllowEmptyCommits: true,
+		Author:            &object.Signature{Name: "t", Email: "t@example.com"},
+	})
+	require.NoError(t, err)
+	return dir, r
+}
+
+func TestOpenRepositoryRemovesPrepareCommitMsgHook(t *testing.T) {
+	service := NewGitRepositoryService(zap.NewNop())
+
+	dir, _ := initRepoWithCommit(t)
+	hookPath := filepath.Join(dir, ".git", "hooks", "prepare-commit-msg")
+	require.NoError(t, os.MkdirAll(filepath.Dir(hookPath), 0o755))
+	require.NoError(t, os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 1\n"), 0o600))
+
+	_, worktree, _, err := service.OpenRepository(dir, "Bot", "bot@example.com")
+	require.NoError(t, err)
+	assert.NotNil(t, worktree)
+
+	// The hook is removed because it cannot be bypassed with --no-verify.
+	assert.NoFileExists(t, hookPath)
+}
+
+func TestGetRemoteURLFallsBackForSCPStyleURLs(t *testing.T) {
+	service := NewGitRepositoryService(zap.NewNop())
+
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	// url.Parse rejects the SCP form ("first path segment in URL cannot contain colon"), so
+	// the raw URL has to be returned unchanged rather than dropped.
+	_, err = r.CreateRemote(&gitConfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@github.com:drupdater/drupdater.git"},
+	})
+	require.NoError(t, err)
+
+	url, err := service.GetRemoteURL(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "git@github.com:drupdater/drupdater.git", url)
+}
+
+func TestGetRemoteURLErrorsOnNonRepository(t *testing.T) {
+	service := NewGitRepositoryService(zap.NewNop())
+
+	_, err := service.GetRemoteURL(t.TempDir())
+	require.Error(t, err)
+}
+
+func TestCloneRepository(t *testing.T) {
+	service := NewGitRepositoryService(zap.NewNop())
+
+	t.Run("clones a branch and prepares the checkout", func(t *testing.T) {
+		source, r := initRepoWithCommit(t)
+		head, err := r.Head()
+		require.NoError(t, err)
+
+		repository, worktree, path, err := service.CloneRepository(source, head.Name().Short(), "", "Bot", "bot@example.com")
+		require.NoError(t, err)
+		assert.NotNil(t, repository)
+		assert.NotNil(t, worktree)
+		require.NotEmpty(t, path)
+
+		// The clone lives under a per-URL directory in the temp dir, which is what lets the
+		// workflow's cleanup remove just this run's clone.
+		assert.True(t, filepath.IsAbs(path))
+		assert.DirExists(t, filepath.Join(path, ".git"))
+
+		cloned, err := git.PlainOpen(path)
+		require.NoError(t, err)
+		cfg, err := cloned.Config()
+		require.NoError(t, err)
+		assert.Equal(t, "Bot", cfg.User.Name)
+		assert.Equal(t, "bot@example.com", cfg.User.Email)
+
+		t.Cleanup(func() { _ = os.RemoveAll(path) })
+	})
+
+	t.Run("returns the clone error for an unreachable repository", func(t *testing.T) {
+		_, _, _, err := service.CloneRepository(t.TempDir(), "main", "", "Bot", "bot@example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "git clone")
+	})
+
+	t.Run("returns the clone error for a branch that does not exist", func(t *testing.T) {
+		source, _ := initRepoWithCommit(t)
+
+		_, _, _, err := service.CloneRepository(source, "no-such-branch", "", "Bot", "bot@example.com")
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Correctness fixes, in rough order of impact:

- code_beautifier: CreatePHPCSConfig created phpcs.xml before checking for
  custom code directories, so a project without any was left with an empty
  phpcs.xml. The next run then treated that file as an existing config and
  failed parsing it for <file> definitions. Render first, write only on
  success.
- composer: allow-plugins is polymorphic (object, true, false, [], null, or
  unset). GetAllowPlugins assumed the object form, so `"allow-plugins": true`
  aborted every run at the first pre-composer-update — composer_allow_plugins
  is mandatory. Every non-object shape now yields an empty, never-nil map, and
  the addon guards the map write as well.
- composer_patches: a remote patch whose issue was fixed upstream was passed
  to worktree.Remove as a URL. That always failed, and the entry — already
  deleted from the patch map — was silently dropped from composer.json with no
  entry in the merge request. Removal now goes through dropPatchFile, which
  skips remote patches, and a genuine removal failure restores the entry.
- composer_patches: validateCombinedPatches used url.ParseRequestURI to tell
  remote from local. That accepts a bare absolute path, so /patches/x.diff was
  passed through unresolved, composer could not find it, and the package was
  pinned on a patch conflict that did not exist. Use isRemotePatch, as the rest
  of the file does.
- repo: the prepare-commit-msg hook removal never ran. go-git's bound worktree
  filesystem rejects any path containing a ".git" component, so the Stat always
  errored. Go through the OS filesystem instead. The hook matters because
  `drush config:export --commit` shells out to the real git binary.
- workflow: cleanup removed the whole "<parent>/private" tree, but only
  "private/<site>" is ours — a private files directory beside the checkout is a
  standard Drupal layout and can hold real project data. Remove per site, then
  drop the parent only if it ended up empty.
- configfile: an empty or comments-only .drupdater.yaml decodes to io.EOF and
  failed the run; it now means "no keys set", the same as an absent file.
- configfile: reject an empty site list. Every per-site phase iterates it, so
  `sites:` or `sites: []` silently skipped installing, updating and exporting
  for all sites while still opening a merge request.
- drupal: ConfigureDatabase is called twice per site (baseline install, then
  before the update hooks) against the same settings.php now that old and new
  code share one working directory, appending the database, hash_salt and
  private-path settings twice. Marked and made idempotent.
- repo: IsSomethingStagedInPath matched with strings.Contains, so dir
  "translations" also matched "translations-backup/de.po".
- cmd: --repository-url rejected SCP-style git URLs that the provider factory
  and clone both accept; validate against parseGitURL instead.
- drupalorg: check the HTTP status before decoding, so a 404 or an outage does
  not surface as an opaque JSON decode failure.

Cleanups: propagate the errors NewCache, NewLogger and prepareCheckout were
dropping; drop the unused config field from CodeBeautifier, DeprecationsRemover
and addonDeps; report rather than discard the composer diff error that only
feeds the log; clean up the composer patch-test scratch directory on exit;
return nil instead of a known-nil err; pointer receiver on Github.
CreateMergeRequest for consistency.

Extracted resolveToken, configFilePath, loadProjectConfig and
resolveCheckoutSettings out of RunE so the decision logic is testable.

Coverage for the changed packages: internal 97.0%, composer 96.7%,
codehosting 95.6%, drupalorg 94.7%, services 90.6%, drupal 90.6%, addon 90.5%,
repo 90.0%. cmd is at 68.8% (up from 50.3%) — the remainder is the composition
root, which wires and runs composer/drush and cannot be unit tested.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KT4Kg5jrjBNqMd7gzRWzos