### PR TITLE
Redact credentials from log output (#169)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -78,7 +79,8 @@ names you can set there. See the README for the full file format.`,
 		// as soon as each becomes known so nothing is logged unredacted in between; never
 		// logged itself, including at debug level with --verbose.
 		redactor := logging.NewRedactor()
-		redactor.Register(os.Getenv("DRUPALCODE_ACCESS_TOKEN"), os.Getenv("COMPOSER_AUTH"))
+		redactor.Register(os.Getenv("DRUPALCODE_ACCESS_TOKEN"))
+		registerComposerAuth(redactor, os.Getenv("COMPOSER_AUTH"))
 
 		// Initialize the logger first so config errors are reported (errors are silenced by Cobra).
 		logger, err := NewLogger(config, redactor)
@@ -171,6 +173,46 @@ func resolveToken(args []string) (string, error) {
 		return token, nil
 	}
 	return "", errors.New("no token provided: pass it as the argument or set DRUPDATER_TOKEN")
+}
+
+// registerComposerAuth registers the credentials carried by a COMPOSER_AUTH env value with the
+// redactor. COMPOSER_AUTH is a JSON object (http-basic/bearer/gitlab-token/github-oauth/... per
+// host, see the Composer docs) and Composer echoes the individual username, password, or token
+// value it contains — typically embedded in a URL after a failed authenticated fetch — not the
+// blob itself, so registering only the raw string would never match that output. Every string
+// leaf of the parsed JSON is registered individually; the raw value is registered too, as a
+// fallback for a value that fails to parse as JSON.
+func registerComposerAuth(redactor *logging.Redactor, composerAuth string) {
+	redactor.Register(composerAuth)
+
+	var parsed any
+	if err := json.Unmarshal([]byte(composerAuth), &parsed); err != nil {
+		return
+	}
+	redactor.Register(jsonStringLeaves(parsed)...)
+}
+
+// jsonStringLeaves returns every string value found anywhere in a decoded JSON structure
+// (as produced by json.Unmarshal into `any`), recursing through nested objects and arrays.
+func jsonStringLeaves(v any) []string {
+	switch t := v.(type) {
+	case string:
+		return []string{t}
+	case map[string]any:
+		leaves := make([]string, 0, len(t))
+		for _, val := range t {
+			leaves = append(leaves, jsonStringLeaves(val)...)
+		}
+		return leaves
+	case []any:
+		leaves := make([]string, 0, len(t))
+		for _, val := range t {
+			leaves = append(leaves, jsonStringLeaves(val)...)
+		}
+		return leaves
+	default:
+		return nil
+	}
 }
 
 // configFilePath returns the .drupdater.yaml to read: --config when set, otherwise the one in

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/addon"
 	"github.com/drupdater/drupdater/internal/codehosting"
+	"github.com/drupdater/drupdater/internal/logging"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/drupdater/drupdater/pkg/drupal"
@@ -72,8 +73,15 @@ names you can set there. See the README for the full file format.`,
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 
+		// Values subprocesses (Composer, Drush, git) can echo back in their own output — most
+		// often a credential embedded in a URL after a failed authenticated fetch. Registered
+		// as soon as each becomes known so nothing is logged unredacted in between; never
+		// logged itself, including at debug level with --verbose.
+		redactor := logging.NewRedactor()
+		redactor.Register(os.Getenv("DRUPALCODE_ACCESS_TOKEN"), os.Getenv("COMPOSER_AUTH"))
+
 		// Initialize the logger first so config errors are reported (errors are silenced by Cobra).
-		logger, err := NewLogger(config)
+		logger, err := NewLogger(config, redactor)
 		if err != nil {
 			// No logger yet, so this one report has to go straight to stderr.
 			fmt.Fprintln(cmd.ErrOrStderr(), "failed to initialize logger:", err)
@@ -85,6 +93,7 @@ names you can set there. See the README for the full file format.`,
 			logger.Error("missing token", zap.Error(err))
 			return err
 		}
+		redactor.Register(config.Token)
 
 		// Load per-project config from .drupdater.yaml (sites, timeout, addons). A missing file
 		// falls back to built-in defaults.
@@ -429,7 +438,7 @@ func NewCache() (otter.Cache[string, string], error) {
 	return otter.MustBuilder[string, string](100).Build()
 }
 
