### PR TITLE
Require the access token only when a VCS operation actually happens

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ docker run ghcr.io/drupdater/drupdater-php8.3:latest \
 - `--clone --repository-url` — tells Drupdater to fetch the repo itself. In CI you
   omit these; it uses the checkout already on disk (see below).
 
-Add `--dry-run` to do everything except create the branch and PR/MR.
+Add `--dry-run` to do everything except create the branch and PR/MR. In
+checkout mode (no `--clone`), a `--dry-run` run touches the VCS platform for
+neither reading nor writing, so it needs no token at all — omit `<token>` and
+leave `DRUPDATER_TOKEN` unset.
 
 ## Prerequisites
 
@@ -163,7 +166,10 @@ the cron to `"0 4 * * *"`, and append `--security` to the run command.
 
 ## Tokens & Permissions
 
-Drupdater needs a token that can **push branches** and **open PRs/MRs**.
+Drupdater needs a token that can **push branches** and **open PRs/MRs** —
+except a checkout-mode `--dry-run` run, which does neither and needs no token
+at all. `--clone` always needs one, dry run or not, since cloning may itself
+require authentication.
 
 | Platform | Token | Notes |
 |----------|-------|-------|
@@ -177,7 +183,9 @@ Configuration is split in two: **CLI flags** (how a run is invoked) and
 
 ### CLI flags
 
