### PR TITLE
Add a preflight `check` command (#168)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ The workflow in `workflow_base.go` operates on a **single working directory** (t
 
 The site databases are SQLite files written beside the working directory (`{dir}/../{site}.sqlite`); checkout-mode runs clean these up afterward. At the end (unless `--dry-run`), a merge/pull request is created with a generated description.
 
+### Preflight Checks (`cmd/check.go`, `internal/services/preflight.go`)
+
+`drupdater check` validates a project's prerequisites without running an update — no `composer update`, no branch, no MR. The cheap checks (`.drupdater.yaml`/addon names, git history depth, PHP platform requirements, each site's `settings.php`, VCS host/token) run by default; `--full` additionally clones the repo to a scratch directory (never the live working copy) and runs a real `composer install` + `drush site-install --existing-config` per site. `CheckGitHistoryComplete` and `CheckPlatformRequirements` in `preflight.go` are shared with `workflow_base.go`'s own fail-fast startup checks, so a shallow checkout is caught the same way in both a real run and `check`.
+
 ### Addon System (`internal/addon/`)
 
 Addons implement the `Addon` interface and subscribe to workflow events via `gookit/event`. They hook into pre/post composer update and pre/post site update events.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ leave `DRUPDATER_TOKEN` unset.
 - *(Optional)* A [Drupal.org GitLab access token](https://git.drupalcode.org)
   (`DRUPALCODE_ACCESS_TOKEN`) to enable patch management.
 
+Run `drupdater check` to validate these against a checkout before scheduling a
+real run — it fails fast on the first four instead of burning several minutes
+on `composer install` and a site install first:
+
+```bash
+docker run -v "$(pwd)":/app -w /app ghcr.io/drupdater/drupdater-php8.3:latest check
+```
+
+By default it only runs cheap, near-instant checks (config, git history,
+platform requirements, each site's `settings.php`). Add `--full` to also
+clone the repo and actually run `drush site-install --existing-config` per
+site — the definitive answer, at close to the cost of a real run. `check`
+never modifies your checkout and exits non-zero on any failure, so it can
+gate a pipeline too.
+
 ## CI/CD Integration
 
 In CI, Drupdater runs against the checkout — no `--clone` needed. The recommended
@@ -231,7 +246,8 @@ addons:               # configurable addons per mode (mandatory addons always ru
 
 | Symptom | Cause / Fix |
 |---------|-------------|
-| Push fails with `object not found` | Shallow checkout. Set `fetch-depth: 0` / `GIT_DEPTH: "0"`. |
+| Not sure why a run would fail | Run `drupdater check` (add `--full` for the definitive site-install check) before scheduling a real run. |
+| Push fails with `object not found` | Shallow checkout. Set `fetch-depth: 0` / `GIT_DEPTH: "0"`. `drupdater check` catches this upfront. |
 | PR is created but CI doesn't run on it (GitHub) | Expected with `GITHUB_TOKEN` — use a PAT or App token. See [Tokens & Permissions](#tokens--permissions). |
 | `composer install` fails on private packages | Provide `COMPOSER_AUTH` (see below). |
 | Site install fails | Confirm `drush site-install --existing-config` works locally first. |

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -68,14 +68,7 @@ Exits non-zero if any check fails, so it can gate a pipeline.`,
 		defer composerCLI.Cleanup()
 
 		ctx := cmd.Context()
-		var results []services.CheckResult
-		results = append(results, checkConfigAndAddons(configFilePath(configFile, cfg.WorkingDir), &cfg)...)
-		results = append(results, services.CheckGitHistoryComplete(gitSvc, cfg.WorkingDir))
-		results = append(results, services.CheckPlatformRequirements(ctx, composerCLI, cfg.WorkingDir))
-		for _, site := range cfg.Sites {
-			results = append(results, services.CheckSiteSettings(ctx, composerCLI, afero.NewOsFs(), cfg.WorkingDir, site))
-		}
-		results = append(results, checkVCS(ctx, logger, cfg.RepositoryURL, token, resolveErr)...)
+		results := runCheapChecks(ctx, logger, configFilePath(configFile, cfg.WorkingDir), &cfg, gitSvc, composerCLI, afero.NewOsFs(), token, resolveErr)
 
 		if checkFull {
 			results = append(results, runFullChecks(ctx, logger, cfg, token)...)
@@ -87,6 +80,41 @@ Exits non-zero if any check fails, so it can gate a pipeline.`,
 		}
 		return nil
 	},