-func NewLogger(config internal.Config) (*zap.Logger, error) {
+func NewLogger(config internal.Config, redactor *logging.Redactor) (*zap.Logger, error) {
 	loggerConfig := zap.NewDevelopmentConfig()
 	loggerConfig.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 
@@ -438,5 +447,5 @@ func NewLogger(config internal.Config) (*zap.Logger, error) {
 		loggerConfig.DisableCaller = true
 		loggerConfig.DisableStacktrace = true
 	}
-	return loggerConfig.Build(zap.AddStacktrace(zapcore.ErrorLevel))
+	return loggerConfig.Build(zap.AddStacktrace(zapcore.ErrorLevel), zap.WrapCore(logging.WrapCore(redactor)))
 }

--- a/cmd/root_extra_test.go
+++ b/cmd/root_extra_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/logging"
 	"github.com/drupdater/drupdater/pkg/repo"
 	git "github.com/go-git/go-git/v5"
 	gitConfig "github.com/go-git/go-git/v5/config"
@@ -52,6 +53,52 @@ func TestResolveToken(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "DRUPDATER_TOKEN")
 	})
+}
+
+func TestRegisterComposerAuth(t *testing.T) {
+	// registerComposerAuth must register the individual credentials inside COMPOSER_AUTH, not
+	// just the raw JSON blob: Composer echoes the username/password/token itself (typically
+	// embedded in a URL after a failed authenticated fetch), never the blob verbatim.
+	redact := func(t *testing.T, redactor *logging.Redactor, msg string) string {
+		t.Helper()
+		core, logs := observer.New(zap.DebugLevel)
+		logger := zap.New(logging.WrapCore(redactor)(core))
+		logger.Info(msg)
+		return logs.All()[0].Message
+	}
+
+	t.Run("registers individual leaf values from valid JSON", func(t *testing.T) {
+		redactor := logging.NewRedactor()
+		registerComposerAuth(redactor, `{"http-basic":{"repo.packagist.com":{"username":"du","password":"s3cr3t-pass"}}}`)
+
+		got := redact(t, redactor, "fetch failed: https://du:s3cr3t-pass@repo.packagist.com/p2/foo.json: 403")
+		assert.NotContains(t, got, "s3cr3t-pass")
+	})
+
+	t.Run("falls back to redacting the raw value when it is not valid JSON", func(t *testing.T) {
+		redactor := logging.NewRedactor()
+		registerComposerAuth(redactor, "not-json-token")
+
+		got := redact(t, redactor, "leaked not-json-token here")
+		assert.NotContains(t, got, "not-json-token")
+	})
+
+	t.Run("empty value is a no-op", func(t *testing.T) {
+		redactor := logging.NewRedactor()
+		registerComposerAuth(redactor, "")
+
+		got := redact(t, redactor, "hello world")
+		assert.Equal(t, "hello world", got)
+	})
+}
+
+func TestJSONStringLeaves(t *testing.T) {
+	leaves := jsonStringLeaves(map[string]any{
+		"a": "1",
+		"b": map[string]any{"c": "2", "d": []any{"3", "4"}},
+		"e": 5.0,
+	})
+	assert.ElementsMatch(t, []string{"1", "2", "3", "4"}, leaves)
 }
 
 func TestConfigFilePath(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/logging"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/repo"
 	git "github.com/go-git/go-git/v5"
@@ -26,7 +27,7 @@ func TestNewLogger(t *testing.T) {
 		}
 
 		// Create logger
-		logger, err := NewLogger(config)
+		logger, err := NewLogger(config, logging.NewRedactor())
 
 		// Assert logger is in debug mode
 		require.NoError(t, err)
@@ -41,7 +42,7 @@ func TestNewLogger(t *testing.T) {
 		}
 
 		// Create logger
-		logger, err := NewLogger(config)
+		logger, err := NewLogger(config, logging.NewRedactor())
 
 		// Assert logger is not in debug mode but is in info mode
 		require.NoError(t, err)
@@ -49,6 +50,7 @@ func TestNewLogger(t *testing.T) {
 		assert.False(t, logger.Core().Enabled(zapcore.DebugLevel))
 		assert.True(t, logger.Core().Enabled(zapcore.InfoLevel))
 	})
+
 }
 
 func TestNewCache(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -50,7 +50,6 @@ func TestNewLogger(t *testing.T) {
 		assert.False(t, logger.Core().Enabled(zapcore.DebugLevel))
 		assert.True(t, logger.Core().Enabled(zapcore.InfoLevel))
 	})