-All flags are optional; pass them after the required `<token>`.
+All flags are optional; pass them after `<token>`, which is itself only
+required for a run that clones or pushes/opens a PR/MR (see
+[Tokens & Permissions](#tokens--permissions)).
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -187,7 +195,7 @@ All flags are optional; pass them after the required `<token>`.
 | `--repository-url` | _(from `origin`)_ | Repo URL. Required with `--clone`; otherwise read from the `origin` remote. |
 | `--security` | `false` | Update only packages with known vulnerabilities. Selects the `addons.security` list. |
 | `--concurrency` | `GOMAXPROCS(0)` | Maximum number of sites to install/update concurrently. Site installs are as much I/O-bound as CPU-bound, so raise or lower this from the CPU-derived default to match the runner (constrained runner, slow disk, or fast NVMe with many small sites). |
-| `--dry-run` | `false` | Run everything but skip branch and PR/MR creation. |
+| `--dry-run` | `false` | Run everything but skip pushing the branch and creating the PR/MR (the branch and commits are still created locally). In checkout mode this also means no token is required. |
 | `--verbose` | `false` | Debug-level logging (also logs resolved config). |
 | `--config` | _(`<working-dir>/.drupdater.yaml`)_ | Path to the config file. |
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,7 +90,7 @@ names you can set there. See the README for the full file format.`,
 			return err
 		}
 
-		config.Token, err = resolveToken(args)
+		config.Token, err = resolveToken(args, config)
 		if err != nil {
 			logger.Error("missing token", zap.Error(err))
 			return err
@@ -133,11 +133,18 @@ names you can set there. See the README for the full file format.`,
 			ensureGitSafeDirectory(cmd.Context(), logger, config.WorkingDir)
 		}
 
-		vcsProviderFactory := codehosting.NewDefaultVcsProviderFactory()
-		platform, err := vcsProviderFactory.Create(config.RepositoryURL, config.Token, logger)
-		if err != nil {
-			logger.Error("failed to create VCS provider", zap.Error(err))
-			return err
+		// Only construct the VCS platform when a run will actually use it: cloning (may be
+		// authenticated) or publishing (pushing + creating the MR, i.e. anything without
+		// --dry-run). A checkout-mode --dry-run run does neither, so it needs no VCS client and
+		// no token — see tokenRequired.
+		var platform codehosting.Platform
+		if tokenRequired(config) {
+			vcsProviderFactory := codehosting.NewDefaultVcsProviderFactory()
+			platform, err = vcsProviderFactory.Create(config.RepositoryURL, config.Token, logger)
+			if err != nil {
+				logger.Error("failed to create VCS provider", zap.Error(err))
+				return err
+			}
 		}
 
 		// Create the event dispatcher and register addons as subscribers
@@ -165,14 +172,29 @@ names you can set there. See the README for the full file format.`,
 // resolveToken returns the access token: the positional argument when one is given, otherwise
 // DRUPDATER_TOKEN. The environment variable is the preferred form because it keeps the token
 // out of the process list and the shell history.
-func resolveToken(args []string) (string, error) {
+//
+// The token is only mandatory when the run will use it — see tokenRequired. A checkout-mode
+// --dry-run run pushes nothing and creates no MR, so it can proceed with no token and no
+// DRUPDATER_TOKEN set at all.
+func resolveToken(args []string, cfg internal.Config) (string, error) {
+	var token string
 	if len(args) == 1 && args[0] != "" {
-		return args[0], nil
+		token = args[0]
+	} else {
+		token = os.Getenv("DRUPDATER_TOKEN")
 	}
-	if token := os.Getenv("DRUPDATER_TOKEN"); token != "" {
-		return token, nil
+	if token == "" && tokenRequired(cfg) {
+		return "", errors.New("no token provided: pass it as the argument or set DRUPDATER_TOKEN")
 	}
-	return "", errors.New("no token provided: pass it as the argument or set DRUPDATER_TOKEN")
+	return token, nil
+}
+
+// tokenRequired reports whether this run performs an operation that needs VCS credentials:
+// cloning (--clone, which may be authenticated) or publishing (pushing the update branch and
+// creating the merge/pull request — i.e. any run without --dry-run). A checkout-mode --dry-run
+// run does neither.
+func tokenRequired(cfg internal.Config) bool {
+	return cfg.Clone || !cfg.DryRun
 }
 
 // registerComposerAuth registers the credentials carried by a COMPOSER_AUTH env value with the
@@ -458,7 +480,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&config.Clone, "clone", false, "Clone the repository instead of using the existing checkout. Requires --repository-url. Intended for local testing.")
 	rootCmd.PersistentFlags().StringVar(&config.RepositoryURL, "repository-url", "", "Repository URL. Required with --clone; otherwise derived from the checkout's origin remote.")
 	rootCmd.PersistentFlags().BoolVar(&config.Security, "security", false, "Only security updates. If true, only security updates will be applied.")
-	rootCmd.PersistentFlags().BoolVar(&config.DryRun, "dry-run", false, "Dry run. If true, no branch and merge request will be created.")
+	rootCmd.PersistentFlags().BoolVar(&config.DryRun, "dry-run", false, "Do not push the update branch or create a merge request. The branch and commits are still created locally.")
 	rootCmd.PersistentFlags().BoolVar(&config.Verbose, "verbose", false, "Verbose")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Path to the config file (default: <working-dir>/.drupdater.yaml).")
 	rootCmd.PersistentFlags().IntVar(&config.Concurrency, "concurrency", runtime.GOMAXPROCS(0), "Maximum number of sites to install/update concurrently. Defaults to GOMAXPROCS(0), which reflects the container's CPU quota, not just the host's core count.")

--- a/cmd/root_extra_test.go
+++ b/cmd/root_extra_test.go
@@ -22,10 +22,13 @@ import (
 )
 
 func TestResolveToken(t *testing.T) {
+	// The zero-value config (no --clone, no --dry-run) requires a token, matching a normal run.
+	normalRun := internal.Config{}
+
 	t.Run("the positional argument wins", func(t *testing.T) {
 		t.Setenv("DRUPDATER_TOKEN", "from-env")
 
-		token, err := resolveToken([]string{"from-arg"})
+		token, err := resolveToken([]string{"from-arg"}, normalRun)
 		require.NoError(t, err)
 		assert.Equal(t, "from-arg", token)
 	})
@@ -33,7 +36,7 @@ func TestResolveToken(t *testing.T) {
 	t.Run("falls back to DRUPDATER_TOKEN", func(t *testing.T) {
 		t.Setenv("DRUPDATER_TOKEN", "from-env")
 
-		token, err := resolveToken(nil)
+		token, err := resolveToken(nil, normalRun)
 		require.NoError(t, err)
 		assert.Equal(t, "from-env", token)
 	})
@@ -41,7 +44,7 @@ func TestResolveToken(t *testing.T) {
 	t.Run("an empty argument falls back to the environment", func(t *testing.T) {
 		t.Setenv("DRUPDATER_TOKEN", "from-env")
 
-		token, err := resolveToken([]string{""})
+		token, err := resolveToken([]string{""}, normalRun)
 		require.NoError(t, err)
 		assert.Equal(t, "from-env", token)
 	})
@@ -49,9 +52,47 @@ func TestResolveToken(t *testing.T) {
 	t.Run("errors when neither is set", func(t *testing.T) {
 		t.Setenv("DRUPDATER_TOKEN", "")
 
-		_, err := resolveToken(nil)
+		_, err := resolveToken(nil, normalRun)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "DRUPDATER_TOKEN")
+	})
+
+	t.Run("a checkout-mode dry-run needs no token", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "")
+
+		token, err := resolveToken(nil, internal.Config{DryRun: true})
+		require.NoError(t, err)
+		assert.Empty(t, token)
+	})
+
+	t.Run("a checkout-mode dry-run still honors a given token", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "from-env")
+
+		token, err := resolveToken(nil, internal.Config{DryRun: true})
+		require.NoError(t, err)
+		assert.Equal(t, "from-env", token)
+	})
+
+	t.Run("--clone still requires a token even with --dry-run", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "")
+
+		_, err := resolveToken(nil, internal.Config{Clone: true, DryRun: true})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DRUPDATER_TOKEN")
+	})
+}
+
+func TestTokenRequired(t *testing.T) {
+	t.Run("a normal checkout run requires a token", func(t *testing.T) {
+		assert.True(t, tokenRequired(internal.Config{}))
+	})
+
+	t.Run("--clone requires a token even with --dry-run", func(t *testing.T) {
+		assert.True(t, tokenRequired(internal.Config{Clone: true, DryRun: true}))
+	})
+
+	t.Run("checkout mode with --dry-run needs no token", func(t *testing.T) {
+		assert.False(t, tokenRequired(internal.Config{DryRun: true}))
 	})
 }
 

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -80,7 +80,13 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 		defer cancel()
 	}
 
-	username, email := ws.platform.GetUser(ctx)
+	// platform is nil for a checkout-mode --dry-run run with no token (see cmd/root.go's
+	// tokenRequired): that run never pushes or creates an MR, so no VCS client was built and
+	// the checkout's own git identity (already configured locally, e.g. by CI) is used as-is.
+	var username, email string
+	if ws.platform != nil {
+		username, email = ws.platform.GetUser(ctx)
+	}
 
 	// Acquire a single working directory: the existing checkout (default, CI) or a fresh
 	// clone (--clone, for local testing). Old and new code live in this one directory

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -481,6 +481,63 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 	vcsProvider.AssertExpectations(t)
 }
 
+func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
+	// Regression for issue #167: a checkout-mode --dry-run run needs no token and therefore
+	// cmd/root.go builds no VCS platform for it. StartUpdate must not dereference a nil platform
+	// to get the commit identity; it proceeds with whatever identity the checkout already has.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		WorkingDir: "/checkout",
+		Branch:     "main",
+		Sites:      []string{"site1"},
+		DryRun:     true,
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil)
+
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil)
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
+
+	repositoryService.EXPECT().OpenRepository(config.WorkingDir, "", "").Return(repository, worktree, "/tmp", nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
+
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
+		{
+			Package: "drupal/core",
+			From:    "9.0.0",
+			To:      "9.1.0",
+		},
+	}, nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	// Execute: platform is nil, exactly as cmd/root.go leaves it for this configuration.
+	workflowService := NewWorkflowBaseService(logger, config, drush, nil, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(ctx, nil)
+
+	require.NoError(t, err)
+	installer.AssertExpectations(t)
+	repositoryService.AssertExpectations(t)
+	repository.AssertExpectations(t)
+	drush.AssertExpectations(t)
+	mockComposer.AssertExpectations(t)
+}
+
 func TestPublishWorkDeletesBranchOnMRFailure(t *testing.T) {
 	// When CreateMergeRequest fails, publishWork must delete the remote branch it just
 	// pushed so the remote is left clean for the next run.

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -133,8 +133,14 @@ func (rs *GitRepositoryService) prepareCheckout(checkout *git.Repository, userna
 	if err != nil {
 		return checkout, nil, "", fmt.Errorf("failed to read git config: %w", err)
 	}
-	config.User.Name = username
-	config.User.Email = email
+	// Empty values (no VCS platform to ask, e.g. a checkout-mode --dry-run run with no token)
+	// leave the checkout's existing commit identity in place instead of blanking it out.
+	if username != "" {
+		config.User.Name = username
+	}
+	if email != "" {
+		config.User.Email = email
+	}
 	if err := checkout.SetConfig(config); err != nil {
 		return checkout, nil, "", err
 	}

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -308,4 +308,29 @@ func TestOpenRepository(t *testing.T) {
 		_, _, _, err := service.OpenRepository(t.TempDir(), "Bot", "bot@example.com")
 		require.Error(t, err)
 	})
+
+	t.Run("empty identity preserves the checkout's existing commit identity", func(t *testing.T) {
+		// A checkout-mode --dry-run run with no token has no VCS platform to ask for the user's
+		// name and email (see cmd/root.go's tokenRequired), so it calls OpenRepository with
+		// empty strings. That must not blank out an identity the checkout already has configured
+		// (e.g. set up by CI) — it should be left alone.
+		dir := t.TempDir()
+		checkout, err := git.PlainInit(dir, false)
+		require.NoError(t, err)
+		cfg, err := checkout.Config()
+		require.NoError(t, err)
+		cfg.User.Name = "Existing User"
+		cfg.User.Email = "existing@example.com"
+		require.NoError(t, checkout.SetConfig(cfg))
+
+		_, _, _, err = service.OpenRepository(dir, "", "")
+		require.NoError(t, err)
+
+		r, err := git.PlainOpen(dir)
+		require.NoError(t, err)
+		cfgAfter, err := r.Config()
+		require.NoError(t, err)
+		assert.Equal(t, "Existing User", cfgAfter.User.Name)
+		assert.Equal(t, "existing@example.com", cfgAfter.User.Email)
+	})
 }


### PR DESCRIPTION
A checkout-mode --dry-run run never pushes or creates a merge/pull request,
so it shouldn't need push/PR credentials either. resolveToken now only
errors on a missing token when the run will clone or publish (push + open
an MR); cmd/root.go skips building the VCS platform for the same runs.
StartUpdate handles a nil platform by leaving the checkout's existing git
identity alone instead of asking a platform that was never built. Also
fixes the --dry-run flag help text, which undersold what dry-run actually
skips.

Fixes #167