### PR TITLE
Fix findings from full code review

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -46,6 +46,7 @@ Exits non-zero if any check fails, so it can gate a pipeline.`,
 		cmd.SilenceErrors = true
 
 		redactor := logging.NewRedactor()
+		registerEnvSecrets(redactor)
 		logger, err := NewLogger(config, redactor)
 		if err != nil {
 			fmt.Fprintln(cmd.ErrOrStderr(), "failed to initialize logger:", err)
@@ -74,7 +75,7 @@ Exits non-zero if any check fails, so it can gate a pipeline.`,
 			results = append(results, runFullChecks(ctx, logger, cfg, token)...)
 		}
 
-		printCheckResults(cmd.OutOrStdout(), results)
+		printCheckResults(cmd.OutOrStdout(), results, redactor)
 		if anyCheckFailed(results) {
 			return errors.New("preflight check failed")
 		}
@@ -242,14 +243,18 @@ func cleanupFullCheckArtifacts(path string, sites []string) {
 	os.Remove(filepath.Join(parent, "private"))
 }
 
-func printCheckResults(w io.Writer, results []services.CheckResult) {
+// printCheckResults writes results to w, redacting each detail message through redactor first: a
+// failed check's Detail can carry a subprocess's raw output (e.g. Composer's error after a failed
+// authenticated fetch), which is exactly where a credential embedded in a URL would otherwise
+// leak straight to stdout, bypassing the logger's own redaction entirely.
+func printCheckResults(w io.Writer, results []services.CheckResult, redactor *logging.Redactor) {
 	for _, r := range results {
 		mark := "✓"
 		if !r.OK {
 			mark = "✗"
 		}
 		if !r.OK && r.Detail != "" {
-			fmt.Fprintf(w, "%s %s: %s\n", mark, r.Name, r.Detail)
+			fmt.Fprintf(w, "%s %s: %s\n", mark, r.Name, redactor.Redact(r.Detail))
 			continue
 		}
 		fmt.Fprintf(w, "%s %s\n", mark, r.Name)

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/logging"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -108,12 +109,29 @@ func TestPrintCheckResults(t *testing.T) {
 		{Name: "a", OK: true},
 		{Name: "b", OK: false, Detail: "went wrong"},
 		{Name: "c", OK: false},
-	})
+	}, logging.NewRedactor())
 
 	out := buf.String()
 	assert.Contains(t, out, "✓ a\n")
 	assert.Contains(t, out, "✗ b: went wrong\n")
 	assert.Contains(t, out, "✗ c\n")