-
 }
 
 func TestNewCache(t *testing.T) {

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -1,0 +1,158 @@
+// Package logging provides a zapcore.Core wrapper that redacts known secret values (access
+// tokens, Composer auth credentials) from log output before it reaches any sink. Subprocesses
+// drupdater shells out to (Composer, Drush, git) can echo those values in their own output, most
+// often in a URL when an authenticated fetch fails; wrapping the logger means every call site is
+// covered without having to remember to sanitize each one individually.
+package logging
+
+import (
+	"errors"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+
+	"go.uber.org/zap/zapcore"
+)
+
+// placeholder replaces every registered secret value wherever it appears in log output.
+const placeholder = "***"
+
+// Redactor holds the exact secret values that must never appear in log output. Redaction is
+// value-based, not pattern-based: matching "things that look like a token" both misses unusual
+// formats and mangles innocent output, whereas the exact secret values are known at startup.
+// Safe for concurrent use.
+type Redactor struct {
+	mu       sync.RWMutex
+	secrets  map[string]struct{}
+	replacer *strings.Replacer
+}
+
+// NewRedactor returns an empty Redactor. Register secret values as soon as they are known so
+// nothing is logged unredacted in between.
+func NewRedactor() *Redactor {
+	return &Redactor{secrets: map[string]struct{}{}}
+}
+
+// Register adds values that must be redacted from all subsequent log output. Empty strings are
+// ignored, since redacting "" would replace every character in every log line. Each value's
+// URL-percent-encoded form is registered alongside it: a token embedded in a URL (e.g. a
+// Composer repository URL) may appear encoded rather than literal.
+func (r *Redactor) Register(values ...string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	changed := false
+	add := func(v string) {
+		if v == "" {
+			return
+		}
+		if _, ok := r.secrets[v]; !ok {
+			r.secrets[v] = struct{}{}
+			changed = true
+		}
+	}
+	for _, v := range values {
+		add(v)
+		add(url.QueryEscape(v))
+	}
+	if changed {
+		r.replacer = nil // rebuilt lazily by redact on next use
+	}
+}
+
+// redact replaces every registered secret value in s with the placeholder.
+func (r *Redactor) redact(s string) string {
+	replacer := r.currentReplacer()
+	if replacer == nil {
+		return s
+	}
+	return replacer.Replace(s)
+}
+
+func (r *Redactor) currentReplacer() *strings.Replacer {
+	r.mu.RLock()
+	replacer := r.replacer
+	empty := len(r.secrets) == 0
+	r.mu.RUnlock()
+	if replacer != nil || empty {
+		return replacer
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.replacer != nil {
+		return r.replacer
+	}
+	if len(r.secrets) == 0 {
+		return nil
+	}
+
+	values := make([]string, 0, len(r.secrets))
+	for v := range r.secrets {
+		values = append(values, v)
+	}
+	// Longest first, so a secret that happens to be a substring of another registered value
+	// is still matched in full rather than being partially consumed by the shorter one.
+	sort.Slice(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
+
+	pairs := make([]string, 0, len(values)*2)
+	for _, v := range values {
+		pairs = append(pairs, v, placeholder)
+	}
+	r.replacer = strings.NewReplacer(pairs...)
+	return r.replacer
+}
+
+// core wraps another zapcore.Core, rewriting the log message and any string/error field through
+// the Redactor before handing the entry on. It never logs the secret set itself.
+type core struct {
+	zapcore.Core
+	redactor *Redactor
+}
+
+// WrapCore returns a zap.Option-compatible constructor that wraps a logger's core with
+// redaction using r. Pass it to zap.WrapCore (or Config.Build) so every entry the logger emits,
+// at every level including Debug, is filtered before it reaches its sink.
+func WrapCore(r *Redactor) func(zapcore.Core) zapcore.Core {
+	return func(c zapcore.Core) zapcore.Core {
+		return &core{Core: c, redactor: r}
+	}
+}
+
+func (c *core) With(fields []zapcore.Field) zapcore.Core {
+	return &core{Core: c.Core.With(c.redactFields(fields)), redactor: c.redactor}
+}
+
+func (c *core) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return ce.AddCore(entry, c)
+	}
+	return ce
+}
+
+func (c *core) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	entry.Message = c.redactor.redact(entry.Message)
+	return c.Core.Write(entry, c.redactFields(fields))
+}
+
+// redactFields returns a copy of fields with string and error values passed through the
+// redactor.
+func (c *core) redactFields(fields []zapcore.Field) []zapcore.Field {
+	out := make([]zapcore.Field, len(fields))
+	for i, f := range fields {
+		switch f.Type {
+		case zapcore.StringType:
+			f.String = c.redactor.redact(f.String)
+		case zapcore.ErrorType:
+			if err, ok := f.Interface.(error); ok {
+				f.Interface = errors.New(c.redactor.redact(err.Error()))
+			}
+		default:
+			// Other kinds (numbers, durations, zap.Any/zap.Strings, ...) are passed through
+			// unchanged: no call site in this codebase puts subprocess output into those.
+		}
+		out[i] = f
+	}
+	return out
+}