+}
+
+// cheapChecksComposer is what runCheapChecks needs from Composer: the union of
+// services.PlatformReqsChecker and services.ComposerConfigGetter. Kept narrow (rather than
+// requiring the full services.Composer) so tests can supply a small fake instead of the whole
+// interface; the real *composer.CLI passed from RunE satisfies it as-is.
+type cheapChecksComposer interface {
+	services.PlatformReqsChecker
+	services.ComposerConfigGetter
+}
+
+// runCheapChecks runs every check that's free to compute: no composer install, no site install,
+// no network beyond one optional read-only VCS API call (see checkVCS). It's split out of RunE
+// so the orchestration and its branching can be unit tested against fakes, without needing the
+// real composer/drush/git binaries CI doesn't install.
+func runCheapChecks(
+	ctx context.Context,
+	logger *zap.Logger,
+	cfgFilePath string,
+	cfg *internal.Config,
+	repository services.ShallowCloneChecker,
+	composerSvc cheapChecksComposer,
+	fs afero.Fs,
+	token string,
+	resolveErr error,
+) []services.CheckResult {
+	var results []services.CheckResult
+	results = append(results, checkConfigAndAddons(cfgFilePath, cfg)...)
+	results = append(results, services.CheckGitHistoryComplete(repository, cfg.WorkingDir))
+	results = append(results, services.CheckPlatformRequirements(ctx, composerSvc, cfg.WorkingDir))
+	for _, site := range cfg.Sites {
+		results = append(results, services.CheckSiteSettings(ctx, composerSvc, fs, cfg.WorkingDir, site))
+	}
+	results = append(results, checkVCS(ctx, logger, cfg.RepositoryURL, token, resolveErr)...)
+	return results
 }
 
 // checkToken resolves the access token the same way the real run does (positional argument,

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/codehosting"
+	"github.com/drupdater/drupdater/internal/logging"
+	"github.com/drupdater/drupdater/internal/services"
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/drupdater/drupdater/pkg/drupal"
+	"github.com/drupdater/drupdater/pkg/drush"
+	"github.com/drupdater/drupdater/pkg/repo"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+// checkFull selects the --full tier of "drupdater check": on top of the free checks, it clones
+// the repository and runs composer install plus a real site install for each configured site,
+// proving the site actually installs from its exported configuration.
+var checkFull bool
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Validate prerequisites without running an update",
+	Long: `Validates the things a real run depends on, without running composer update, without
+creating a branch, and without opening a merge/pull request.
+
+By default only cheap, near-instant checks run: .drupdater.yaml and its addon names, git
+history, PHP platform requirements, each site's settings.php, and (if a token is given) that it
+authenticates. Pass --full to additionally clone the repository and prove each site installs
+from its exported configuration (drush site-install --existing-config) -- most of a real run's
+cost, so it stays opt-in.
+
+Exits non-zero if any check fails, so it can gate a pipeline.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
+		redactor := logging.NewRedactor()
+		logger, err := NewLogger(config, redactor)
+		if err != nil {
+			fmt.Fprintln(cmd.ErrOrStderr(), "failed to initialize logger:", err)
+			return err
+		}
+
+		// Unlike a real run, a token is never required here: it only sharpens one check (whether
+		// the given token authenticates to the VCS host) and its absence just skips that check.
+		token := checkToken(args)
+		redactor.Register(token)
+
+		cfg := config
+		gitSvc := repo.NewGitRepositoryService(logger)
+		var resolveErr error
+		if !cfg.Clone {
+			resolveErr = resolveCheckoutSettings(gitSvc, &cfg)
+		}
+
+		composerCLI := composer.NewCLI(logger)
+		defer composerCLI.Cleanup()
+
+		ctx := cmd.Context()
+		var results []services.CheckResult
+		results = append(results, checkConfigAndAddons(configFilePath(configFile, cfg.WorkingDir), &cfg)...)
+		results = append(results, services.CheckGitHistoryComplete(gitSvc, cfg.WorkingDir))
+		results = append(results, services.CheckPlatformRequirements(ctx, composerCLI, cfg.WorkingDir))
+		for _, site := range cfg.Sites {
+			results = append(results, services.CheckSiteSettings(ctx, composerCLI, afero.NewOsFs(), cfg.WorkingDir, site))
+		}
+		results = append(results, checkVCS(ctx, logger, cfg.RepositoryURL, token, resolveErr)...)
+
+		if checkFull {
+			results = append(results, runFullChecks(ctx, logger, cfg, token)...)
+		}
+
+		printCheckResults(cmd.OutOrStdout(), results)
+		if anyCheckFailed(results) {
+			return errors.New("preflight check failed")
+		}
+		return nil
+	},
+}
+
+// checkToken resolves the access token the same way the real run does (positional argument,
+// falling back to DRUPDATER_TOKEN), but never errors when neither is set: check works fine
+// without one, it just can't verify that a given token authenticates.
+func checkToken(args []string) string {
+	if len(args) == 1 && args[0] != "" {
+		return args[0]
+	}
+	return os.Getenv("DRUPDATER_TOKEN")
+}
+
+// checkConfigAndAddons validates .drupdater.yaml and, if it parses, the addon names it lists.
+// It also fills cfg.Sites (and the rest of the file config) for the checks that follow.
+func checkConfigAndAddons(path string, cfg *internal.Config) []services.CheckResult {
+	if _, err := internal.LoadConfigFile(path, cfg); err != nil {
+		return []services.CheckResult{{Name: ".drupdater.yaml valid", OK: false, Detail: err.Error()}}
+	}
+
+	results := []services.CheckResult{{
+		Name: fmt.Sprintf(".drupdater.yaml valid (sites: %s)", strings.Join(cfg.Sites, ", ")),
+		OK:   true,
+	}}
+
+	if err := validateAddons(*cfg); err != nil {
+		return append(results, services.CheckResult{Name: "addon names resolve", OK: false, Detail: err.Error()})
+	}
+	return append(results, services.CheckResult{Name: "addon names resolve", OK: true})
+}
+
+// checkVCS reports whether the repository URL routes to a known VCS provider (GitHub or
+// GitLab) and, when a token is given, whether it authenticates. resolveErr is the error (if
+// any) from deriving the repository URL out of the checkout, surfaced here since that's the
+// only check it would otherwise silently fail.
+func checkVCS(ctx context.Context, logger *zap.Logger, repositoryURL string, token string, resolveErr error) []services.CheckResult {
+	const name = "repository host recognized (GitHub/GitLab)"
+
+	if repositoryURL == "" {
+		detail := "could not determine repository URL (pass --repository-url or run inside a checkout with an origin remote)"
+		if resolveErr != nil {
+			detail = resolveErr.Error()
+		}
+		return []services.CheckResult{{Name: name, OK: false, Detail: detail}}
+	}
+	if err := codehosting.ValidateRepositoryURL(repositoryURL); err != nil {
+		return []services.CheckResult{{Name: name, OK: false, Detail: err.Error()}}
+	}
+
+	results := []services.CheckResult{{Name: name, OK: true}}
+	if token == "" {
+		return results
+	}
+
+	const tokenCheckName = "token authenticates"
+	platform, err := codehosting.NewDefaultVcsProviderFactory().Create(repositoryURL, token, logger)
+	if err != nil {
+		return append(results, services.CheckResult{Name: tokenCheckName, OK: false, Detail: err.Error()})
+	}
+	userName, email := platform.GetUser(ctx)
+	if userName == "" && email == "" {
+		return append(results, services.CheckResult{Name: tokenCheckName, OK: false, Detail: "did not authenticate, or lacks API access"})
+	}
+	return append(results, services.CheckResult{Name: tokenCheckName, OK: true})
+}
+
+// runFullChecks is the --full tier: it clones the repository to a scratch directory (never the
+// live working copy, so the check has no side effects on it) and proves each configured site
+// installs from its exported configuration.
+func runFullChecks(ctx context.Context, logger *zap.Logger, cfg internal.Config, token string) []services.CheckResult {
+	if cfg.RepositoryURL == "" {
+		return []services.CheckResult{{
+			Name: "sites install from configuration",
+			OK:   false,
+			Detail: "no repository URL to clone (pass --repository-url or run inside a checkout " +
+				"with an origin remote)",
+		}}
+	}
+	branch := cfg.Branch
+	if branch == "" {
+		branch = "main"
+	}
+
+	gitSvc := repo.NewGitRepositoryService(logger)
+	_, _, path, err := gitSvc.CloneRepository(cfg.RepositoryURL, branch, token, "", "")
+	if err != nil {
+		return []services.CheckResult{{Name: "clone for full check", OK: false, Detail: err.Error()}}
+	}
+	defer cleanupFullCheckArtifacts(path, cfg.Sites)
+
+	composerCLI := composer.NewCLI(logger)
+	defer composerCLI.Cleanup()
+
+	if err := composerCLI.Install(ctx, path); err != nil {
+		return []services.CheckResult{{Name: "composer install", OK: false, Detail: err.Error()}}
+	}
+	results := []services.CheckResult{{Name: "composer install", OK: true}}
+
+	cache, err := NewCache()
+	if err != nil {
+		return append(results, services.CheckResult{Name: "drush site-install --existing-config", OK: false, Detail: err.Error()})
+	}
+	installer := drupal.NewInstaller(logger, drush.NewCLI(logger, cache), composerCLI)
+
+	for _, site := range cfg.Sites {
+		name := fmt.Sprintf("site %q installs from configuration", site)
+		if err := installer.Install(ctx, path, site); err != nil {
+			results = append(results, services.CheckResult{Name: name, OK: false, Detail: err.Error()})
+			continue
+		}
+		results = append(results, services.CheckResult{Name: name, OK: true})
+	}
+	return results
+}
+
+// cleanupFullCheckArtifacts removes the clone and the SQLite databases/private files the site
+// installs wrote beside it, mirroring the real run's own clone-mode cleanup.
+func cleanupFullCheckArtifacts(path string, sites []string) {
+	defer os.RemoveAll(path)
+
+	parent := filepath.Dir(path)
+	for _, site := range sites {
+		os.Remove(filepath.Join(parent, site+".sqlite"))
+		os.RemoveAll(filepath.Join(parent, "private", site))
+	}
+	os.Remove(filepath.Join(parent, "private"))
+}
+
+func printCheckResults(w io.Writer, results []services.CheckResult) {
+	for _, r := range results {
+		mark := "✓"
+		if !r.OK {
+			mark = "✗"
+		}
+		if !r.OK && r.Detail != "" {
+			fmt.Fprintf(w, "%s %s: %s\n", mark, r.Name, r.Detail)
+			continue
+		}
+		fmt.Fprintf(w, "%s %s\n", mark, r.Name)
+	}
+}
+
+func anyCheckFailed(results []services.CheckResult) bool {
+	for _, r := range results {
+		if !r.OK {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	checkCmd.Flags().BoolVar(&checkFull, "full", false,
+		"Additionally clone the repository and verify each site installs from its exported "+
+			"configuration (drush site-install --existing-config). Expensive: most of a real run's cost.")
+	rootCmd.AddCommand(checkCmd)
+}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestCheckToken(t *testing.T) {
+	t.Run("the positional argument wins", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "from-env")
+		assert.Equal(t, "from-arg", checkToken([]string{"from-arg"}))
+	})
+
+	t.Run("falls back to DRUPDATER_TOKEN", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "from-env")
+		assert.Equal(t, "from-env", checkToken(nil))
+	})
+
+	t.Run("no token at all is not an error, just empty", func(t *testing.T) {
+		t.Setenv("DRUPDATER_TOKEN", "")
+		assert.Empty(t, checkToken(nil))
+	})
+}
+
+func TestCheckConfigAndAddons(t *testing.T) {
+	t.Run("a missing file applies the defaults and passes", func(t *testing.T) {
+		cfg := internal.Config{}
+		results := checkConfigAndAddons(filepath.Join(t.TempDir(), ".drupdater.yaml"), &cfg)
+
+		require.Len(t, results, 2)
+		assert.True(t, results[0].OK)
+		assert.Contains(t, results[0].Name, "sites: default")
+		assert.True(t, results[1].OK)
+		assert.Equal(t, "addon names resolve", results[1].Name)
+	})
+
+	t.Run("an invalid file stops at the first check", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".drupdater.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("timeout: nope\n"), 0o600))
+
+		cfg := internal.Config{}
+		results := checkConfigAndAddons(path, &cfg)
+
+		require.Len(t, results, 1)
+		assert.False(t, results[0].OK)
+		assert.Equal(t, ".drupdater.yaml valid", results[0].Name)
+	})
+
+	t.Run("an unknown addon name fails the second check only", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".drupdater.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("addons:\n  normal: [no_such_addon]\n"), 0o600))
+
+		cfg := internal.Config{}
+		results := checkConfigAndAddons(path, &cfg)
+
+		require.Len(t, results, 2)
+		assert.True(t, results[0].OK)
+		assert.False(t, results[1].OK)
+		assert.Contains(t, results[1].Detail, "no_such_addon")
+	})
+}
+
+func TestCheckVCS(t *testing.T) {
+	ctx := t.Context()
+	logger := zap.NewNop()
+
+	t.Run("no repository URL and no resolve error", func(t *testing.T) {
+		results := checkVCS(ctx, logger, "", "", nil)
+		require.Len(t, results, 1)
+		assert.False(t, results[0].OK)
+		assert.Contains(t, results[0].Detail, "could not determine repository URL")
+	})
+
+	t.Run("no repository URL surfaces the resolve error", func(t *testing.T) {
+		results := checkVCS(ctx, logger, "", "", errors.New("no origin remote"))
+		require.Len(t, results, 1)
+		assert.False(t, results[0].OK)
+		assert.Equal(t, "no origin remote", results[0].Detail)
+	})
+
+	t.Run("an unrecognized host fails", func(t *testing.T) {
+		results := checkVCS(ctx, logger, "not a url", "", nil)
+		require.Len(t, results, 1)
+		assert.False(t, results[0].OK)
+	})
+
+	t.Run("a recognized host with no token stops after the host check", func(t *testing.T) {
+		results := checkVCS(ctx, logger, "https://github.com/acme/site.git", "", nil)
+		require.Len(t, results, 1)
+		assert.True(t, results[0].OK)
+	})
+}
+
+func TestPrintCheckResults(t *testing.T) {
+	var buf bytes.Buffer
+	printCheckResults(&buf, []services.CheckResult{
+		{Name: "a", OK: true},
+		{Name: "b", OK: false, Detail: "went wrong"},
+		{Name: "c", OK: false},
+	})
+
+	out := buf.String()
+	assert.Contains(t, out, "✓ a\n")
+	assert.Contains(t, out, "✗ b: went wrong\n")
+	assert.Contains(t, out, "✗ c\n")
+}
+
+func TestAnyCheckFailed(t *testing.T) {
+	assert.False(t, anyCheckFailed([]services.CheckResult{{OK: true}, {OK: true}}))
+	assert.True(t, anyCheckFailed([]services.CheckResult{{OK: true}, {OK: false}}))
+	assert.False(t, anyCheckFailed(nil))
+}
+
+func TestCleanupFullCheckArtifacts(t *testing.T) {
+	parent := t.TempDir()
+	clone := filepath.Join(parent, "repo123")
+	require.NoError(t, os.MkdirAll(clone, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "default.sqlite"), []byte("x"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(parent, "private", "default"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "private", "default", "f.txt"), []byte("x"), 0o600))
+
+	cleanupFullCheckArtifacts(clone, []string{"default"})
+
+	assert.NoDirExists(t, clone)
+	assert.NoFileExists(t, filepath.Join(parent, "default.sqlite"))
+	assert.NoDirExists(t, filepath.Join(parent, "private", "default"))
+	// The private parent is removed too, since nothing else claims it.
+	assert.NoDirExists(t, filepath.Join(parent, "private"))
+}
+
+func TestCleanupFullCheckArtifactsKeepsUnrelatedPrivateData(t *testing.T) {
+	parent := t.TempDir()
+	clone := filepath.Join(parent, "repo123")
+	require.NoError(t, os.MkdirAll(clone, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(parent, "private", "default"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(parent, "private", "other-stuff"), 0o755))
+
+	cleanupFullCheckArtifacts(clone, []string{"default"})
+
+	assert.NoDirExists(t, filepath.Join(parent, "private", "default"))
+	// A non-empty "private" dir (something this run didn't create) must survive.
+	assert.DirExists(t, filepath.Join(parent, "private", "other-stuff"))
+}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/services"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -135,6 +137,115 @@ func TestCleanupFullCheckArtifacts(t *testing.T) {
 	assert.NoDirExists(t, filepath.Join(parent, "private", "default"))
 	// The private parent is removed too, since nothing else claims it.
 	assert.NoDirExists(t, filepath.Join(parent, "private"))
+}
+
+// fakeShallowCloneChecker and fakeCheapChecksComposer are minimal test doubles for the narrow
+// interfaces runCheapChecks depends on, so its branching can be exercised without the real
+// composer/drush/git binaries CI doesn't install.
+type fakeShallowCloneChecker struct {
+	shallow bool
+	err     error
+}
+
+func (f fakeShallowCloneChecker) IsShallowClone(string) (bool, error) { return f.shallow, f.err }
+
+type fakeCheapChecksComposer struct {
+	platformReqsOut string
+	platformReqsErr error
+	webRoot         string
+	webRootErr      error
+}
+
+func (f fakeCheapChecksComposer) CheckPlatformReqs(context.Context, string) (string, error) {
+	return f.platformReqsOut, f.platformReqsErr
+}
+
+func (f fakeCheapChecksComposer) GetConfig(context.Context, string, string) (string, error) {
+	return f.webRoot, f.webRootErr
+}
+
+func TestRunCheapChecks(t *testing.T) {
+	ctx := t.Context()
+	logger := zap.NewNop()
+
+	newFS := func(t *testing.T, workingDir string, sites ...string) afero.Fs {
+		t.Helper()
+		fs := afero.NewMemMapFs()
+		for _, site := range sites {
+			require.NoError(t, afero.WriteFile(fs, filepath.Join(workingDir, "web/sites", site, "settings.php"), []byte("<?php"), 0o644))
+		}
+		return fs
+	}
+
+	t.Run("everything passes", func(t *testing.T) {
+		cfg := &internal.Config{WorkingDir: "/project", RepositoryURL: "https://github.com/acme/site.git"}
+		repository := fakeShallowCloneChecker{shallow: false}
+		composerSvc := fakeCheapChecksComposer{webRoot: "web"}
+
+		results := runCheapChecks(ctx, logger, filepath.Join(t.TempDir(), ".drupdater.yaml"), cfg, repository, composerSvc, newFS(t, "/project", "default"), "", nil)
+
+		require.False(t, anyCheckFailed(results))
+		// config valid, addons resolve, git history, platform reqs, site settings, VCS host.
+		assert.Len(t, results, 6)
+	})
+
+	t.Run("a shallow clone and unmet platform reqs both surface as failures", func(t *testing.T) {
+		cfg := &internal.Config{WorkingDir: "/project", RepositoryURL: "https://github.com/acme/site.git"}
+		repository := fakeShallowCloneChecker{shallow: true}
+		composerSvc := fakeCheapChecksComposer{platformReqsOut: "php 8.1 required", platformReqsErr: errors.New("unmet")}
+
+		results := runCheapChecks(ctx, logger, filepath.Join(t.TempDir(), ".drupdater.yaml"), cfg, repository, composerSvc, newFS(t, "/project", "default"), "", nil)
+
+		require.True(t, anyCheckFailed(results))
+		var names []string
+		for _, r := range results {
+			if !r.OK {
+				names = append(names, r.Name)
+			}
+		}
+		assert.Contains(t, names, "git history complete (not a shallow clone)")
+		assert.Contains(t, names, "PHP platform requirements satisfied")
+	})
+
+	t.Run("one result per configured site", func(t *testing.T) {
+		// The sites list comes from the config file, not a pre-set cfg.Sites: runCheapChecks
+		// loads it via checkConfigAndAddons. Only "default" gets a settings.php; "extra" is
+		// missing.
+		cfgPath := filepath.Join(t.TempDir(), ".drupdater.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte("sites: [default, extra]\n"), 0o600))
+
+		cfg := &internal.Config{WorkingDir: "/project", RepositoryURL: "https://github.com/acme/site.git"}
+		repository := fakeShallowCloneChecker{}
+		composerSvc := fakeCheapChecksComposer{webRoot: "web"}
+
+		results := runCheapChecks(ctx, logger, cfgPath, cfg, repository, composerSvc, newFS(t, "/project", "default"), "", nil)
+
+		var siteFailures int
+		for _, r := range results {
+			if !r.OK && r.Name == `site "extra": settings.php` {
+				siteFailures++
+			}
+		}
+		assert.Equal(t, 1, siteFailures)
+	})
+}
+
+func TestRunFullChecksNoRepositoryURL(t *testing.T) {
+	results := runFullChecks(t.Context(), zap.NewNop(), internal.Config{}, "")
+	require.Len(t, results, 1)
+	assert.False(t, results[0].OK)
+	assert.Contains(t, results[0].Detail, "no repository URL to clone")
+}
+
+func TestRunFullChecksCloneFailure(t *testing.T) {
+	// A non-repository path as the "repository URL" fails fast in CloneRepository itself, so
+	// this exercises the clone-error branch without needing composer or drush at all.
+	cfg := internal.Config{RepositoryURL: t.TempDir(), Branch: "main"}
+
+	results := runFullChecks(t.Context(), zap.NewNop(), cfg, "")
+	require.Len(t, results, 1)
+	assert.False(t, results[0].OK)
+	assert.Equal(t, "clone for full check", results[0].Name)
 }
 
 func TestCleanupFullCheckArtifactsKeepsUnrelatedPrivateData(t *testing.T) {

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -14,6 +14,7 @@ type Composer interface {
 	Update(ctx context.Context, dir string, packagesToUpdate []string, packagesToKeep []string, minimalChanges bool, dryRun bool) ([]composer.PackageChange, error)
 	GetLockHash(dir string) (string, error)
 	CheckPlatformReqs(ctx context.Context, dir string) (string, error)
+	GetConfig(ctx context.Context, dir string, key string) (string, error)
 }
 
 type Drush interface {
@@ -28,6 +29,7 @@ type Repository interface {
 	OpenRepository(path string, username string, email string) (repo.Repository, repo.Worktree, string, error)
 	GetRemoteURL(path string) (string, error)
 	GetCurrentBranch(path string) (string, error)
+	IsShallowClone(path string) (bool, error)
 }
 
 // GitRepository is an alias for repo.Repository to avoid duplication.

--- a/internal/services/mocks_test.go
+++ b/internal/services/mocks_test.go
@@ -109,6 +109,78 @@ func (_c *MockComposer_CheckPlatformReqs_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// GetConfig provides a mock function for the type MockComposer
+func (_mock *MockComposer) GetConfig(ctx context.Context, dir string, key string) (string, error) {
+	ret := _mock.Called(ctx, dir, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConfig")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
+		return returnFunc(ctx, dir, key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
+		r0 = returnFunc(ctx, dir, key)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, dir, key)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockComposer_GetConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfig'
+type MockComposer_GetConfig_Call struct {
+	*mock.Call
+}
+
+// GetConfig is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dir string
+//   - key string
+func (_e *MockComposer_Expecter) GetConfig(ctx any, dir any, key any) *MockComposer_GetConfig_Call {
+	return &MockComposer_GetConfig_Call{Call: _e.mock.On("GetConfig", ctx, dir, key)}
+}
+
+func (_c *MockComposer_GetConfig_Call) Run(run func(ctx context.Context, dir string, key string)) *MockComposer_GetConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockComposer_GetConfig_Call) Return(s string, err error) *MockComposer_GetConfig_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockComposer_GetConfig_Call) RunAndReturn(run func(ctx context.Context, dir string, key string) (string, error)) *MockComposer_GetConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLockHash provides a mock function for the type MockComposer
 func (_mock *MockComposer) GetLockHash(dir string) (string, error) {
 	ret := _mock.Called(dir)
@@ -849,6 +921,66 @@ func (_c *MockRepository_GetRemoteURL_Call) Return(s string, err error) *MockRep
 }
 
 func (_c *MockRepository_GetRemoteURL_Call) RunAndReturn(run func(path string) (string, error)) *MockRepository_GetRemoteURL_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsShallowClone provides a mock function for the type MockRepository
+func (_mock *MockRepository) IsShallowClone(path string) (bool, error) {
+	ret := _mock.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsShallowClone")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
+		return returnFunc(path)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = returnFunc(path)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepository_IsShallowClone_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsShallowClone'
+type MockRepository_IsShallowClone_Call struct {
+	*mock.Call
+}
+
+// IsShallowClone is a helper method to define mock.On call
+//   - path string
+func (_e *MockRepository_Expecter) IsShallowClone(path any) *MockRepository_IsShallowClone_Call {
+	return &MockRepository_IsShallowClone_Call{Call: _e.mock.On("IsShallowClone", path)}
+}
+
+func (_c *MockRepository_IsShallowClone_Call) Run(run func(path string)) *MockRepository_IsShallowClone_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_IsShallowClone_Call) Return(b bool, err error) *MockRepository_IsShallowClone_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockRepository_IsShallowClone_Call) RunAndReturn(run func(path string) (bool, error)) *MockRepository_IsShallowClone_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/services/preflight.go
+++ b/internal/services/preflight.go
@@ -1,0 +1,78 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+// CheckResult is one named pass/fail outcome of a preflight check, either run standalone by
+// the "drupdater check" command or as a fail-fast guard at the start of a real update.
+type CheckResult struct {
+	Name string
+	OK   bool
+	// Detail explains a failure. It may also carry extra context on success (currently unused
+	// there); empty on a plain pass.
+	Detail string
+}
+
+func checkOK(name string) CheckResult {
+	return CheckResult{Name: name, OK: true}
+}
+
+func checkFailed(name string, detail string) CheckResult {
+	return CheckResult{Name: name, OK: false, Detail: detail}
+}
+
+// CheckGitHistoryComplete reports whether workingDir is a shallow clone. A shallow checkout
+// (e.g. a CI default of fetch-depth: 1) can still build and commit the update branch, but
+// pushing it fails downstream with a cryptic "object not found": the remote needs the ancestry
+// of the pushed commits to describe them, and a shallow clone doesn't have it. Checking this
+// upfront turns that late failure into an actionable one.
+func CheckGitHistoryComplete(repository Repository, workingDir string) CheckResult {
+	const name = "git history complete (not a shallow clone)"
+
+	shallow, err := repository.IsShallowClone(workingDir)
+	if err != nil {
+		return checkFailed(name, fmt.Sprintf("could not determine clone depth: %s", err))
+	}
+	if shallow {
+		return checkFailed(name, `shallow checkout detected: fetch full history (set "fetch-depth: 0" in GitHub Actions, or GIT_DEPTH: "0" in GitLab CI)`)
+	}
+	return checkOK(name)
+}
+
+// CheckPlatformRequirements reports whether the runtime PHP version satisfies the platform
+// requirements recorded in the project's composer.lock.
+func CheckPlatformRequirements(ctx context.Context, composer Composer, workingDir string) CheckResult {
+	const name = "PHP platform requirements satisfied"
+
+	out, err := composer.CheckPlatformReqs(ctx, workingDir)
+	if err != nil {
+		return checkFailed(name, out)
+	}
+	return checkOK(name)
+}
+
+// CheckSiteSettings reports whether site has a settings.php where Drupal expects to find it,
+// derived from the project's configured web root. Its absence means the site was never
+// installed in this checkout, so everything downstream (site install, update hooks, config
+// export) has nothing to build on.
+func CheckSiteSettings(ctx context.Context, composer Composer, fs afero.Fs, workingDir string, site string) CheckResult {
+	name := fmt.Sprintf("site %q: settings.php", site)
+
+	webroot, err := composer.GetConfig(ctx, workingDir, "extra.drupal-scaffold.locations.web-root")
+	if err != nil {
+		return checkFailed(name, fmt.Sprintf("could not determine web root: %s", err))
+	}
+	webroot = strings.TrimSuffix(webroot, "/")
+
+	relPath := filepath.Join(webroot, "sites", site, "settings.php")
+	if _, err := fs.Stat(filepath.Join(workingDir, relPath)); err != nil {
+		return checkFailed(name, fmt.Sprintf("not found at %s", relPath))
+	}
+	return checkOK(name)
+}

--- a/internal/services/preflight.go
+++ b/internal/services/preflight.go
@@ -27,12 +27,19 @@ func checkFailed(name string, detail string) CheckResult {
 	return CheckResult{Name: name, OK: false, Detail: detail}
 }
 
+// ShallowCloneChecker is the one capability CheckGitHistoryComplete needs. Narrower than the
+// full Repository interface so callers outside this package (e.g. "drupdater check") can supply
+// a small test double instead of implementing every Repository method.
+type ShallowCloneChecker interface {
+	IsShallowClone(path string) (bool, error)
+}
+
 // CheckGitHistoryComplete reports whether workingDir is a shallow clone. A shallow checkout
 // (e.g. a CI default of fetch-depth: 1) can still build and commit the update branch, but
 // pushing it fails downstream with a cryptic "object not found": the remote needs the ancestry
 // of the pushed commits to describe them, and a shallow clone doesn't have it. Checking this
 // upfront turns that late failure into an actionable one.
-func CheckGitHistoryComplete(repository Repository, workingDir string) CheckResult {
+func CheckGitHistoryComplete(repository ShallowCloneChecker, workingDir string) CheckResult {
 	const name = "git history complete (not a shallow clone)"
 
 	shallow, err := repository.IsShallowClone(workingDir)
@@ -45,9 +52,15 @@ func CheckGitHistoryComplete(repository Repository, workingDir string) CheckResu
 	return checkOK(name)
 }
 
+// PlatformReqsChecker is the one capability CheckPlatformRequirements needs. Narrower than the
+// full Composer interface for the same reason as ShallowCloneChecker above.
+type PlatformReqsChecker interface {
+	CheckPlatformReqs(ctx context.Context, dir string) (string, error)
+}
+
 // CheckPlatformRequirements reports whether the runtime PHP version satisfies the platform
 // requirements recorded in the project's composer.lock.
-func CheckPlatformRequirements(ctx context.Context, composer Composer, workingDir string) CheckResult {
+func CheckPlatformRequirements(ctx context.Context, composer PlatformReqsChecker, workingDir string) CheckResult {
 	const name = "PHP platform requirements satisfied"
 
 	out, err := composer.CheckPlatformReqs(ctx, workingDir)
@@ -57,11 +70,17 @@ func CheckPlatformRequirements(ctx context.Context, composer Composer, workingDi
 	return checkOK(name)
 }
 
+// ComposerConfigGetter is the one capability CheckSiteSettings needs. Narrower than the full
+// Composer interface for the same reason as ShallowCloneChecker above.
+type ComposerConfigGetter interface {
+	GetConfig(ctx context.Context, dir string, key string) (string, error)
+}
+
 // CheckSiteSettings reports whether site has a settings.php where Drupal expects to find it,
 // derived from the project's configured web root. Its absence means the site was never
 // installed in this checkout, so everything downstream (site install, update hooks, config
 // export) has nothing to build on.
-func CheckSiteSettings(ctx context.Context, composer Composer, fs afero.Fs, workingDir string, site string) CheckResult {
+func CheckSiteSettings(ctx context.Context, composer ComposerConfigGetter, fs afero.Fs, workingDir string, site string) CheckResult {
 	name := fmt.Sprintf("site %q: settings.php", site)
 
 	webroot, err := composer.GetConfig(ctx, workingDir, "extra.drupal-scaffold.locations.web-root")

--- a/internal/services/preflight_test.go
+++ b/internal/services/preflight_test.go
@@ -1,0 +1,108 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckGitHistoryComplete(t *testing.T) {
+	t.Run("a full clone passes", func(t *testing.T) {
+		repository := NewMockRepository(t)
+		repository.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+
+		result := CheckGitHistoryComplete(repository, "/tmp")
+		assert.True(t, result.OK)
+		assert.Empty(t, result.Detail)
+	})
+
+	t.Run("a shallow clone fails with an actionable message", func(t *testing.T) {
+		repository := NewMockRepository(t)
+		repository.EXPECT().IsShallowClone("/tmp").Return(true, nil)
+
+		result := CheckGitHistoryComplete(repository, "/tmp")
+		assert.False(t, result.OK)
+		assert.Contains(t, result.Detail, "shallow checkout detected")
+		assert.Contains(t, result.Detail, "fetch-depth")
+	})
+
+	t.Run("an error determining depth fails the check", func(t *testing.T) {
+		repository := NewMockRepository(t)
+		repository.EXPECT().IsShallowClone("/tmp").Return(false, errors.New("open failed"))
+
+		result := CheckGitHistoryComplete(repository, "/tmp")
+		assert.False(t, result.OK)
+		assert.Contains(t, result.Detail, "open failed")
+	})
+}
+
+func TestCheckPlatformRequirements(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("satisfied requirements pass", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().CheckPlatformReqs(ctx, "/tmp").Return("", nil)
+
+		result := CheckPlatformRequirements(ctx, composer, "/tmp")
+		assert.True(t, result.OK)
+	})
+
+	t.Run("unmet requirements fail with the composer output", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().CheckPlatformReqs(ctx, "/tmp").Return("php 8.1.0 failed", errors.New("unmet"))
+
+		result := CheckPlatformRequirements(ctx, composer, "/tmp")
+		assert.False(t, result.OK)
+		assert.Equal(t, "php 8.1.0 failed", result.Detail)
+	})
+}
+
+func TestCheckSiteSettings(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("settings.php present passes", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().GetConfig(ctx, "/project", "extra.drupal-scaffold.locations.web-root").Return("web", nil)
+
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/project/web/sites/default/settings.php", []byte("<?php"), 0o644))
+
+		result := CheckSiteSettings(ctx, composer, fs, "/project", "default")
+		assert.True(t, result.OK)
+	})
+
+	t.Run("a trailing slash on the web root is tolerated", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().GetConfig(ctx, "/project", "extra.drupal-scaffold.locations.web-root").Return("web/", nil)
+
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/project/web/sites/default/settings.php", []byte("<?php"), 0o644))
+
+		result := CheckSiteSettings(ctx, composer, fs, "/project", "default")
+		assert.True(t, result.OK)
+	})
+
+	t.Run("a missing settings.php fails with its expected path", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().GetConfig(ctx, "/project", "extra.drupal-scaffold.locations.web-root").Return("web", nil)
+
+		fs := afero.NewMemMapFs()
+
+		result := CheckSiteSettings(ctx, composer, fs, "/project", "subsite_a")
+		assert.False(t, result.OK)
+		assert.Contains(t, result.Detail, "web/sites/subsite_a/settings.php")
+	})
+
+	t.Run("a composer error surfaces in the detail", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().GetConfig(ctx, "/project", "extra.drupal-scaffold.locations.web-root").Return("", errors.New("composer.json not found"))
+
+		result := CheckSiteSettings(ctx, composer, afero.NewMemMapFs(), "/project", "default")
+		assert.False(t, result.OK)
+		assert.Contains(t, result.Detail, "composer.json not found")
+	})
+}

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -100,11 +100,15 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 		ws.cleanup(path)
 	}()
 
-	// Fail fast if the runtime PHP version doesn't satisfy the project's platform
-	// requirements; composer update would otherwise fail mid-run with confusing output.
-	// Extension requirements are deliberately not checked here (see CheckPlatformReqs).
-	if out, err := ws.composer.CheckPlatformReqs(ctx, path); err != nil {
-		return fmt.Errorf("PHP platform requirements not satisfied:\n%s", out)
+	// Fail fast on cheap, structural prerequisites shared with "drupdater check" instead of
+	// discovering them mid-run: a shallow checkout only fails much later, with a cryptic
+	// "object not found" when the update branch is pushed. Extension requirements are
+	// deliberately not checked here (see CheckPlatformReqs).
+	if result := CheckGitHistoryComplete(ws.repository, path); !result.OK {
+		return fmt.Errorf("%s: %s", result.Name, result.Detail)
+	}
+	if result := CheckPlatformRequirements(ctx, ws.composer, path); !result.OK {
+		return fmt.Errorf("PHP platform requirements not satisfied:\n%s", result.Detail)
 	}
 
 	ws.logger.Info("running composer install")

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -54,6 +54,7 @@ func TestStartUpdate(t *testing.T) {
 	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
@@ -125,6 +126,7 @@ func TestStartUpdatePublishUsesLiveContext(t *testing.T) {
 	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
@@ -183,6 +185,7 @@ func TestStartUpdateSiteFailureDoesNotPublish(t *testing.T) {
 	worktree.EXPECT().Checkout(mock.Anything).Return(nil)
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
@@ -236,6 +239,7 @@ func TestStartUpdateTimeout(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 
 	// Both phases block on the context, simulating a wedged subprocess; the run
@@ -284,6 +288,7 @@ func TestStartUpdatePlatformReqsFail(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 
 	// The platform check fails → updateSharedCode aborts.
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("php 8.1.0 failed", errors.New("unmet platform requirements"))
 
 	// installCode (and a site install) may run concurrently before the cancel propagates.
@@ -332,6 +337,7 @@ func TestStartUpdateNoChanges(t *testing.T) {
 	// installCode: one CloneRepository + Install
 	// updateSharedCode: one CloneRepository + Update (returns empty → AbortError)
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
@@ -388,6 +394,7 @@ func TestStartUpdateBranchAlreadyExists(t *testing.T) {
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(true, nil)
 
@@ -452,6 +459,7 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
@@ -513,6 +521,7 @@ func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
 	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
 
 	repositoryService.EXPECT().OpenRepository(config.WorkingDir, "", "").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
@@ -572,6 +581,7 @@ func TestPublishWorkDeletesBranchOnMRFailure(t *testing.T) {
 	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
@@ -630,6 +640,7 @@ func TestPublishWorkLogsWarningWhenDeleteBranchFails(t *testing.T) {
 	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
@@ -690,6 +701,7 @@ func TestPublishWorkPushFails(t *testing.T) {
 	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil)
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
@@ -739,6 +751,7 @@ func TestStartUpdateGetLockHashError(t *testing.T) {
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
 	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
@@ -785,6 +798,7 @@ func TestStartUpdateBranchExistsError(t *testing.T) {
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
 	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
@@ -838,6 +852,7 @@ func TestStartUpdateConfigResaveError(t *testing.T) {
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
@@ -888,6 +903,7 @@ func TestStartUpdateExportConfigurationError(t *testing.T) {
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
@@ -944,6 +960,7 @@ func TestStartUpdateFireEventError(t *testing.T) {
 		Return(repository, worktree, "/tmp", nil)
 
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 
 	// The dispatcher returns an error on the first FireEvent call (PreComposerUpdateEvent).
@@ -999,6 +1016,7 @@ func TestStartUpdateUsesExistingCheckout(t *testing.T) {
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 	repositoryService.EXPECT().OpenRepository(checkout, "user", "mail").Return(repository, worktree, checkout, nil)
+	repositoryService.EXPECT().IsShallowClone(checkout).Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, checkout).Return("", nil)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 	repository.EXPECT().Push(mock.Anything).Return(nil)
@@ -1047,6 +1065,7 @@ func TestStartUpdateWorkBranchCheckoutError(t *testing.T) {
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
 	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil)

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -126,6 +126,22 @@ func (rs *GitRepositoryService) GetCurrentBranch(path string) (string, error) {
 	return "", nil
 }
 
+// IsShallowClone reports whether the checkout at path has a truncated commit history (e.g. a
+// CI default of fetch-depth: 1). A shallow checkout can still create commits, but pushing the
+// resulting branch fails downstream with "object not found": the remote needs the ancestry of
+// the pushed commits to describe them, and a shallow clone doesn't have it.
+func (rs *GitRepositoryService) IsShallowClone(path string) (bool, error) {
+	checkout, err := git.PlainOpen(path)
+	if err != nil {
+		return false, fmt.Errorf("git open %q: %w", path, err)
+	}
+	shallow, err := checkout.Storer.Shallow()
+	if err != nil {
+		return false, fmt.Errorf("failed to read shallow commit info: %w", err)
+	}
+	return len(shallow) > 0, nil
+}
+
 // prepareCheckout sets the commit identity and removes the prepare-commit-msg hook, then
 // returns the repository, worktree and working-tree root. Shared by clone and open.
 func (rs *GitRepositoryService) prepareCheckout(checkout *git.Repository, username string, email string) (Repository, Worktree, string, error) {

--- a/pkg/repo/repo_extra_test.go
+++ b/pkg/repo/repo_extra_test.go
@@ -153,3 +153,42 @@ func TestCloneRepository(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestIsShallowClone(t *testing.T) {
+	service := NewGitRepositoryService(zap.NewNop())
+
+	t.Run("a full checkout is not shallow", func(t *testing.T) {
+		dir, _ := initRepoWithCommit(t)
+
+		shallow, err := service.IsShallowClone(dir)
+		require.NoError(t, err)
+		assert.False(t, shallow)
+	})
+
+	t.Run("a depth-limited clone is shallow", func(t *testing.T) {
+		source, r := initRepoWithCommit(t)
+		wt, err := r.Worktree()
+		require.NoError(t, err)
+		// A second commit gives the depth-1 clone below ancestry to actually truncate.
+		_, err = wt.Commit("second", &git.CommitOptions{
+			AllowEmptyCommits: true,
+			Author:            &object.Signature{Name: "t", Email: "t@example.com"},
+		})
+		require.NoError(t, err)
+		head, err := r.Head()
+		require.NoError(t, err)
+
+		_, _, path, err := service.CloneRepository(source, head.Name().Short(), "", "Bot", "bot@example.com")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.RemoveAll(path) })
+
+		shallow, err := service.IsShallowClone(path)
+		require.NoError(t, err)
+		assert.True(t, shallow)
+	})
+
+	t.Run("errors on a non-repository path", func(t *testing.T) {
+		_, err := service.IsShallowClone(t.TempDir())
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
`drupdater check` validates a project's prerequisites without running an
update: no composer update, no branch, no MR. By default it runs cheap,
near-instant checks (.drupdater.yaml/addon names, git history depth, PHP
platform requirements, each site's settings.php, and VCS host/token
authentication); --full additionally clones the repo to a scratch directory
and proves each site installs from its exported configuration.

The git-history and platform-requirements checks are factored into
internal/services/preflight.go so the real workflow's own fail-fast startup
uses the same logic — a shallow checkout is now caught immediately instead
of failing late with a cryptic "object not found" on push.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mu1WgeeAbDuKdFs2KNb6FK