+}
+
+func TestPrintCheckResultsRedactsDetail(t *testing.T) {
+	// A failed check's Detail can carry raw subprocess output (e.g. a Composer error after a
+	// failed authenticated fetch), which is exactly where a leaked credential would otherwise
+	// reach stdout unredacted.
+	redactor := logging.NewRedactor()
+	redactor.Register("s3cr3t-token")
+
+	var buf bytes.Buffer
+	printCheckResults(&buf, []services.CheckResult{
+		{Name: "composer install", OK: false, Detail: "fetch failed: https://s3cr3t-token@example.com/repo.git: 403"},
+	}, redactor)
+
+	out := buf.String()
+	assert.NotContains(t, out, "s3cr3t-token")
+	assert.Contains(t, out, "***")
 }
 
 func TestAnyCheckFailed(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,8 +79,7 @@ names you can set there. See the README for the full file format.`,
 		// as soon as each becomes known so nothing is logged unredacted in between; never
 		// logged itself, including at debug level with --verbose.
 		redactor := logging.NewRedactor()
-		redactor.Register(os.Getenv("DRUPALCODE_ACCESS_TOKEN"))
-		registerComposerAuth(redactor, os.Getenv("COMPOSER_AUTH"))
+		registerEnvSecrets(redactor)
 
 		// Initialize the logger first so config errors are reported (errors are silenced by Cobra).
 		logger, err := NewLogger(config, redactor)
@@ -197,13 +196,26 @@ func tokenRequired(cfg internal.Config) bool {
 	return cfg.Clone || !cfg.DryRun
 }
 
+// registerEnvSecrets registers every credential-bearing environment value a subprocess
+// (Composer, Drush, git) might echo back in its own output, so nothing leaks unredacted between
+// the moment a value becomes known and the moment it might appear in a log line. Shared by the
+// real run and "drupdater check", which shells out to the same subprocesses and must redact the
+// same secrets from anything it prints.
+func registerEnvSecrets(redactor *logging.Redactor) {
+	redactor.Register(os.Getenv("DRUPALCODE_ACCESS_TOKEN"))
+	registerComposerAuth(redactor, os.Getenv("COMPOSER_AUTH"))
+}
+
 // registerComposerAuth registers the credentials carried by a COMPOSER_AUTH env value with the
 // redactor. COMPOSER_AUTH is a JSON object (http-basic/bearer/gitlab-token/github-oauth/... per
-// host, see the Composer docs) and Composer echoes the individual username, password, or token
-// value it contains — typically embedded in a URL after a failed authenticated fetch — not the
-// blob itself, so registering only the raw string would never match that output. Every string
-// leaf of the parsed JSON is registered individually; the raw value is registered too, as a
-// fallback for a value that fails to parse as JSON.
+// host, see the Composer docs) and Composer echoes the individual password or token value it
+// contains — typically embedded in a URL after a failed authenticated fetch — not the blob
+// itself, so registering only the raw string would never match that output. Every string leaf of
+// the parsed JSON is registered individually, except values keyed "username": Composer's
+// documented http-basic form for package registries (e.g. Packagist.com) commonly sets username
+// to the literal word "token", which is not a secret and must not be redacted from unrelated log
+// output that happens to contain that word. The raw value is registered too, as a fallback for a
+// value that fails to parse as JSON.
 func registerComposerAuth(redactor *logging.Redactor, composerAuth string) {
 	redactor.Register(composerAuth)
 
@@ -211,25 +223,29 @@ func registerComposerAuth(redactor *logging.Redactor, composerAuth string) {
 	if err := json.Unmarshal([]byte(composerAuth), &parsed); err != nil {
 		return
 	}
-	redactor.Register(jsonStringLeaves(parsed)...)
+	redactor.Register(composerAuthSecretLeaves(parsed, "")...)
 }
 
-// jsonStringLeaves returns every string value found anywhere in a decoded JSON structure
-// (as produced by json.Unmarshal into `any`), recursing through nested objects and arrays.
-func jsonStringLeaves(v any) []string {
+// composerAuthSecretLeaves returns every string value found anywhere in a decoded COMPOSER_AUTH
+// JSON structure (as produced by json.Unmarshal into `any`), recursing through nested objects and
+// arrays, except values reached through a "username" key (see registerComposerAuth).
+func composerAuthSecretLeaves(v any, key string) []string {
 	switch t := v.(type) {
 	case string:
+		if key == "username" {
+			return nil
+		}
 		return []string{t}
 	case map[string]any:
 		leaves := make([]string, 0, len(t))
-		for _, val := range t {
-			leaves = append(leaves, jsonStringLeaves(val)...)
+		for k, val := range t {
+			leaves = append(leaves, composerAuthSecretLeaves(val, k)...)
 		}
 		return leaves
 	case []any:
 		leaves := make([]string, 0, len(t))
 		for _, val := range t {
-			leaves = append(leaves, jsonStringLeaves(val)...)
+			leaves = append(leaves, composerAuthSecretLeaves(val, key)...)
 		}
 		return leaves
 	default:

--- a/cmd/root_extra_test.go
+++ b/cmd/root_extra_test.go
@@ -96,6 +96,22 @@ func TestTokenRequired(t *testing.T) {
 	})
 }
 
+func TestRegisterEnvSecrets(t *testing.T) {
+	// registerEnvSecrets is what wires DRUPALCODE_ACCESS_TOKEN and COMPOSER_AUTH into the
+	// redactor for both a real run (cmd/root.go) and "drupdater check" (cmd/check.go), which
+	// shells out to the same subprocesses and must redact the same secrets from anything it
+	// prints.
+	t.Setenv("DRUPALCODE_ACCESS_TOKEN", "drupalcode-secret")
+	t.Setenv("COMPOSER_AUTH", `{"bearer":{"example.com":"bearer-secret"}}`)
+
+	redactor := logging.NewRedactor()
+	registerEnvSecrets(redactor)
+
+	got := redactor.Redact("leaked drupalcode-secret and bearer-secret")
+	assert.NotContains(t, got, "drupalcode-secret")
+	assert.NotContains(t, got, "bearer-secret")
+}
+
 func TestRegisterComposerAuth(t *testing.T) {
 	// registerComposerAuth must register the individual credentials inside COMPOSER_AUTH, not
 	// just the raw JSON blob: Composer echoes the username/password/token itself (typically
@@ -133,13 +149,28 @@ func TestRegisterComposerAuth(t *testing.T) {
 	})
 }
 
-func TestJSONStringLeaves(t *testing.T) {
-	leaves := jsonStringLeaves(map[string]any{
+func TestComposerAuthSecretLeaves(t *testing.T) {
+	leaves := composerAuthSecretLeaves(map[string]any{
 		"a": "1",
 		"b": map[string]any{"c": "2", "d": []any{"3", "4"}},
 		"e": 5.0,
-	})
+	}, "")
 	assert.ElementsMatch(t, []string{"1", "2", "3", "4"}, leaves)
+}
+
+func TestComposerAuthSecretLeavesSkipsUsername(t *testing.T) {
+	// Packagist.com's documented http-basic form sets username to the literal word "token" and
+	// the real secret in password; the username leaf must not be registered as a secret, or every
+	// occurrence of the word "token" in unrelated log output gets redacted too.
+	leaves := composerAuthSecretLeaves(map[string]any{
+		"http-basic": map[string]any{
+			"repo.packagist.com": map[string]any{
+				"username": "token",
+				"password": "s3cr3t-pass",
+			},
+		},
+	}, "")
+	assert.Equal(t, []string{"s3cr3t-pass"}, leaves)
 }
 
 func TestConfigFilePath(t *testing.T) {

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -134,6 +134,7 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error { //nolint:
 
 	cb.logger.Debug("adding files to commit", zap.Any("files", codingStyleUpdateResult.Files))
 
+	var addedFiles []string
 	for file := range codingStyleUpdateResult.Files {
 		if (codingStyleUpdateResult.Files[file].Errors + codingStyleUpdateResult.Files[file].Warnings) == 0 {
 			continue
@@ -143,12 +144,16 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error { //nolint:
 		if _, err := event.Worktree().Add(relativePath); err != nil {
 			return fmt.Errorf("failed to add file to commit: %w", err)
 		}
+		addedFiles = append(addedFiles, relativePath)
 	}
 
 	// phpcbf may not have changed anything on disk (some "fixable" issues aren't actually
 	// auto-fixable, and RunCBF errors are only logged), which would make an empty commit that
-	// go-git rejects. Only commit when something is actually staged.
-	staged, err := somethingStaged(event.Worktree())
+	// go-git rejects. Only commit when something this handler added is actually staged — checked
+	// against just those paths, not the whole index, so a same-event listener's own uncommitted
+	// change (e.g. deprecations_remover's composer.* diff, if it were ever left dangling) can
+	// never get swept into this commit.
+	staged, err := stagedAnyOf(event.Worktree(), addedFiles)
 	if err != nil {
 		return fmt.Errorf("failed to check worktree status: %w", err)
 	}
@@ -161,14 +166,18 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error { //nolint:
 	return err
 }
 
-// somethingStaged reports whether the worktree has any staged change.
-func somethingStaged(worktree Worktree) (bool, error) {
+// stagedAnyOf reports whether any of paths has a staged (non-Unmodified) change in worktree. An
+// empty paths list is "nothing to check" and short-circuits without querying git status.
+func stagedAnyOf(worktree Worktree, paths []string) (bool, error) {
+	if len(paths) == 0 {
+		return false, nil
+	}
 	status, err := worktree.Status()
 	if err != nil {
 		return false, err
 	}
-	for _, s := range status {
-		if s.Staging != git.Unmodified {
+	for _, p := range paths {
+		if s, ok := status[p]; ok && s.Staging != git.Unmodified {
 			return true, nil
 		}
 	}

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -461,21 +461,32 @@ func TestCodingStyles(t *testing.T) {
 		composer.AssertExpectations(t)
 	})
 
-	t.Run("somethingStaged reports staged changes and propagates errors", func(t *testing.T) {
+	t.Run("stagedAnyOf reports staged changes and propagates errors, scoped to given paths", func(t *testing.T) {
 		wt := NewMockWorktree(t)
 		wt.EXPECT().Status().Return(git.Status{"a": &git.FileStatus{Staging: git.Unmodified}}, nil).Once()
-		staged, err := somethingStaged(wt)
+		staged, err := stagedAnyOf(wt, []string{"a"})
 		require.NoError(t, err)
 		assert.False(t, staged)
 
 		wt.EXPECT().Status().Return(git.Status{"a": &git.FileStatus{Staging: git.Modified}}, nil).Once()
-		staged, err = somethingStaged(wt)
+		staged, err = stagedAnyOf(wt, []string{"a"})
 		require.NoError(t, err)
 		assert.True(t, staged)
 
+		// A staged change to a path the caller didn't ask about must not count.
+		wt.EXPECT().Status().Return(git.Status{"b": &git.FileStatus{Staging: git.Modified}}, nil).Once()
+		staged, err = stagedAnyOf(wt, []string{"a"})
+		require.NoError(t, err)
+		assert.False(t, staged)
+
 		wt.EXPECT().Status().Return(nil, assert.AnError).Once()
-		_, err = somethingStaged(wt)
+		_, err = stagedAnyOf(wt, []string{"a"})
 		require.Error(t, err)
+
+		// An empty path list short-circuits without even querying git status.
+		staged, err = stagedAnyOf(wt, nil)
+		require.NoError(t, err)
+		assert.False(t, staged)
 	})
 
 	t.Run("Fixable", func(t *testing.T) {

--- a/internal/addon/composer_audit.go
+++ b/internal/addon/composer_audit.go
@@ -46,8 +46,11 @@ func (ca *ComposerAudit) SubscribedEvents() map[string]any {
 			Priority: event.Max,
 			Listener: event.ListenerFunc(ca.preComposerUpdateHandler),
 		},
+		// Below Normal: this reports the security posture of the final code, so it must run
+		// after code_beautifier and deprecations_remover — both Normal/AboveNormal — rather than
+		// possibly interleaving with them at an arbitrary point.
 		"post-code-update": event.ListenerItem{
-			Priority: event.Normal,
+			Priority: event.BelowNormal,
 			Listener: event.ListenerFunc(ca.postCodeUpdateHandler),
 		},
 		"pre-merge-request-create": event.ListenerItem{

--- a/internal/addon/composer_audit_test.go
+++ b/internal/addon/composer_audit_test.go
@@ -50,7 +50,7 @@ func TestComposerAudit_SubscribedEvents(t *testing.T) {
 	assert.Equal(t, event.Max, preComposerEvent.Priority)
 
 	postCodeEvent := events["post-code-update"].(event.ListenerItem)
-	assert.Equal(t, event.Normal, postCodeEvent.Priority)
+	assert.Equal(t, event.BelowNormal, postCodeEvent.Priority)
 
 	preMergeEvent := events["pre-merge-request-create"].(event.ListenerItem)
 	assert.Equal(t, event.Normal, preMergeEvent.Priority)

--- a/internal/addon/composer_diff.go
+++ b/internal/addon/composer_diff.go
@@ -36,8 +36,14 @@ func (cd *ComposerDiff) SubscribedEvents() map[string]any {
 	}
 }
 
-// RenderTemplate returns the rendered template for this addon.
+// RenderTemplate returns the rendered template for this addon, or "" if there is no dependency
+// diff to show (e.g. the postComposerUpdateHandler never ran, or composer diff reported no
+// visible change), matching how every other addon's RenderTemplate omits its section rather than
+// emitting an empty header.
 func (cd *ComposerDiff) RenderTemplate() (string, error) {
+	if cd.table == "" {
+		return "", nil
+	}
 	return cd.Render("composer_diff.go.tmpl", cd.table)
 }
 

--- a/internal/addon/composer_diff_test.go
+++ b/internal/addon/composer_diff_test.go
@@ -84,3 +84,14 @@ func TestComposerDiff_RenderTemplate(t *testing.T) {
 	assert.Equal(t, expected, result)
 	composerRunner.AssertExpectations(t)
 }
+
+func TestComposerDiff_RenderTemplate_NoDiff(t *testing.T) {
+	// An empty table (postComposerUpdateHandler never ran) must render nothing, not an empty
+	// "Dependency updates" header.
+	diff := NewComposerDiff(zap.NewNop(), NewMockComposer(t))
+
+	result, err := diff.RenderTemplate()
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/internal/addon/composer_patches_1.go
+++ b/internal/addon/composer_patches_1.go
@@ -504,7 +504,7 @@ func (h *ComposerPatches1) downloadFile(ctx context.Context, url, folder string,
 		return fmt.Errorf("failed to download file: status code %d", resp.StatusCode)
 	}
 
-	if err = os.MkdirAll(folder, os.ModePerm); err != nil {
+	if err = os.MkdirAll(folder, 0o755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 

--- a/internal/addon/deprecations_remover.go
+++ b/internal/addon/deprecations_remover.go
@@ -27,8 +27,13 @@ func NewDeprecationsRemover(logger *zap.Logger, rector Rector, composer Composer
 // SubscribedEvents returns the events this addon listens to
 func (dr *DeprecationsRemover) SubscribedEvents() map[string]any {
 	return map[string]any{
+		// Above Normal: this handler temporarily requires palantirnet/drupal-rector (see below),
+		// and code_beautifier's own "post-code-update" listener (Normal) may commit composer.*
+		// via AddGlob if it installs drupal/coder — it must never run in between the require and
+		// the cleanup this handler does before returning, or it would sweep up an unrelated,
+		// half-finished composer.json/composer.lock diff into its own commit.
 		"post-code-update": event.ListenerItem{
-			Priority: event.Normal,
+			Priority: event.AboveNormal,
 			Listener: event.ListenerFunc(dr.postCodeUpdateHandler),
 		},
 	}
@@ -68,6 +73,13 @@ func (dr *DeprecationsRemover) postCodeUpdateHandler(e event.Event) error {
 		if _, err := dr.composer.Remove(evt.Context(), evt.Path(), "palantirnet/drupal-rector"); err != nil {
 			return err
 		}
+		// Commit whatever composer.json/composer.lock diff remains from temporarily requiring
+		// rector (a version-solving pass rarely restores the lock file byte-for-byte). Doing this
+		// here, rather than leaving the files dirty, means no other "post-code-update" listener's
+		// own worktree.AddGlob("composer.*") can ever sweep this unrelated diff into its commit.
+		if err := dr.commitTemporaryRectorCleanup(evt.Worktree()); err != nil {
+			return err
+		}
 	}
 
 	if deprecationRemovalResult.Totals.ChangedFiles == 0 {
@@ -84,5 +96,22 @@ func (dr *DeprecationsRemover) postCodeUpdateHandler(e event.Event) error {
 	dr.logger.Debug("committing deprecation removals")
 	_, err = evt.Worktree().Commit("Remove deprecations", &git.CommitOptions{})
 
+	return err
+}
+
+// commitTemporaryRectorCleanup commits any composer.json/composer.lock diff left over from
+// temporarily requiring palantirnet/drupal-rector, or does nothing if removing it left no trace.
+func (dr *DeprecationsRemover) commitTemporaryRectorCleanup(worktree Worktree) error {
+	if err := worktree.AddGlob("composer.*"); err != nil {
+		return err
+	}
+	staged, err := stagedAnyOf(worktree, []string{"composer.json", "composer.lock"})
+	if err != nil {
+		return err
+	}
+	if !staged {
+		return nil
+	}
+	_, err = worktree.Commit("Remove temporary drupal-rector installation", &git.CommitOptions{})
 	return err
 }

--- a/internal/addon/deprecations_remover_test.go
+++ b/internal/addon/deprecations_remover_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/rector"
 
+	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestDeprecationsRemover_SubscribedEvents(t *testing.T) {
 
 	assert.Contains(t, events, "post-code-update")
 	item := events["post-code-update"].(event.ListenerItem)
-	assert.Equal(t, event.Normal, item.Priority)
+	assert.Equal(t, event.AboveNormal, item.Priority)
 }
 
 func TestDeprecationsRemover_RenderTemplate(t *testing.T) {
@@ -54,6 +55,11 @@ func TestRemoveDeprecations(t *testing.T) {
 		}, nil)
 		composer.EXPECT().Remove(mock.Anything, "/path/to/repo", []string{"palantirnet/drupal-rector"}).Return("", nil)
 
+		// Removing the temporarily-required rector left composer.json/composer.lock unchanged
+		// from HEAD, so nothing is staged and no cleanup commit happens.
+		worktree.EXPECT().AddGlob("composer.*").Return(nil).Once()
+		worktree.EXPECT().Status().Return(git.Status{}, nil).Once()
+
 		// Execute
 		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(context.Background(), "/path/to/repo", worktree)
@@ -64,6 +70,35 @@ func TestRemoveDeprecations(t *testing.T) {
 		composer.AssertExpectations(t)
 		runner.AssertExpectations(t)
 		worktree.AssertExpectations(t)
+	})
+
+	t.Run("Rector is not installed and removing it leaves a composer.lock diff", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().IsPackageInstalled(mock.Anything, "/path/to/repo", "palantirnet/drupal-rector").Return(false, nil)
+		composer.EXPECT().Require(mock.Anything, "/path/to/repo", []string{"palantirnet/drupal-rector"}).Return("", nil)
+		composer.EXPECT().GetCustomCodeDirectories(mock.Anything, "/path/to/repo").Return([]string{"web/modules/custom"}, nil)
+
+		runner := NewMockRector(t)
+		runner.EXPECT().Run(mock.Anything, "/path/to/repo", []string{"web/modules/custom"}).Return(rector.ReturnOutput{
+			ChangedFiles: []string{},
+			FileDiffs:    []rector.ReturnOutputFillDiff{},
+			Totals:       rector.ReturnOutputTotals{ChangedFiles: 0, Errors: 0},
+		}, nil)
+		composer.EXPECT().Remove(mock.Anything, "/path/to/repo", []string{"palantirnet/drupal-rector"}).Return("", nil)
+
+		wt := NewMockWorktree(t)
+		wt.EXPECT().AddGlob("composer.*").Return(nil).Once()
+		wt.EXPECT().Status().Return(git.Status{"composer.lock": &git.FileStatus{Staging: git.Modified}}, nil).Once()
+		wt.EXPECT().Commit("Remove temporary drupal-rector installation", mock.Anything).Return(plumbing.NewHash(""), nil).Once()
+
+		updateRemoveDeprecations := NewDeprecationsRemover(logger, runner, composer)
+		postCodeUpdate := services.NewPostCodeUpdateEvent(context.Background(), "/path/to/repo", wt)
+		err := updateRemoveDeprecations.postCodeUpdateHandler(postCodeUpdate)
+
+		require.NoError(t, err)
+		composer.AssertExpectations(t)
+		runner.AssertExpectations(t)
+		wt.AssertExpectations(t)
 	})
 
 	t.Run("Rector is installed and command executed successfully with one fix", func(t *testing.T) {

--- a/internal/addon/unsupported_modules.go
+++ b/internal/addon/unsupported_modules.go
@@ -44,8 +44,14 @@ func (um *UnsupportedModules) SubscribedEvents() map[string]any {
 	}
 }
 
-// RenderTemplate returns the rendered template for this addon.
+// RenderTemplate returns the rendered template for this addon. Locking here is not required for
+// correctness today — the workflow only calls it after every site's forEachSite goroutine has
+// returned, and errgroup.Wait establishes a happens-before edge for that — but that ordering is
+// an invariant of the caller, not of this type, so mu still guards the read.
 func (um *UnsupportedModules) RenderTemplate() (string, error) {
+	um.mu.Lock()
+	defer um.mu.Unlock()
+
 	if len(um.modules) == 0 {
 		return "", nil
 	}

--- a/internal/addon/update_hooks.go
+++ b/internal/addon/update_hooks.go
@@ -44,8 +44,14 @@ func (uh *UpdateHooks) SubscribedEvents() map[string]any {
 	}
 }
 
-// RenderTemplate returns the rendered template for this addon
+// RenderTemplate returns the rendered template for this addon. Locking here is not required for
+// correctness today — the workflow only calls it after every site's forEachSite goroutine has
+// returned, and errgroup.Wait establishes a happens-before edge for that — but that ordering is
+// an invariant of the caller, not of this type, so mu still guards the read.
 func (uh *UpdateHooks) RenderTemplate() (string, error) {
+	uh.mu.Lock()
+	defer uh.mu.Unlock()
+
 	if len(uh.hooks) == 0 {
 		return "", nil
 	}

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -61,6 +61,14 @@ func (r *Redactor) Register(values ...string) {
 	}
 }
 
+// Redact replaces every registered secret value in s with the placeholder. It is the exported
+// counterpart of redact, for output written outside the logger (e.g. a preflight check's report,
+// printed straight to a writer rather than logged) that must get the same redaction as any other
+// place a subprocess's output can surface a leaked credential.
+func (r *Redactor) Redact(s string) string {
+	return r.redact(s)
+}
+
 // redact replaces every registered secret value in s with the placeholder.
 func (r *Redactor) redact(s string) string {
 	replacer := r.currentReplacer()

--- a/internal/services/mocks_test.go
+++ b/internal/services/mocks_test.go
@@ -1100,6 +1100,61 @@ func (_m *MockGitRepository) EXPECT() *MockGitRepository_Expecter {
 	return &MockGitRepository_Expecter{mock: &_m.Mock}
 }
 
+// Head provides a mock function for the type MockGitRepository
+func (_mock *MockGitRepository) Head() (*plumbing.Reference, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Head")
+	}
+
+	var r0 *plumbing.Reference
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (*plumbing.Reference, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() *plumbing.Reference); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*plumbing.Reference)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGitRepository_Head_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Head'
+type MockGitRepository_Head_Call struct {
+	*mock.Call
+}
+
+// Head is a helper method to define mock.On call
+func (_e *MockGitRepository_Expecter) Head() *MockGitRepository_Head_Call {
+	return &MockGitRepository_Head_Call{Call: _e.mock.On("Head")}
+}
+
+func (_c *MockGitRepository_Head_Call) Run(run func()) *MockGitRepository_Head_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockGitRepository_Head_Call) Return(reference *plumbing.Reference, err error) *MockGitRepository_Head_Call {
+	_c.Call.Return(reference, err)
+	return _c
+}
+
+func (_c *MockGitRepository_Head_Call) RunAndReturn(run func() (*plumbing.Reference, error)) *MockGitRepository_Head_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Push provides a mock function for the type MockGitRepository
 func (_mock *MockGitRepository) Push(o *git.PushOptions) error {
 	ret := _mock.Called(o)
@@ -1147,6 +1202,74 @@ func (_c *MockGitRepository_Push_Call) Return(err error) *MockGitRepository_Push
 }
 
 func (_c *MockGitRepository_Push_Call) RunAndReturn(run func(o *git.PushOptions) error) *MockGitRepository_Push_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Reference provides a mock function for the type MockGitRepository
+func (_mock *MockGitRepository) Reference(name plumbing.ReferenceName, resolved bool) (*plumbing.Reference, error) {
+	ret := _mock.Called(name, resolved)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reference")
+	}
+
+	var r0 *plumbing.Reference
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(plumbing.ReferenceName, bool) (*plumbing.Reference, error)); ok {
+		return returnFunc(name, resolved)
+	}
+	if returnFunc, ok := ret.Get(0).(func(plumbing.ReferenceName, bool) *plumbing.Reference); ok {
+		r0 = returnFunc(name, resolved)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*plumbing.Reference)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(plumbing.ReferenceName, bool) error); ok {
+		r1 = returnFunc(name, resolved)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockGitRepository_Reference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reference'
+type MockGitRepository_Reference_Call struct {
+	*mock.Call
+}
+
+// Reference is a helper method to define mock.On call
+//   - name plumbing.ReferenceName
+//   - resolved bool
+func (_e *MockGitRepository_Expecter) Reference(name any, resolved any) *MockGitRepository_Reference_Call {
+	return &MockGitRepository_Reference_Call{Call: _e.mock.On("Reference", name, resolved)}
+}
+
+func (_c *MockGitRepository_Reference_Call) Run(run func(name plumbing.ReferenceName, resolved bool)) *MockGitRepository_Reference_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 plumbing.ReferenceName
+		if args[0] != nil {
+			arg0 = args[0].(plumbing.ReferenceName)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockGitRepository_Reference_Call) Return(reference *plumbing.Reference, err error) *MockGitRepository_Reference_Call {
+	_c.Call.Return(reference, err)
+	return _c
+}
+
+func (_c *MockGitRepository_Reference_Call) RunAndReturn(run func(name plumbing.ReferenceName, resolved bool) (*plumbing.Reference, error)) *MockGitRepository_Reference_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2084,6 +2207,285 @@ func (_c *MockEventDispatcher_FireEvent_Call) Return(err error) *MockEventDispat
 }
 
 func (_c *MockEventDispatcher_FireEvent_Call) RunAndReturn(run func(e event.Event) error) *MockEventDispatcher_FireEvent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// NewMockShallowCloneChecker creates a new instance of MockShallowCloneChecker. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewMockShallowCloneChecker(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *MockShallowCloneChecker {
+	mock := &MockShallowCloneChecker{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
+// MockShallowCloneChecker is an autogenerated mock type for the ShallowCloneChecker type
+type MockShallowCloneChecker struct {
+	mock.Mock
+}
+
+type MockShallowCloneChecker_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *MockShallowCloneChecker) EXPECT() *MockShallowCloneChecker_Expecter {
+	return &MockShallowCloneChecker_Expecter{mock: &_m.Mock}
+}
+
+// IsShallowClone provides a mock function for the type MockShallowCloneChecker
+func (_mock *MockShallowCloneChecker) IsShallowClone(path string) (bool, error) {
+	ret := _mock.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsShallowClone")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
+		return returnFunc(path)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = returnFunc(path)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockShallowCloneChecker_IsShallowClone_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsShallowClone'
+type MockShallowCloneChecker_IsShallowClone_Call struct {
+	*mock.Call
+}
+
+// IsShallowClone is a helper method to define mock.On call
+//   - path string
+func (_e *MockShallowCloneChecker_Expecter) IsShallowClone(path any) *MockShallowCloneChecker_IsShallowClone_Call {
+	return &MockShallowCloneChecker_IsShallowClone_Call{Call: _e.mock.On("IsShallowClone", path)}
+}
+
+func (_c *MockShallowCloneChecker_IsShallowClone_Call) Run(run func(path string)) *MockShallowCloneChecker_IsShallowClone_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockShallowCloneChecker_IsShallowClone_Call) Return(b bool, err error) *MockShallowCloneChecker_IsShallowClone_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockShallowCloneChecker_IsShallowClone_Call) RunAndReturn(run func(path string) (bool, error)) *MockShallowCloneChecker_IsShallowClone_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// NewMockPlatformReqsChecker creates a new instance of MockPlatformReqsChecker. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewMockPlatformReqsChecker(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *MockPlatformReqsChecker {
+	mock := &MockPlatformReqsChecker{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
+// MockPlatformReqsChecker is an autogenerated mock type for the PlatformReqsChecker type
+type MockPlatformReqsChecker struct {
+	mock.Mock
+}
+
+type MockPlatformReqsChecker_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *MockPlatformReqsChecker) EXPECT() *MockPlatformReqsChecker_Expecter {
+	return &MockPlatformReqsChecker_Expecter{mock: &_m.Mock}
+}
+
+// CheckPlatformReqs provides a mock function for the type MockPlatformReqsChecker
+func (_mock *MockPlatformReqsChecker) CheckPlatformReqs(ctx context.Context, dir string) (string, error) {
+	ret := _mock.Called(ctx, dir)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CheckPlatformReqs")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return returnFunc(ctx, dir)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, dir)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, dir)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPlatformReqsChecker_CheckPlatformReqs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckPlatformReqs'
+type MockPlatformReqsChecker_CheckPlatformReqs_Call struct {
+	*mock.Call
+}
+
+// CheckPlatformReqs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dir string
+func (_e *MockPlatformReqsChecker_Expecter) CheckPlatformReqs(ctx any, dir any) *MockPlatformReqsChecker_CheckPlatformReqs_Call {
+	return &MockPlatformReqsChecker_CheckPlatformReqs_Call{Call: _e.mock.On("CheckPlatformReqs", ctx, dir)}
+}
+
+func (_c *MockPlatformReqsChecker_CheckPlatformReqs_Call) Run(run func(ctx context.Context, dir string)) *MockPlatformReqsChecker_CheckPlatformReqs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPlatformReqsChecker_CheckPlatformReqs_Call) Return(s string, err error) *MockPlatformReqsChecker_CheckPlatformReqs_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockPlatformReqsChecker_CheckPlatformReqs_Call) RunAndReturn(run func(ctx context.Context, dir string) (string, error)) *MockPlatformReqsChecker_CheckPlatformReqs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// NewMockComposerConfigGetter creates a new instance of MockComposerConfigGetter. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewMockComposerConfigGetter(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *MockComposerConfigGetter {
+	mock := &MockComposerConfigGetter{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
+// MockComposerConfigGetter is an autogenerated mock type for the ComposerConfigGetter type
+type MockComposerConfigGetter struct {
+	mock.Mock
+}
+
+type MockComposerConfigGetter_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *MockComposerConfigGetter) EXPECT() *MockComposerConfigGetter_Expecter {
+	return &MockComposerConfigGetter_Expecter{mock: &_m.Mock}
+}
+
+// GetConfig provides a mock function for the type MockComposerConfigGetter
+func (_mock *MockComposerConfigGetter) GetConfig(ctx context.Context, dir string, key string) (string, error) {
+	ret := _mock.Called(ctx, dir, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConfig")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
+		return returnFunc(ctx, dir, key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
+		r0 = returnFunc(ctx, dir, key)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, dir, key)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockComposerConfigGetter_GetConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfig'
+type MockComposerConfigGetter_GetConfig_Call struct {
+	*mock.Call
+}
+
+// GetConfig is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dir string
+//   - key string
+func (_e *MockComposerConfigGetter_Expecter) GetConfig(ctx any, dir any, key any) *MockComposerConfigGetter_GetConfig_Call {
+	return &MockComposerConfigGetter_GetConfig_Call{Call: _e.mock.On("GetConfig", ctx, dir, key)}
+}
+
+func (_c *MockComposerConfigGetter_GetConfig_Call) Run(run func(ctx context.Context, dir string, key string)) *MockComposerConfigGetter_GetConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockComposerConfigGetter_GetConfig_Call) Return(s string, err error) *MockComposerConfigGetter_GetConfig_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockComposerConfigGetter_GetConfig_Call) RunAndReturn(run func(ctx context.Context, dir string, key string) (string, error)) *MockComposerConfigGetter_GetConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,7 +71,7 @@ func NewWorkflowBaseService(
 	}
 }
 
-func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []internal.Addon) error {
+func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []internal.Addon) (err error) {
 	start := time.Now()
 
 	// Bound the whole run so a wedged subprocess or network call can't hang forever.
@@ -95,8 +96,16 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 	if err != nil {
 		return err
 	}
+
+	// Capture the checkout's current HEAD before any branch is created, so a failed or aborted
+	// run can restore it below — see captureOriginalHead.
+	originalRef := ws.captureOriginalHead(repository)
+
 	defer func() {
 		ws.logger.Info("update run finished", zap.Duration("duration", time.Since(start)))
+		if err != nil && originalRef != nil {
+			ws.restoreOriginalCheckout(worktree, originalRef)
+		}
 		ws.cleanup(path)
 	}()
 
@@ -143,6 +152,43 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 		return ws.publishWork(ctx, repository, updateBranchName, addons)
 	}
 	return nil
+}
+
+// captureOriginalHead returns the checkout's current HEAD in checkout mode, or nil in clone mode
+// (a clone's whole temp directory is discarded by cleanup regardless, so there is nothing to
+// restore there) or if HEAD could not be read. It is used by StartUpdate to put a checkout-mode
+// run's working directory back exactly where it found it if the run does not complete
+// successfully — otherwise a failed or aborted run leaves the checkout on drupdater's own
+// throwaway work branch, with composer.json's allow-plugins possibly still left at true by
+// composer_allow_plugins' own pre-composer-update handler and never reverted. Best-effort: a
+// failure to read HEAD only means the restore is skipped, not that the run itself aborts over
+// what is otherwise a safety net.
+func (ws *WorkflowBaseService) captureOriginalHead(repository GitRepository) *plumbing.Reference {
+	if ws.config.Clone {
+		return nil
+	}
+	ref, err := repository.Head()
+	if err != nil {
+		ws.logger.Warn("failed to determine current HEAD, checkout will not be restored if the run fails", zap.Error(err))
+		return nil
+	}
+	return ref
+}
+
+// restoreOriginalCheckout switches worktree back to originalRef, discarding any uncommitted
+// changes and stray commits accumulated on drupdater's own throwaway work branch. It runs only
+// to tidy up after a run that has already failed or been aborted, so an error here is logged,
+// not returned: it must never mask the original failure.
+func (ws *WorkflowBaseService) restoreOriginalCheckout(worktree Worktree, originalRef *plumbing.Reference) {
+	opts := &git.CheckoutOptions{Force: true}
+	if originalRef.Name().IsBranch() {
+		opts.Branch = originalRef.Name()
+	} else {
+		opts.Hash = originalRef.Hash()
+	}
+	if err := worktree.Checkout(opts); err != nil {
+		ws.logger.Warn("failed to restore checkout to its original state", zap.Error(err))
+	}
 }
 
 // acquireWorkingCopy returns the single working directory the run operates on. By default it
@@ -269,13 +315,8 @@ func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository 
 
 	updateBranchName := fmt.Sprintf("update-%s", composerLockHash)
 
-	// Check if branch already exists
-	exists, err := ws.repository.BranchExists(repository, updateBranchName, ws.config.Token)
-	if err != nil {
-		return "", fmt.Errorf("failed to check if branch exists: %w", err)
-	}
-	if exists {
-		return "", AbortError{Msg: fmt.Sprintf("branch %s already exists, skipping", updateBranchName)}
+	if err := ws.ensureUpdateBranchAvailable(repository, updateBranchName); err != nil {
+		return "", err
 	}
 
 	// Create the final branch from the work branch's tip (carrying the accumulated commits).
@@ -289,6 +330,32 @@ func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository 
 	}
 
 	return updateBranchName, nil
+}
+
+// ensureUpdateBranchAvailable returns an AbortError if updateBranchName is already taken, locally
+// or on the remote, and a plain error if either check itself fails.
+//
+// The local check runs first: a local ref by this name can be left over from a prior
+// checkout-mode run of the same code-content hash that got this far before failing (see
+// restoreOriginalCheckout — it puts the checkout's HEAD back, but never deletes local branches
+// drupdater created). Without it, the Create:true checkout that follows this call would fail on
+// go-git's raw "a branch named ... already exists" instead of the same clean AbortError a remote
+// collision gets.
+func (ws *WorkflowBaseService) ensureUpdateBranchAvailable(repository GitRepository, updateBranchName string) error {
+	if _, err := repository.Reference(plumbing.NewBranchReferenceName(updateBranchName), false); err == nil {
+		return AbortError{Msg: fmt.Sprintf("branch %s already exists locally, skipping", updateBranchName)}
+	} else if !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return fmt.Errorf("failed to check for a local %s branch: %w", updateBranchName, err)
+	}
+
+	exists, err := ws.repository.BranchExists(repository, updateBranchName, ws.config.Token)
+	if err != nil {
+		return fmt.Errorf("failed to check if branch exists: %w", err)
+	}
+	if exists {
+		return AbortError{Msg: fmt.Sprintf("branch %s already exists, skipping", updateBranchName)}
+	}
+	return nil
 }
 
 func (ws *WorkflowBaseService) updateSite(ctx context.Context, path string, worktree Worktree, site string) error {

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -12,12 +12,14 @@ import (
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/codehosting"
 	"github.com/drupdater/drupdater/pkg/composer"
+	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestStartUpdate(t *testing.T) {
@@ -56,6 +58,7 @@ func TestStartUpdate(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
 	repository.EXPECT().Push(mock.Anything).Return(nil)
@@ -128,6 +131,7 @@ func TestStartUpdatePublishUsesLiveContext(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
 	repository.EXPECT().Push(mock.Anything).Return(nil)
@@ -187,6 +191,7 @@ func TestStartUpdateSiteFailureDoesNotPublish(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
@@ -396,6 +401,7 @@ func TestStartUpdateBranchAlreadyExists(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(true, nil)
 
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
@@ -423,6 +429,117 @@ func TestStartUpdateBranchAlreadyExists(t *testing.T) {
 	require.ErrorAs(t, err, &abortErr)
 	assert.Contains(t, err.Error(), "already exists")
 	repositoryService.AssertExpectations(t)
+}
+
+func TestStartUpdateLocalBranchAlreadyExists(t *testing.T) {
+	// Regression: a local ref left over from a prior checkout-mode run of the same
+	// code-content hash (one that reached this branch before failing later) must abort with the
+	// same clean AbortError a remote collision gets, not the raw go-git "a branch named ...
+	// already exists" from the Create:true checkout that follows. BranchExists (the remote
+	// check) must never even run once the local ref is found.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Clone:         true,
+		Sites:         []string{"site1"},
+		DryRun:        false,
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
+
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(plumbing.NewBranchReferenceName("update-dummy-hash"), false).
+		Return(plumbing.NewHashReference(plumbing.NewBranchReferenceName("update-dummy-hash"), plumbing.NewHash("stale")), nil)
+
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
+		{Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(ctx, nil)
+
+	var abortErr AbortError
+	require.ErrorAs(t, err, &abortErr)
+	assert.Contains(t, err.Error(), "already exists locally")
+	repositoryService.AssertNotCalled(t, "BranchExists", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestStartUpdateLocalBranchLookupError(t *testing.T) {
+	// A Reference lookup failure that is not "not found" (e.g. a corrupt local ref) must
+	// surface as an error rather than being silently treated as "no local branch".
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Clone:         true,
+		Sites:         []string{"site1"},
+		DryRun:        false,
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
+
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	lookupErr := errors.New("corrupt ref")
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, lookupErr)
+
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
+		{Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(ctx, nil)
+
+	require.ErrorIs(t, err, lookupErr)
+	repositoryService.AssertNotCalled(t, "BranchExists", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestStartUpdateWithDryRun(t *testing.T) {
@@ -461,6 +578,7 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
@@ -523,7 +641,11 @@ func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
 	repositoryService.EXPECT().OpenRepository(config.WorkingDir, "", "").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
+	// Checkout mode (Clone is unset): StartUpdate captures HEAD up front so it can restore the
+	// checkout if the run fails. This run succeeds, so it is never used to restore anything.
+	repository.EXPECT().Head().Return(plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), plumbing.NewHash("a")), nil)
 
 	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
 		{
@@ -583,6 +705,7 @@ func TestPublishWorkDeletesBranchOnMRFailure(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
 	repository.EXPECT().Push(mock.Anything).Return(nil)
@@ -642,6 +765,7 @@ func TestPublishWorkLogsWarningWhenDeleteBranchFails(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
 	repository.EXPECT().Push(mock.Anything).Return(nil)
@@ -703,6 +827,7 @@ func TestPublishWorkPushFails(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
 	pushErr := errors.New("authentication failed")
@@ -807,6 +932,7 @@ func TestStartUpdateBranchExistsError(t *testing.T) {
 	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
 
 	branchErr := errors.New("git remote unreachable")
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, branchErr)
 
 	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
@@ -854,6 +980,7 @@ func TestStartUpdateConfigResaveError(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
 	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
@@ -905,6 +1032,7 @@ func TestStartUpdateExportConfigurationError(t *testing.T) {
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
 	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
@@ -1018,8 +1146,12 @@ func TestStartUpdateUsesExistingCheckout(t *testing.T) {
 	repositoryService.EXPECT().OpenRepository(checkout, "user", "mail").Return(repository, worktree, checkout, nil)
 	repositoryService.EXPECT().IsShallowClone(checkout).Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, checkout).Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
 	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 	repository.EXPECT().Push(mock.Anything).Return(nil)
+	// Checkout mode: HEAD is captured up front to restore the checkout on failure. This run
+	// succeeds, so it is never used.
+	repository.EXPECT().Head().Return(plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), plumbing.NewHash("a")), nil)
 
 	fixture, err := os.ReadFile("testdata/dependency_update.md")
 	require.NoError(t, err, "Failed to read test fixture")
@@ -1078,6 +1210,128 @@ func TestStartUpdateWorkBranchCheckoutError(t *testing.T) {
 	repository.AssertNotCalled(t, "Push", mock.Anything)
 }
 
+func TestStartUpdateRestoresCheckoutOnFailureInCheckoutMode(t *testing.T) {
+	// Regression: a checkout-mode run that fails or aborts must not leave the checkout on
+	// drupdater's own throwaway work branch with an uncommitted composer.json (e.g.
+	// composer_allow_plugins' allow-plugins:true, set before the failure and never reverted).
+	// StartUpdate captures the original HEAD up front and, on any non-nil return in checkout
+	// mode, checks the worktree back out to it.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	checkout := t.TempDir()
+	config := internal.Config{
+		WorkingDir: checkout,
+		Branch:     "main",
+		Sites:      []string{"site1"},
+		DryRun:     true,
+	}
+
+	worktree := NewMockWorktree(t)
+	// updateSharedCode checks out a dedicated work branch before doing any work; the restore
+	// checkout (if any) happens afterward. Capture every call's arguments rather than trying to
+	// distinguish them via a second, more specific expectation, since testify matches expected
+	// calls for the same method in registration order and a wildcard registered first would
+	// simply swallow the later, more specific call too.
+	var checkoutCalls []*git.CheckoutOptions
+	worktree.EXPECT().Checkout(mock.Anything).RunAndReturn(func(opts *git.CheckoutOptions) error {
+		checkoutCalls = append(checkoutCalls, opts)
+		return nil
+	})
+
+	originalRef := plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), plumbing.NewHash("cafe"))
+	repository.EXPECT().Head().Return(originalRef, nil)
+
+	repositoryService.EXPECT().OpenRepository(checkout, "", "").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
+	mockComposer.EXPECT().Install(mock.Anything, "/tmp").Return(nil)
+	// No changes at all: composer.Update returns an empty slice, which updateSharedCode turns
+	// into an AbortError before ever reaching BranchExists or a push.
+	mockComposer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{}, nil)
+
+	installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, nil, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(ctx, nil)
+
+	var abortErr AbortError
+	require.ErrorAs(t, err, &abortErr)
+
+	require.NotEmpty(t, checkoutCalls)
+	restoreCheckout := checkoutCalls[len(checkoutCalls)-1]
+	assert.True(t, restoreCheckout.Force)
+	assert.Equal(t, originalRef.Name(), restoreCheckout.Branch)
+}
+
+func TestStartUpdateDoesNotRestoreCheckoutOnSuccess(t *testing.T) {
+	// The counterpart to the regression above: a successful checkout-mode run must not be
+	// disturbed by the new restore-on-failure logic.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	drush := NewMockDrush(t)
+	ctx := context.Background()
+
+	checkout := t.TempDir()
+	config := internal.Config{
+		Branch:     "main",
+		Token:      "token",
+		WorkingDir: checkout,
+		Sites:      []string{"site1"},
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	// Only the work-branch/final-branch checkouts happen; no restore checkout on success.
+	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Twice()
+
+	installer.EXPECT().Install(mock.Anything, checkout, "site1").Return(nil)
+	installer.EXPECT().ConfigureDatabase(mock.Anything, checkout, "site1").Return(nil)
+
+	drush.EXPECT().UpdateSite(mock.Anything, checkout, "site1").Return(nil)
+	drush.EXPECT().ExportConfiguration(mock.Anything, checkout, "site1").Return(nil)
+	drush.EXPECT().ConfigResave(mock.Anything, checkout, "site1").Return(nil)
+
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	repositoryService.EXPECT().OpenRepository(checkout, "user", "mail").Return(repository, worktree, checkout, nil)
+	repositoryService.EXPECT().IsShallowClone(checkout).Return(false, nil)
+	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, checkout).Return("", nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
+	repository.EXPECT().Push(mock.Anything).Return(nil)
+	repository.EXPECT().Head().Return(plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), plumbing.NewHash("a")), nil)
+
+	fixture, err := os.ReadFile("testdata/dependency_update.md")
+	require.NoError(t, err, "Failed to read test fixture")
+	vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, string(fixture), mock.Anything, config.Branch).Return(codehosting.MergeRequest{}, nil)
+
+	mockComposer.EXPECT().Update(mock.Anything, checkout, mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
+		{Package: "drupal/core", From: "9.0.0", To: "9.1.0"},
+	}, nil)
+	mockComposer.EXPECT().Install(mock.Anything, checkout).Return(nil)
+	mockComposer.EXPECT().GetLockHash(checkout).Return("dummy-hash", nil)
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err = workflowService.StartUpdate(ctx, nil)
+
+	require.NoError(t, err)
+	worktree.AssertExpectations(t)
+}
+
 func TestForEachSite(t *testing.T) {
 	logger := zap.NewNop()
 	sites := []string{"site1", "site2", "site3", "site4"}
@@ -1128,6 +1382,39 @@ func TestForEachSite(t *testing.T) {
 		})
 
 		require.ErrorIs(t, err, boom)
+	})
+}
+
+func TestRestoreOriginalCheckout(t *testing.T) {
+	t.Run("restores a named branch", func(t *testing.T) {
+		ws := &WorkflowBaseService{logger: zap.NewNop()}
+		worktree := NewMockWorktree(t)
+		ref := plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), plumbing.NewHash("cafe"))
+		worktree.EXPECT().Checkout(&git.CheckoutOptions{Branch: ref.Name(), Force: true}).Return(nil)
+
+		ws.restoreOriginalCheckout(worktree, ref)
+	})
+
+	t.Run("restores a detached HEAD by hash", func(t *testing.T) {
+		ws := &WorkflowBaseService{logger: zap.NewNop()}
+		worktree := NewMockWorktree(t)
+		hash := plumbing.NewHash("cafe")
+		ref := plumbing.NewHashReference(plumbing.HEAD, hash)
+		worktree.EXPECT().Checkout(&git.CheckoutOptions{Hash: hash, Force: true}).Return(nil)
+
+		ws.restoreOriginalCheckout(worktree, ref)
+	})
+
+	t.Run("a failed restore is logged, not propagated", func(t *testing.T) {
+		core, logs := observer.New(zap.WarnLevel)
+		ws := &WorkflowBaseService{logger: zap.New(core)}
+		worktree := NewMockWorktree(t)
+		ref := plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), plumbing.NewHash("cafe"))
+		worktree.EXPECT().Checkout(mock.Anything).Return(assert.AnError)
+
+		ws.restoreOriginalCheckout(worktree, ref)
+
+		assert.Positive(t, logs.Len())
 	})
 }
 

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"unicode/utf8"
 
 	"github.com/spf13/afero"
 	"go.uber.org/zap"
@@ -332,9 +331,13 @@ func (s *CLI) Diff(ctx context.Context, dir string, withLinks bool) (string, err
 	}
 
 	if withLinks {
-		// If table is too long, Github/Gitlab will not accept it. So we use the version without the links.
-		tableCharCount := utf8.RuneCountInString(out)
-		if tableCharCount > 63000 {
+		// If the table is too long, GitHub/GitLab will not accept it. GitHub's and GitLab's MR
+		// body limits (65536 and 1MB respectively) are byte limits, not rune counts, so measure
+		// this the same way: a table full of multi-byte package/issue titles could pass a rune
+		// count under the cap yet still exceed it in bytes. This is only the dependency-diff
+		// section of the body, not the whole thing, so the threshold stays comfortably under
+		// the smaller (GitHub) limit to leave room for the other addons' sections.
+		if len(out) > 63000 {
 			return s.Diff(ctx, dir, false)
 		}
 	}
@@ -458,36 +461,57 @@ type lockPackage struct {
 	Extra json.RawMessage `json:"extra"`
 }
 
+// scratchComposerJSON is the base composer.json for the scratch project used to test whether a
+// patch applies. It is written fresh before every check (see resetScratchProject) rather than
+// once, so one check's `composer require` can never leave state a later, unrelated check reads.
+const scratchComposerJSON = `{
+	"name": "drupdater/patch-test",
+	"type": "project",
+	"repositories": [
+		{
+			"type": "composer",
+			"url": "https://packages.drupal.org/8"
+		}
+	],
+	"require": {
+		"cweagans/composer-patches": "~1.0"
+	},
+	"config": {
+		"allow-plugins": true
+	},
+	"extra": {
+		"composer-exit-on-patch-failure": true,
+		"patches-file": "composer.patches.json"
+	}
+}`
+
 func (s *CLI) initTempDir() {
 	s.tempDir, s.initErr = afero.TempDir(s.fs, "", "composer-service")
 	if s.initErr != nil {
 		return
 	}
+	s.initErr = afero.WriteFile(s.fs, s.tempDir+"/composer.json", []byte(scratchComposerJSON), 0644)
+}
 
-	// Create a composer.json file
-	composerJSON := `{
-		"name": "drupdater/patch-test",
-		"type": "project",
-		"repositories": [
-			{
-				"type": "composer",
-				"url": "https://packages.drupal.org/8"
-			}
-		],
-		"require": {
-			"cweagans/composer-patches": "~1.0"
-		},
-		"config": {
-			"allow-plugins": true
-		},
-		"extra": {
-			"composer-exit-on-patch-failure": true,
-			"patches-file": "composer.patches.json"
-		}
-	}`
-
-	// Write the composer.json file to the temporary directory
-	s.initErr = afero.WriteFile(s.fs, s.tempDir+"/composer.json", []byte(composerJSON), 0644)
+// resetScratchProject restores the scratch project to its pristine state before a new check
+// runs. CheckIfPatchApplies and CheckIfPatchesApply both run `composer require <pkg>:<version>`
+// in this directory, which permanently adds that package (at that exact version) to
+// composer.json and composer.lock. Without resetting first, every later check inherits every
+// earlier check's requirement: a version conflict between two unrelated packages checked earlier
+// in the same run would make `composer require` fail for a reason that has nothing to do with
+// whether the patch under test actually applies, and — because that failure is deliberately read
+// as "the patch does not apply" — silently pins the wrong package version in the merge request.
+func (s *CLI) resetScratchProject() error {
+	if err := afero.WriteFile(s.fs, s.tempDir+"/composer.json", []byte(scratchComposerJSON), 0644); err != nil {
+		return fmt.Errorf("failed to reset scratch composer.json: %w", err)
+	}
+	if err := s.fs.RemoveAll(s.tempDir + "/composer.lock"); err != nil {
+		return fmt.Errorf("failed to remove scratch composer.lock: %w", err)
+	}
+	if err := s.fs.RemoveAll(s.tempDir + "/vendor"); err != nil {
+		return fmt.Errorf("failed to remove scratch vendor directory: %w", err)
+	}
+	return nil
 }
 
 // Cleanup removes the scratch composer project used for patch-apply checks. It is a no-op
@@ -502,6 +526,11 @@ func (s *CLI) Cleanup() {
 		s.logger.Warn("failed to remove composer scratch directory", zap.String("dir", s.tempDir), zap.Error(err))
 	}
 	s.tempDir = ""
+	// Reset initOnce too: without this, a patch check running after Cleanup would see initOnce
+	// already spent and skip straight past initTempDir with a stale, empty tempDir — writing
+	// composer.patches.json and running `composer require` in the process's own working
+	// directory (Dir: "" resolves to cwd) instead of a scratch project.
+	s.initOnce = sync.Once{}
 }
 
 type patchTestConfig struct {
@@ -513,6 +542,9 @@ func (s *CLI) CheckIfPatchApplies(ctx context.Context, packageName string, packa
 	s.initOnce.Do(s.initTempDir)
 	if s.initErr != nil {
 		return false, s.initErr
+	}
+	if err := s.resetScratchProject(); err != nil {
+		return false, err
 	}
 
 	// Create a composer.patches.json file using json.Marshal to safely handle
@@ -547,6 +579,9 @@ func (s *CLI) CheckIfPatchesApply(ctx context.Context, packageName string, packa
 	s.initOnce.Do(s.initTempDir)
 	if s.initErr != nil {
 		return false, s.initErr
+	}
+	if err := s.resetScratchProject(); err != nil {
+		return false, err
 	}
 
 	patchMap := make(map[string]string, len(patchPaths))

--- a/pkg/composer/composer_extra_test.go
+++ b/pkg/composer/composer_extra_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -131,6 +133,58 @@ func TestCleanup(t *testing.T) {
 	})
 }
 
+func TestResetScratchProject(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	service := &CLI{logger: zap.NewNop(), fs: fs}
+	service.initOnce.Do(service.initTempDir)
+	require.NoError(t, service.initErr)
+
+	// Simulate what a prior CheckIfPatchApplies/CheckIfPatchesApply call left behind: a
+	// composer.json with a pinned require added by `composer require` for an earlier, unrelated
+	// check, plus the composer.lock and vendor tree that call produced.
+	require.NoError(t, afero.WriteFile(fs, service.tempDir+"/composer.json", []byte(`{"require":{"some/leftover-package":"1.2.3"}}`), 0644))
+	require.NoError(t, afero.WriteFile(fs, service.tempDir+"/composer.lock", []byte("{}"), 0644))
+	require.NoError(t, afero.WriteFile(fs, service.tempDir+"/vendor/autoload.php", []byte("<?php"), 0644))
+
+	require.NoError(t, service.resetScratchProject())
+
+	content, err := afero.ReadFile(fs, service.tempDir+"/composer.json")
+	require.NoError(t, err)
+	assert.JSONEq(t, scratchComposerJSON, string(content))
+
+	lockExists, err := afero.Exists(fs, service.tempDir+"/composer.lock")
+	require.NoError(t, err)
+	assert.False(t, lockExists)
+
+	vendorExists, err := afero.DirExists(fs, service.tempDir+"/vendor")
+	require.NoError(t, err)
+	assert.False(t, vendorExists)
+}
+
+func TestCleanupResetsInitOnceForReinitialization(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	service := &CLI{logger: zap.NewNop(), fs: fs}
+
+	service.initOnce.Do(service.initTempDir)
+	require.NoError(t, service.initErr)
+	firstDir := service.tempDir
+	require.NotEmpty(t, firstDir)
+
+	service.Cleanup()
+	assert.Empty(t, service.tempDir)
+
+	// A later check must reinitialize a fresh scratch project, not silently skip past
+	// initTempDir with initOnce already spent and an empty tempDir left over from Cleanup.
+	service.initOnce.Do(service.initTempDir)
+	require.NoError(t, service.initErr)
+	assert.NotEmpty(t, service.tempDir)
+	assert.NotEqual(t, firstDir, service.tempDir)
+
+	exists, err := afero.DirExists(fs, service.tempDir)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
 func TestInstallReturnsNilOnSuccess(t *testing.T) {
 	stubComposerOutput(t, "Nothing to install")
 
@@ -218,6 +272,36 @@ func TestGetInstalledPackageVersionErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no versions found")
 	})
+}
+
+func TestDiffFallsBackWhenTooLargeInBytes(t *testing.T) {
+	// GitHub/GitLab's merge/pull request body limit is a byte limit, not a rune count. A diff
+	// table full of multi-byte characters (accented package or issue titles, say) can be under
+	// the threshold in runes yet already over it in bytes, so the fallback must measure bytes.
+	// "é" is a single rune but 2 bytes in UTF-8: 40000 of them is 40000 runes (under the 63000
+	// rune threshold) but 80000 bytes (over it).
+	hugeMultiByte := strings.Repeat("é", 40000)
+
+	var calls int
+	execCommand = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+		calls++
+		out := hugeMultiByte
+		if !slices.Contains(arg, "--with-links") {
+			out = "short plain diff"
+		}
+		cs := []string{"-test.run=TestHelperProcess", "--", out}
+		cs = append(cs, arg...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", "GOCOVERDIR=/tmp"}
+		return cmd
+	}
+	t.Cleanup(func() { execCommand = exec.CommandContext })
+
+	service := &CLI{logger: zap.NewNop()}
+	out, err := service.Diff(t.Context(), "/tmp", true)
+	require.NoError(t, err)
+	assert.Equal(t, "short plain diff", out)
+	assert.Equal(t, 2, calls, "expected a fallback call without --with-links")
 }
 
 func TestDiffFailure(t *testing.T) {

--- a/pkg/drupal/installer.go
+++ b/pkg/drupal/installer.go
@@ -16,7 +16,9 @@ import (
 
 type Drush interface {
 	InstallSite(ctx context.Context, path string, site string) error
-	GetConfigSyncDir(ctx context.Context, path string, site string, create bool) (string, error)
+	// GetConfigSyncDir returns the site's config sync directory; relative controls whether the
+	// path is returned relative to path (true) or as the absolute path drush reports (false).
+	GetConfigSyncDir(ctx context.Context, path string, site string, relative bool) (string, error)
 }
 
 type Composer interface {

--- a/pkg/drupal/mocks_test.go
+++ b/pkg/drupal/mocks_test.go
@@ -38,8 +38,8 @@ func (_m *MockDrush) EXPECT() *MockDrush_Expecter {
 }
 
 // GetConfigSyncDir provides a mock function for the type MockDrush
-func (_mock *MockDrush) GetConfigSyncDir(ctx context.Context, path string, site string, create bool) (string, error) {
-	ret := _mock.Called(ctx, path, site, create)
+func (_mock *MockDrush) GetConfigSyncDir(ctx context.Context, path string, site string, relative bool) (string, error) {
+	ret := _mock.Called(ctx, path, site, relative)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConfigSyncDir")
@@ -48,15 +48,15 @@ func (_mock *MockDrush) GetConfigSyncDir(ctx context.Context, path string, site 
 	var r0 string
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) (string, error)); ok {
-		return returnFunc(ctx, path, site, create)
+		return returnFunc(ctx, path, site, relative)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, bool) string); ok {
-		r0 = returnFunc(ctx, path, site, create)
+		r0 = returnFunc(ctx, path, site, relative)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, bool) error); ok {
-		r1 = returnFunc(ctx, path, site, create)
+		r1 = returnFunc(ctx, path, site, relative)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -72,12 +72,12 @@ type MockDrush_GetConfigSyncDir_Call struct {
 //   - ctx context.Context
 //   - path string
 //   - site string
-//   - create bool
-func (_e *MockDrush_Expecter) GetConfigSyncDir(ctx any, path any, site any, create any) *MockDrush_GetConfigSyncDir_Call {
-	return &MockDrush_GetConfigSyncDir_Call{Call: _e.mock.On("GetConfigSyncDir", ctx, path, site, create)}
+//   - relative bool
+func (_e *MockDrush_Expecter) GetConfigSyncDir(ctx any, path any, site any, relative any) *MockDrush_GetConfigSyncDir_Call {
+	return &MockDrush_GetConfigSyncDir_Call{Call: _e.mock.On("GetConfigSyncDir", ctx, path, site, relative)}
 }
 
-func (_c *MockDrush_GetConfigSyncDir_Call) Run(run func(ctx context.Context, path string, site string, create bool)) *MockDrush_GetConfigSyncDir_Call {
+func (_c *MockDrush_GetConfigSyncDir_Call) Run(run func(ctx context.Context, path string, site string, relative bool)) *MockDrush_GetConfigSyncDir_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -110,7 +110,7 @@ func (_c *MockDrush_GetConfigSyncDir_Call) Return(s string, err error) *MockDrus
 	return _c
 }
 
-func (_c *MockDrush_GetConfigSyncDir_Call) RunAndReturn(run func(ctx context.Context, path string, site string, create bool) (string, error)) *MockDrush_GetConfigSyncDir_Call {
+func (_c *MockDrush_GetConfigSyncDir_Call) RunAndReturn(run func(ctx context.Context, path string, site string, relative bool) (string, error)) *MockDrush_GetConfigSyncDir_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/repo/mocks_test.go
+++ b/pkg/repo/mocks_test.go
@@ -37,6 +37,61 @@ func (_m *MockRepository) EXPECT() *MockRepository_Expecter {
 	return &MockRepository_Expecter{mock: &_m.Mock}
 }
 
+// Head provides a mock function for the type MockRepository
+func (_mock *MockRepository) Head() (*plumbing.Reference, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Head")
+	}
+
+	var r0 *plumbing.Reference
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (*plumbing.Reference, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() *plumbing.Reference); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*plumbing.Reference)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepository_Head_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Head'
+type MockRepository_Head_Call struct {
+	*mock.Call
+}
+
+// Head is a helper method to define mock.On call
+func (_e *MockRepository_Expecter) Head() *MockRepository_Head_Call {
+	return &MockRepository_Head_Call{Call: _e.mock.On("Head")}
+}
+
+func (_c *MockRepository_Head_Call) Run(run func()) *MockRepository_Head_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockRepository_Head_Call) Return(reference *plumbing.Reference, err error) *MockRepository_Head_Call {
+	_c.Call.Return(reference, err)
+	return _c
+}
+
+func (_c *MockRepository_Head_Call) RunAndReturn(run func() (*plumbing.Reference, error)) *MockRepository_Head_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Push provides a mock function for the type MockRepository
 func (_mock *MockRepository) Push(o *git.PushOptions) error {
 	ret := _mock.Called(o)
@@ -84,6 +139,74 @@ func (_c *MockRepository_Push_Call) Return(err error) *MockRepository_Push_Call 
 }
 
 func (_c *MockRepository_Push_Call) RunAndReturn(run func(o *git.PushOptions) error) *MockRepository_Push_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Reference provides a mock function for the type MockRepository
+func (_mock *MockRepository) Reference(name plumbing.ReferenceName, resolved bool) (*plumbing.Reference, error) {
+	ret := _mock.Called(name, resolved)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reference")
+	}
+
+	var r0 *plumbing.Reference
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(plumbing.ReferenceName, bool) (*plumbing.Reference, error)); ok {
+		return returnFunc(name, resolved)
+	}
+	if returnFunc, ok := ret.Get(0).(func(plumbing.ReferenceName, bool) *plumbing.Reference); ok {
+		r0 = returnFunc(name, resolved)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*plumbing.Reference)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(plumbing.ReferenceName, bool) error); ok {
+		r1 = returnFunc(name, resolved)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepository_Reference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reference'
+type MockRepository_Reference_Call struct {
+	*mock.Call
+}
+
+// Reference is a helper method to define mock.On call
+//   - name plumbing.ReferenceName
+//   - resolved bool
+func (_e *MockRepository_Expecter) Reference(name any, resolved any) *MockRepository_Reference_Call {
+	return &MockRepository_Reference_Call{Call: _e.mock.On("Reference", name, resolved)}
+}
+
+func (_c *MockRepository_Reference_Call) Run(run func(name plumbing.ReferenceName, resolved bool)) *MockRepository_Reference_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 plumbing.ReferenceName
+		if args[0] != nil {
+			arg0 = args[0].(plumbing.ReferenceName)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_Reference_Call) Return(reference *plumbing.Reference, err error) *MockRepository_Reference_Call {
+	_c.Call.Return(reference, err)
+	return _c
+}
+
+func (_c *MockRepository_Reference_Call) RunAndReturn(run func(name plumbing.ReferenceName, resolved bool) (*plumbing.Reference, error)) *MockRepository_Reference_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -19,6 +19,13 @@ import (
 type Repository interface {
 	Push(o *git.PushOptions) error
 	Remote(name string) (*git.Remote, error)
+	// Head returns the resolved HEAD reference: pointing at a branch (Name().IsBranch() is true)
+	// when the checkout is on one, or directly at a commit hash (Name() == plumbing.HEAD) when
+	// detached — the state a CI checkout is normally left in.
+	Head() (*plumbing.Reference, error)
+	// Reference looks up a single local reference by name, returning plumbing.ErrReferenceNotFound
+	// if it doesn't exist.
+	Reference(name plumbing.ReferenceName, resolved bool) (*plumbing.Reference, error)
 }
 
 type Worktree interface {

--- a/pkg/repo/repo_extra_test.go
+++ b/pkg/repo/repo_extra_test.go
@@ -9,6 +9,7 @@ import (
 	gitConfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -151,6 +152,48 @@ func TestCloneRepository(t *testing.T) {
 
 		_, _, _, err := service.CloneRepository(source, "no-such-branch", "", "Bot", "bot@example.com")
 		require.Error(t, err)
+	})
+
+	t.Run("returns the error when the project directory cannot be created", func(t *testing.T) {
+		roService := &GitRepositoryService{logger: zap.NewNop(), fs: afero.NewReadOnlyFs(afero.NewMemMapFs())}
+
+		_, _, _, err := roService.CloneRepository("https://example.com/repo.git", "main", "", "Bot", "bot@example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create project directory")
+	})
+}
+
+func TestHead(t *testing.T) {
+	// Head() is what StartUpdate uses to capture a checkout-mode run's original state before
+	// creating drupdater's own throwaway work branch, so it can restore it if the run fails.
+	service := NewGitRepositoryService(zap.NewNop())
+
+	t.Run("resolves to the checked-out branch", func(t *testing.T) {
+		dir, _ := initRepoWithCommit(t)
+
+		repository, _, _, err := service.OpenRepository(dir, "Bot", "bot@example.com")
+		require.NoError(t, err)
+
+		ref, err := repository.Head()
+		require.NoError(t, err)
+		assert.True(t, ref.Name().IsBranch())
+	})
+
+	t.Run("resolves directly to a commit hash when detached", func(t *testing.T) {
+		dir, r := initRepoWithCommit(t)
+		head, err := r.Head()
+		require.NoError(t, err)
+		wt, err := r.Worktree()
+		require.NoError(t, err)
+		require.NoError(t, wt.Checkout(&git.CheckoutOptions{Hash: head.Hash()}))
+
+		repository, _, _, err := service.OpenRepository(dir, "Bot", "bot@example.com")
+		require.NoError(t, err)
+
+		ref, err := repository.Head()
+		require.NoError(t, err)
+		assert.False(t, ref.Name().IsBranch())
+		assert.Equal(t, head.Hash(), ref.Hash())
 	})
 }
 


### PR DESCRIPTION
- drupdater check now redacts the same secrets (DRUPALCODE_ACCESS_TOKEN,
  COMPOSER_AUTH) as a real run, including in printed check results.
- COMPOSER_AUTH parsing no longer treats "username" values as secrets,
  fixing false-positive redaction of common words like "token".
- The patch-apply scratch Composer project resets composer.json/.lock/
  vendor before every check, so one patch's `composer require` can no
  longer contaminate another's result; Cleanup() also resets initOnce
  so a later check reinitializes a real scratch dir instead of silently
  running in the process's own cwd.
- deprecations_remover, code_beautifier, and composer_audit now use
  distinct event priorities; deprecations_remover commits or discards
  any leftover composer.* diff from its temporary rector install itself,
  and code_beautifier's staging check is scoped to files it actually
  added rather than the whole index.
- A failed or aborted checkout-mode run now restores the checkout's
  original HEAD instead of leaving it on drupdater's throwaway branch
  with uncommitted composer.json changes; a stale local update-<hash>
  branch from a prior failed run is now detected and reported as a
  clean AbortError instead of a raw go-git error.
- Diff-table truncation now measures UTF-8 bytes, matching GitHub/
  GitLab's byte-based body limit, instead of rune count.
- Minor fixes: UnsupportedModules/UpdateHooks lock their mutex in
  RenderTemplate, GetConfigSyncDir's interface parameter is renamed to
  match its actual meaning, patch-download directories use 0o755
  instead of 0o777, and ComposerDiff omits its section when there's no
  diff to show.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013hUcXZu2BzBLjg6iZsws76