### PR TITLE
fix: use GOMAXPROCS(0) for site concurrency, add --concurrency override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Config is split into two tiers, with no overlap:
 | `--clone` | false | Clone instead of using the checkout (needs `--repository-url`); for testing |
 | `--repository-url` | _(from `origin`)_ | Repo URL; required with `--clone`, else read from `origin` |
 | `--security` | false | Only apply security updates; selects the `addons.security` list |
+| `--concurrency` | `GOMAXPROCS(0)` | Max concurrent per-site work in `forEachSite`; describes the machine, not the project, so it's a flag rather than a `.drupdater.yaml` key |
 | `--dry-run` | false | Skip branch creation and MR |
 | `--verbose` | false | Debug-level structured logging |
 | `--config` | _(`<working-dir>/.drupdater.yaml`)_ | Path to the config file |

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ All flags are optional; pass them after the required `<token>`.
 | `--clone` | `false` | Clone instead of using the checkout. Requires `--repository-url`. For local testing. |
 | `--repository-url` | _(from `origin`)_ | Repo URL. Required with `--clone`; otherwise read from the `origin` remote. |
 | `--security` | `false` | Update only packages with known vulnerabilities. Selects the `addons.security` list. |
+| `--concurrency` | `GOMAXPROCS(0)` | Maximum number of sites to install/update concurrently. Site installs are as much I/O-bound as CPU-bound, so raise or lower this from the CPU-derived default to match the runner (constrained runner, slow disk, or fast NVMe with many small sites). |
 | `--dry-run` | `false` | Run everything but skip branch and PR/MR creation. |
 | `--verbose` | `false` | Debug-level logging (also logs resolved config). |
 | `--config` | _(`<working-dir>/.drupdater.yaml`)_ | Path to the config file. |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"syscall"
@@ -409,6 +410,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&config.DryRun, "dry-run", false, "Dry run. If true, no branch and merge request will be created.")
 	rootCmd.PersistentFlags().BoolVar(&config.Verbose, "verbose", false, "Verbose")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Path to the config file (default: <working-dir>/.drupdater.yaml).")
+	rootCmd.PersistentFlags().IntVar(&config.Concurrency, "concurrency", runtime.GOMAXPROCS(0), "Maximum number of sites to install/update concurrently. Defaults to GOMAXPROCS(0), which reflects the container's CPU quota, not just the host's core count.")
 
 	rootCmd.AddCommand(addonsCmd)
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -14,6 +14,10 @@ type Config struct {
 	Verbose       bool
 	Timeout       time.Duration
 	Addons        AddonsConfig
+	// Concurrency bounds how many sites are installed/updated at once. It describes the
+	// machine the run happens on, not the project, so it's a CLI flag rather than a
+	// .drupdater.yaml key. A value <= 0 means "use GOMAXPROCS(0)".
+	Concurrency int
 }
 
 // AddonsConfig lists which configurable addons run in each mode. Mandatory addons

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -145,11 +145,16 @@ func (ws *WorkflowBaseService) acquireWorkingCopy(username, email string) (GitRe
 	return ws.repository.OpenRepository(ws.config.WorkingDir, username, email)
 }
 
-// forEachSite runs fn for every configured site concurrently, bounded to the CPU count, and
-// cancels the rest on the first error.
+// forEachSite runs fn for every configured site concurrently, bounded by config.Concurrency
+// (or GOMAXPROCS(0), which reflects the container's CPU quota, when unset), and cancels the
+// rest on the first error.
 func (ws *WorkflowBaseService) forEachSite(ctx context.Context, fn func(context.Context, string) error) error {
 	g, groupCtx := errgroup.WithContext(ctx)
-	g.SetLimit(runtime.NumCPU())
+	limit := ws.config.Concurrency
+	if limit <= 0 {
+		limit = runtime.GOMAXPROCS(0)
+	}
+	g.SetLimit(limit)
 	for _, site := range ws.config.Sites {
 		g.Go(func() error {
 			return fn(groupCtx, site)

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -999,6 +1000,59 @@ func TestStartUpdateWorkBranchCheckoutError(t *testing.T) {
 	require.ErrorIs(t, err, checkoutErr)
 	require.ErrorContains(t, err, "failed to create work branch")
 	repository.AssertNotCalled(t, "Push", mock.Anything)
+}
+
+func TestForEachSite(t *testing.T) {
+	logger := zap.NewNop()
+	sites := []string{"site1", "site2", "site3", "site4"}
+
+	t.Run("bounds concurrency to config.Concurrency", func(t *testing.T) {
+		ws := &WorkflowBaseService{logger: logger, config: internal.Config{Sites: sites, Concurrency: 1}}
+
+		var current, peak atomic.Int32
+		err := ws.forEachSite(context.Background(), func(_ context.Context, _ string) error {
+			n := current.Add(1)
+			defer current.Add(-1)
+			for {
+				m := peak.Load()
+				if n <= m || peak.CompareAndSwap(m, n) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, peak.Load())
+	})
+
+	t.Run("falls back to GOMAXPROCS(0) when Concurrency is unset", func(t *testing.T) {
+		ws := &WorkflowBaseService{logger: logger, config: internal.Config{Sites: sites}}
+
+		var calls atomic.Int32
+		err := ws.forEachSite(context.Background(), func(_ context.Context, _ string) error {
+			calls.Add(1)
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.EqualValues(t, len(sites), calls.Load())
+	})
+
+	t.Run("propagates the first error and cancels the rest", func(t *testing.T) {
+		ws := &WorkflowBaseService{logger: logger, config: internal.Config{Sites: sites, Concurrency: 2}}
+		boom := errors.New("boom")
+
+		err := ws.forEachSite(context.Background(), func(_ context.Context, site string) error {
+			if site == "site1" {
+				return boom
+			}
+			return nil
+		})
+
+		require.ErrorIs(t, err, boom)
+	})
 }
 
 func TestCleanup(t *testing.T) {


### PR DESCRIPTION
runtime.NumCPU() ignores cgroup CPU quotas (only cgroup CPU sets), so a
container limited to e.g. 2 CPUs on a 32-core host would still fan out
site installs to 32 concurrent workers, causing thrashing and possible
CI timeouts/OOM kills. GOMAXPROCS(0) reflects the container's actual
CPU budget since Go derives it from the cgroup quota when set.

Also add an explicit --concurrency flag, since site installs are as
much I/O-bound as CPU-bound and users may want to tune it independently
of the CPU-derived default.

Fixes #170

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RyNynQ28YrLeVLfJcF5guz