--- a/internal/logging/redact_test.go
+++ b/internal/logging/redact_test.go
@@ -1,0 +1,132 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// newTestLogger builds a zap.Logger writing JSON lines into buf, with its core wrapped by r,
+// mirroring how NewLogger wires the redactor into the real logger.
+func newTestLogger(buf *bytes.Buffer, r *Redactor) *zap.Logger {
+	encoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	base := zapcore.NewCore(encoder, zapcore.AddSync(buf), zapcore.DebugLevel)
+	return zap.New(WrapCore(r)(base))
+}
+
+func TestRedactorRedactsSecretsFromLogOutput(t *testing.T) {
+	const token = "gh_super_secret_token"
+
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	redactor.Register(token)
+	logger := newTestLogger(&buf, redactor)
+
+	logger.Debug("composer clone failed: " + fmt.Sprintf("https://%s@example.com/repo.git: 403", token))
+
+	out := buf.String()
+	assert.NotContains(t, out, token)
+	assert.Contains(t, out, "***")
+}
+
+func TestRedactorRedactsPercentEncodedForm(t *testing.T) {
+	const token = "a b+c/d"
+
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	redactor.Register(token)
+	logger := newTestLogger(&buf, redactor)
+
+	encoded := url.QueryEscape(token)
+	require.NotEqual(t, token, encoded)
+
+	logger.Info("fetch failed for https://example.com/repo.git?token=" + encoded)
+
+	out := buf.String()
+	assert.NotContains(t, out, token)
+	assert.NotContains(t, out, encoded)
+}
+
+func TestRedactorRedactsStringFields(t *testing.T) {
+	const token = "field-secret"
+
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	redactor.Register(token)
+	logger := newTestLogger(&buf, redactor)
+
+	logger.Info("command output", zap.String("output", "auth failed with token "+token))
+
+	out := buf.String()
+	assert.NotContains(t, out, token)
+}
+
+func TestRedactorRedactsErrorFields(t *testing.T) {
+	const token = "err-secret"
+
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	redactor.Register(token)
+	logger := newTestLogger(&buf, redactor)
+
+	err := fmt.Errorf("composer update failed: %w", fmt.Errorf("401 for https://%s@example.com", token))
+	logger.Error("update failed", zap.Error(err))
+
+	out := buf.String()
+	assert.NotContains(t, out, token)
+}
+
+func TestRedactorRedactsFieldsAddedWithWith(t *testing.T) {
+	const token = "with-secret"
+
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	redactor.Register(token)
+	logger := newTestLogger(&buf, redactor).With(zap.String("output", "leaked "+token))
+
+	logger.Info("done")
+
+	out := buf.String()
+	assert.NotContains(t, out, token)
+}
+
+func TestRedactorIgnoresEmptyValues(t *testing.T) {
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	redactor.Register("")
+	logger := newTestLogger(&buf, redactor)
+
+	logger.Info("hello world")
+
+	out := buf.String()
+	assert.NotContains(t, out, "***")
+	assert.Contains(t, out, "hello world")
+}
+
+func TestRedactorLongestSecretWinsOverSubstring(t *testing.T) {
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	redactor.Register("secret")
+	redactor.Register("secret-extended")
+	logger := newTestLogger(&buf, redactor)
+
+	logger.Info("value: secret-extended")
+
+	out := buf.String()
+	assert.NotContains(t, out, "secret-extended")
+	assert.NotContains(t, out, "secret")
+}
+
+func TestCoreSyncDelegates(t *testing.T) {
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	logger := newTestLogger(&buf, redactor)
+
+	require.NoError(t, logger.Sync())
+}


### PR DESCRIPTION
Composer, Drush, and git can echo authenticated URLs or auth material in
their own output, and that output flows straight into the logger. In CI
that lands in a retained, often widely-readable job log, so a failed
authenticated fetch could leak a push-capable token.

Add internal/logging.Redactor, a zapcore.Core wrapper that replaces
registered secret values (and their URL-percent-encoded form) with a fixed
placeholder in the log message and any string/error field, before the
entry reaches its sink. Wire it into cmd/root.go's logger construction and
register config.Token, DRUPALCODE_ACCESS_TOKEN, and COMPOSER_AUTH as soon
as each becomes known, so it covers every subprocess call site without
requiring changes at each one.