### PR TITLE
feat: add --report for machine-readable JSON run output (#166)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,8 @@ Config is split into two tiers, with no overlap:
 | `--repository-url` | _(from `origin`)_ | Repo URL; required with `--clone`, else read from `origin` |
 | `--security` | false | Only apply security updates; selects the `addons.security` list |
 | `--concurrency` | `GOMAXPROCS(0)` | Max concurrent per-site work in `forEachSite`; describes the machine, not the project, so it's a flag rather than a `.drupdater.yaml` key |
-| `--dry-run` | false | Skip branch creation and MR |
+| `--dry-run` | false | Skip pushing the branch and creating the MR (branch and commits are still made locally) |
+| `--report` | _(disabled)_ | Write the machine-readable JSON run report to this path (`internal/report`). Emitted on every exit path — success, failure and `--dry-run` — from `StartUpdate`'s defer. Also applies to `drupdater check`, which writes a `report.Check` instead |
 | `--verbose` | false | Debug-level structured logging |
 | `--config` | _(`<working-dir>/.drupdater.yaml`)_ | Path to the config file |
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BINARY_NAME=drupdater
 DOCKER_IMAGE=drupdater-local
 VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS=-ldflags "-X main.version=${VERSION}"
+LDFLAGS=-ldflags "-X github.com/drupdater/drupdater/internal.Version=${VERSION}"
 
 # Default target
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ chore.
 - [CI/CD Integration](#cicd-integration)
 - [Tokens & Permissions](#tokens--permissions)
 - [Configuration](#configuration)
+- [Run report](#run-report)
 - [Troubleshooting](#troubleshooting)
 - [Architecture](#architecture)
 - [Development](#development)
@@ -211,6 +212,7 @@ required for a run that clones or pushes/opens a PR/MR (see
 | `--security` | `false` | Update only packages with known vulnerabilities. Selects the `addons.security` list. |
 | `--concurrency` | `GOMAXPROCS(0)` | Maximum number of sites to install/update concurrently. Site installs are as much I/O-bound as CPU-bound, so raise or lower this from the CPU-derived default to match the runner (constrained runner, slow disk, or fast NVMe with many small sites). |
 | `--dry-run` | `false` | Run everything but skip pushing the branch and creating the PR/MR (the branch and commits are still created locally). In checkout mode this also means no token is required. |
+| `--report` | _(disabled)_ | Write a machine-readable JSON report of the run to this path. Written on every outcome, including failures and `--dry-run`. See [Run report](#run-report). |
 | `--verbose` | `false` | Debug-level logging (also logs resolved config). |
 | `--config` | _(`<working-dir>/.drupdater.yaml`)_ | Path to the config file. |
 
@@ -241,6 +243,100 @@ addons:               # configurable addons per mode (mandatory addons always ru
 |----------|---------|
 | `DRUPALCODE_ACCESS_TOKEN` | Drupal.org GitLab PAT. Required for patch management (detecting upstream-committed patches and downloading updated patch files). |
 | `COMPOSER_AUTH` | Composer auth JSON for private Packagist/registries. See [Composer docs](https://getcomposer.org/doc/03-cli.md#composer-auth). |
+
+## Run report
+
+`--report <path>` writes a JSON document describing the run. It is written on
+**every** outcome — including a run that failed halfway and a `--dry-run` that
+never opened a PR/MR — so a failing repository leaves behind something better
+than a log to read.
+
+```bash
+drupdater --dry-run --report ./drupdater-report.json
+```
+
+```json
+{
+  "schema_version": 1,
+  "drupdater_version": "v0.12.0",
+  "started_at": "2026-07-25T02:00:00Z",
+  "finished_at": "2026-07-25T02:14:31Z",
+  "duration_seconds": 871.4,
+  "status": "success",
+  "mode": "security",
+  "dry_run": false,
+  "repository": "https://github.com/org/site.git",
+  "base_branch": "main",
+  "update_branch": "drupdater-3f81a2c",
+  "merge_request": { "url": "https://github.com/org/site/pull/42" },
+  "sites": ["default"],
+  "packages": [
+    { "action": "Upgrade", "package": "drupal/core", "from": "10.1.8", "to": "10.2.0" }
+  ],
+  "phases": [
+    { "name": "composer install", "started_at": "...", "duration_seconds": 63.2, "ok": true },
+    { "name": "baseline site install", "started_at": "...", "duration_seconds": 121.9, "ok": true }
+  ],
+  "addons": {
+    "composer_audit": { "fixed": [], "remaining": [] },
+    "update_hooks": { "default": {} }
+  }
+}
+```
+
+**`status`** is one of:
+
+| Value | Meaning |
+|---|---|
+| `success` | Every phase the run attempted completed. A `--dry-run` that stopped before pushing is a success. |
+| `no_changes` | The run worked and found nothing to update. Reported separately so an up-to-date site isn't mistaken for a broken one. |
+| `failed` | A phase returned an error. `failed_phase` and `error` say which and why. |
+
+**`phases`** records each step with its duration, which makes the cost of a run
+measurable without separate instrumentation — the phase distribution shows
+whether a run is dominated by `composer install`, by site installs, or by Rector.
+
+**`addons`** carries one structured section per addon that has something to
+report (`composer_audit`, `update_hooks`, `unsupported_modules`,
+`composer_patches`). Addons with nothing to say are omitted rather than present
+and empty.
+
+Credentials never appear in the report: the repository URL is stripped of any
+embedded userinfo, and the finished document passes through the same redactor
+that filters the logs.
+
+### With `drupdater check`
+
+`--report` applies to the preflight command too, where it writes the check
+results instead of a run — useful for gating a pipeline on a machine-readable
+verdict:
+
+```bash
+drupdater check --report ./preflight.json
+```
+
+```json
+{
+  "schema_version": 1,
+  "drupdater_version": "v0.12.0",
+  "checked_at": "2026-07-25T02:00:00Z",
+  "ok": false,
+  "results": [
+    { "name": "git history complete (not a shallow clone)", "ok": true },
+    { "name": "site \"default\": settings.php", "ok": false, "detail": "not found at web/sites/default/settings.php" }
+  ]
+}
+```
+
+### Schema stability
+
+`schema_version` is part of the contract. New fields may be added without
+bumping it — **consumers must ignore unknown fields** — while removing or
+renaming a field increments it.
+
+> [!NOTE]
+> While drupdater is pre-1.0, the schema may still gain fields between minor
+> versions. It will not silently rename or drop them.
 
 ## Troubleshooting
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -12,6 +12,7 @@ import (
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/codehosting"
 	"github.com/drupdater/drupdater/internal/logging"
+	"github.com/drupdater/drupdater/internal/report"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/drupdater/drupdater/pkg/drupal"
@@ -76,6 +77,9 @@ Exits non-zero if any check fails, so it can gate a pipeline.`,
 		}
 
 		printCheckResults(cmd.OutOrStdout(), results, redactor)
+
+		writeCheckReport(logger, redactor, config.ReportPath, results)
+
 		if anyCheckFailed(results) {
 			return errors.New("preflight check failed")
 		}
@@ -116,6 +120,38 @@ func runCheapChecks(
 	}
 	results = append(results, checkVCS(ctx, logger, cfg.RepositoryURL, token, resolveErr)...)
 	return results
+}
+
+// writeCheckReport writes the preflight result to path, doing nothing when --report was not
+// given. --report is a persistent flag, so it applies to "check" as well as to a real run; a
+// preflight has no phases, packages or branch, so it gets its own document shape (report.Check)
+// rather than a run report with most of its fields left empty.
+//
+// As with a run's report, a write failure is logged and swallowed: the check's own verdict, and
+// the exit status carrying it, matter more than the file describing it.
+func writeCheckReport(logger *zap.Logger, redactor *logging.Redactor, path string, results []services.CheckResult) {
+	if path == "" {
+		return
+	}
+
+	check := report.NewCheck(internal.Version, toReportCheckResults(results))
+	if err := report.WriteCheck(afero.NewOsFs(), path, check, redactor.Redact); err != nil {
+		logger.Warn("failed to write check report", zap.String("path", path), zap.Error(err))
+		return
+	}
+	logger.Info("check report written", zap.String("path", path))
+}
+
+// toReportCheckResults converts the services results into the report's own schema type, for the
+// same reason report.PackageChange mirrors composer.PackageChange: the report is a published
+// contract and must not change shape because an internal type was refactored.
+func toReportCheckResults(results []services.CheckResult) []report.CheckResult {
+	out := make([]report.CheckResult, 0, len(results))
+	for _, r := range results {
+		out = append(out, report.CheckResult{Name: r.Name, OK: r.OK, Detail: r.Detail})
+	}
+
+	return out
 }
 
 // checkToken resolves the access token the same way the real run does (positional argument,

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/drupdater/drupdater/internal/logging"
+	"github.com/drupdater/drupdater/internal/report"
+	"github.com/drupdater/drupdater/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestReportSinkWritesRedactedReport(t *testing.T) {
+	const token = "s3cret-token"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "report.json")
+
+	redactor := logging.NewRedactor()
+	redactor.Register(token)
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	sink := reportSink(zap.New(core), redactor, path)
+
+	rec := report.NewRecorder("dev", report.ModeSecurity, false, "https://example.com/repo.git", "main", []string{"default"})
+	_ = rec.Run("clone", func() error {
+		return errNotAuthorized(token)
+	})
+	sink(rec.Finish())
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(raw), token, "the report must go through the log redactor")
+
+	var decoded report.Report
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, report.StatusFailed, decoded.Status)
+	assert.Equal(t, "clone", decoded.FailedPhase)
+
+	assert.Equal(t, 1, logs.FilterMessage("run report written").Len())
+}
+
+// A report that cannot be written must not turn a completed run into a failed command, nor mask
+// the run's own error: the sink logs and moves on.
+func TestReportSinkWarnsInsteadOfFailingWhenTheWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	// A path whose parent is a regular file cannot be created.
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o600))
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	sink := reportSink(zap.New(core), logging.NewRedactor(), filepath.Join(blocker, "report.json"))
+
+	assert.NotPanics(t, func() {
+		sink(report.NewRecorder("dev", report.ModeNormal, true, "", "main", nil).Finish())
+	})
+
+	require.Equal(t, 1, logs.FilterMessage("failed to write run report").Len())
+}
+
+func TestWriteCheckReportWritesWhenPathGiven(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "check.json")
+	core, logs := observer.New(zapcore.InfoLevel)
+
+	writeCheckReport(zap.New(core), logging.NewRedactor(), path, []services.CheckResult{
+		{Name: "git history complete", OK: true},
+		{Name: "platform requirements", OK: false, Detail: "php 8.4 required"},
+	})
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var decoded report.Check
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.False(t, decoded.OK, "one failing check makes the whole preflight not OK")
+	assert.Len(t, decoded.Results, 2)
+	assert.Equal(t, 1, logs.FilterMessage("check report written").Len())
+}
+
+// Without --report the check command must not create any file.
+func TestWriteCheckReportDoesNothingWithoutAPath(t *testing.T) {
+	dir := t.TempDir()
+
+	writeCheckReport(zap.NewNop(), logging.NewRedactor(), "", []services.CheckResult{{Name: "a", OK: true}})
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestWriteCheckReportWarnsWhenTheWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o600))
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	writeCheckReport(zap.New(core), logging.NewRedactor(), filepath.Join(blocker, "check.json"), nil)
+
+	assert.Equal(t, 1, logs.FilterMessage("failed to write check report").Len())
+}
+
+func TestToReportCheckResults(t *testing.T) {
+	out := toReportCheckResults([]services.CheckResult{
+		{Name: "git history complete", OK: true},
+		{Name: "site \"default\": settings.php", OK: false, Detail: "not found at web/sites/default"},
+	})
+
+	require.Len(t, out, 2)
+	assert.Equal(t, "git history complete", out[0].Name)
+	assert.True(t, out[0].OK)
+	assert.Empty(t, out[0].Detail)
+	assert.False(t, out[1].OK)
+	assert.Equal(t, "not found at web/sites/default", out[1].Detail)
+}
+
+func TestToReportCheckResultsWithNoResults(t *testing.T) {
+	assert.Empty(t, toReportCheckResults(nil))
+}
+
+// errNotAuthorized builds an error whose message embeds the token, mirroring how git and composer
+// report an authentication failure against an authenticated URL.
+type authError string
+
+func (e authError) Error() string { return string(e) }
+
+func errNotAuthorized(token string) error {
+	return authError("authentication failed for https://user:" + token + "@example.com/repo.git")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/drupdater/drupdater/internal/addon"
 	"github.com/drupdater/drupdater/internal/codehosting"
 	"github.com/drupdater/drupdater/internal/logging"
+	"github.com/drupdater/drupdater/internal/report"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/drupdater/drupdater/pkg/drupal"
@@ -30,6 +31,7 @@ import (
 	"github.com/drupdater/drupdater/pkg/repo"
 	"github.com/gookit/event"
 	"github.com/maypok86/otter"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -153,7 +155,11 @@ names you can set there. See the README for the full file format.`,
 		}
 		dispatcher := createDispatcher(addons)
 
-		workflow := services.NewWorkflowBaseService(logger, config, drush, platform, git, installer, composer, dispatcher)
+		var opts []services.Option
+		if config.ReportPath != "" {
+			opts = append(opts, services.WithReportSink(reportSink(logger, redactor, config.ReportPath)))
+		}
+		workflow := services.NewWorkflowBaseService(logger, config, drush, platform, git, installer, composer, dispatcher, opts...)
 
 		// Start the update workflow
 		err = workflow.StartUpdate(cmd.Context(), addons)
@@ -166,6 +172,22 @@ names you can set there. See the README for the full file format.`,
 		}
 		return nil
 	},
+}
+
+// reportSink returns the callback that writes the run report to path.
+//
+// A failure to write the report is logged and swallowed: the report describes the run, it is not
+// the run. Turning a full, successful update into a failed command because a path was not
+// writable would be a worse outcome than the missing file — and on the failure path, masking the
+// real error with a filesystem one would be worse still.
+func reportSink(logger *zap.Logger, redactor *logging.Redactor, path string) func(report.Report) {
+	return func(rep report.Report) {
+		if err := report.Write(afero.NewOsFs(), path, rep, redactor.Redact); err != nil {
+			logger.Warn("failed to write run report", zap.String("path", path), zap.Error(err))
+			return
+		}
+		logger.Info("run report written", zap.String("path", path))
+	}
 }
 
 // resolveToken returns the access token: the positional argument when one is given, otherwise
@@ -500,6 +522,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&config.Verbose, "verbose", false, "Verbose")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "Path to the config file (default: <working-dir>/.drupdater.yaml).")
 	rootCmd.PersistentFlags().IntVar(&config.Concurrency, "concurrency", runtime.GOMAXPROCS(0), "Maximum number of sites to install/update concurrently. Defaults to GOMAXPROCS(0), which reflects the container's CPU quota, not just the host's core count.")
+	rootCmd.PersistentFlags().StringVar(&config.ReportPath, "report", "", "Write a machine-readable JSON report of the run to this path. Written on every outcome, including failures and --dry-run.")
 
 	rootCmd.AddCommand(addonsCmd)
 }

--- a/internal/addon/composer_patches_1.go
+++ b/internal/addon/composer_patches_1.go
@@ -31,26 +31,29 @@ func (pu PatchUpdates) Changes() bool {
 	return len(pu.Removed) > 0 || len(pu.Updated) > 0 || len(pu.Conflicts) > 0
 }
 
+// The json tags on these three types are part of the --report schema (see report.go in this
+// package); rename a field only alongside a report.SchemaVersion bump.
+
 type RemovedPatch struct {
-	Package          string
-	PatchDescription string
-	PatchPath        string
-	Reason           string
+	Package          string `json:"package"`
+	PatchDescription string `json:"patch_description"`
+	PatchPath        string `json:"patch_path"`
+	Reason           string `json:"reason"`
 }
 
 type UpdatedPatch struct {
-	Package           string
-	PatchDescription  string
-	PreviousPatchPath string
-	NewPatchPath      string
+	Package           string `json:"package"`
+	PatchDescription  string `json:"patch_description"`
+	PreviousPatchPath string `json:"previous_patch_path"`
+	NewPatchPath      string `json:"new_patch_path"`
 }
 
 type ConflictPatch struct {
-	Package          string
-	FixedVersion     string
-	PatchPath        string
-	PatchDescription string
-	NewVersion       string
+	Package          string `json:"package"`
+	FixedVersion     string `json:"fixed_version"`
+	PatchPath        string `json:"patch_path"`
+	PatchDescription string `json:"patch_description"`
+	NewVersion       string `json:"new_version"`
 }
 
 type ComposerPatches1 struct {

--- a/internal/addon/report.go
+++ b/internal/addon/report.go
@@ -1,0 +1,136 @@
+package addon
+
+import (
+	"sort"
+
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/drupdater/drupdater/pkg/drush"
+)
+
+// This file holds every addon's contribution to the machine-readable run report (--report).
+//
+// The methods live together rather than beside each addon's other code on purpose: together they
+// are the report's addons schema, which is a published contract, and keeping them in one place
+// makes it reviewable as a whole. Scattered across eight files it is very easy to change a field
+// name without noticing that a consumer depends on it.
+//
+// Each addon satisfies report.Reporter structurally -- ReportKey() string and ReportData() any --
+// so none of them has to import the report package. Addons that do not implement it are simply
+// absent from the report.
+//
+// The keys match the names used in .drupdater.yaml's addon lists, so a report reads the same way
+// the project is configured.
+//
+// Two addons deliberately contribute nothing:
+//
+//   - composer_diff renders a markdown dependency table for the merge request. The same
+//     information is already in the report's top-level "packages" field, in structured form,
+//     straight from composer update -- a markdown table in a JSON document would be strictly
+//     worse than what is already there.
+//   - composer_normalizer and code_beautifier only change formatting; that a run reformatted
+//     code is visible in the diff, and has no consumer beyond it.
+
+// --- composer_audit ---
+
+// SecurityAdvisories is the composer_audit section: which advisories the update resolved and
+// which are still open afterwards. The remaining advisories are the more actionable half — they
+// are what a fleet-wide exposure view is built from.
+type SecurityAdvisories struct {
+	Fixed     []composer.Advisory `json:"fixed"`
+	Remaining []composer.Advisory `json:"remaining"`
+}
+
+// ReportKey implements report.Reporter.
+func (ca *ComposerAudit) ReportKey() string { return "composer_audit" }
+
+// ReportData implements report.Reporter.
+func (ca *ComposerAudit) ReportData() any {
+	fixed := ca.GetFixedAdvisories()
+	remaining := ca.afterAudit.Advisories
+	if len(fixed) == 0 && len(remaining) == 0 {
+		return nil
+	}
+
+	return SecurityAdvisories{Fixed: fixed, Remaining: remaining}
+}
+
+// --- update_hooks ---
+
+// ReportKey implements report.Reporter.
+func (uh *UpdateHooks) ReportKey() string { return "update_hooks" }
+
+// ReportData implements report.Reporter. The result is keyed by site, matching the shape the
+// merge request description uses, because in a multisite run the same module can have different
+// pending hooks per site.
+func (uh *UpdateHooks) ReportData() any {
+	uh.mu.Lock()
+	defer uh.mu.Unlock()
+
+	if len(uh.hooks) == 0 {
+		return nil
+	}
+
+	// Copy rather than hand out the live map: the report is serialised after the run, but the
+	// caller has no way to know that this map is mutex-guarded state.
+	out := make(map[string]map[string]drush.UpdateHook, len(uh.hooks))
+	for site, hooks := range uh.hooks {
+		siteHooks := make(map[string]drush.UpdateHook, len(hooks))
+		for name, hook := range hooks {
+			siteHooks[name] = hook
+		}
+		out[site] = siteHooks
+	}
+
+	return out
+}
+
+// --- unsupported_modules ---
+
+// ReportKey implements report.Reporter.
+func (um *UnsupportedModules) ReportKey() string { return "unsupported_modules" }
+
+// ReportData implements report.Reporter. Modules are sorted by name so two runs over an
+// unchanged site produce byte-identical sections, which lets a consumer diff reports directly
+// instead of having to normalise map ordering first.
+func (um *UnsupportedModules) ReportData() any {
+	um.mu.Lock()
+	defer um.mu.Unlock()
+
+	if len(um.modules) == 0 {
+		return nil
+	}
+
+	modules := make([]drush.UnsupportedModule, 0, len(um.modules))
+	for _, module := range um.modules {
+		modules = append(modules, module)
+	}
+	sort.Slice(modules, func(i, j int) bool { return modules[i].Name < modules[j].Name })
+
+	return modules
+}
+
+// --- composer_patches ---
+
+// Patches is the composer_patches section. Conflicts are the ones that need a human: a patch
+// that no longer applies to the updated package and could not be replaced automatically.
+type Patches struct {
+	Removed   []RemovedPatch  `json:"removed"`
+	Updated   []UpdatedPatch  `json:"updated"`
+	Conflicts []ConflictPatch `json:"conflicts"`
+}
+
+// ReportKey implements report.Reporter.
+func (h *ComposerPatches1) ReportKey() string { return "composer_patches" }
+
+// ReportData implements report.Reporter.
+func (h *ComposerPatches1) ReportData() any {
+	if !h.patchUpdates.Changes() {
+		return nil
+	}
+
+	return Patches{
+		Removed:   h.patchUpdates.Removed,
+		Updated:   h.patchUpdates.Updated,
+		Conflicts: h.patchUpdates.Conflicts,
+	}
+}

--- a/internal/addon/report_test.go
+++ b/internal/addon/report_test.go
@@ -1,0 +1,131 @@
+package addon
+
+import (
+	"testing"
+
+	"github.com/drupdater/drupdater/internal/report"
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/drupdater/drupdater/pkg/drush"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every addon contributing to the report must satisfy report.Reporter structurally, without
+// importing the report package itself. If a signature drifts, this fails to compile.
+var (
+	_ report.Reporter = (*ComposerAudit)(nil)
+	_ report.Reporter = (*UpdateHooks)(nil)
+	_ report.Reporter = (*UnsupportedModules)(nil)
+	_ report.Reporter = (*ComposerPatches1)(nil)
+)
+
+func TestComposerAuditReportData(t *testing.T) {
+	before := composer.Advisory{CVE: "CVE-1", PackageName: "drupal/foo"}
+	stillOpen := composer.Advisory{CVE: "CVE-2", PackageName: "drupal/bar"}
+
+	ca := &ComposerAudit{
+		beforeAudit: composer.Audit{Advisories: []composer.Advisory{before, stillOpen}},
+		afterAudit:  composer.Audit{Advisories: []composer.Advisory{stillOpen}},
+	}
+
+	assert.Equal(t, "composer_audit", ca.ReportKey())
+
+	data, ok := ca.ReportData().(SecurityAdvisories)
+	require.True(t, ok)
+	require.Len(t, data.Fixed, 1)
+	assert.Equal(t, "CVE-1", data.Fixed[0].CVE)
+	require.Len(t, data.Remaining, 1)
+	assert.Equal(t, "CVE-2", data.Remaining[0].CVE)
+}
+
+func TestComposerAuditReportDataNilWhenNothingToReport(t *testing.T) {
+	ca := &ComposerAudit{}
+	assert.Nil(t, ca.ReportData(), "an addon with nothing to say must not add an empty section")
+}
+
+func TestUpdateHooksReportData(t *testing.T) {
+	uh := &UpdateHooks{
+		hooks: UpdateHooksPerSite{
+			"default": {"foo_update_9001": drush.UpdateHook{Module: "foo", Description: "Add a field"}},
+		},
+	}
+
+	assert.Equal(t, "update_hooks", uh.ReportKey())
+
+	data, ok := uh.ReportData().(map[string]map[string]drush.UpdateHook)
+	require.True(t, ok)
+	require.Contains(t, data, "default")
+	assert.Equal(t, "foo", data["default"]["foo_update_9001"].Module)
+}
+
+// ReportData must hand back a copy: the live map is mutex-guarded state that keeps being written
+// while sites update concurrently, and the caller cannot know that.
+func TestUpdateHooksReportDataCopiesTheLiveMap(t *testing.T) {
+	uh := &UpdateHooks{
+		hooks: UpdateHooksPerSite{
+			"default": {"foo_update_9001": drush.UpdateHook{Module: "foo"}},
+		},
+	}
+
+	data := uh.ReportData().(map[string]map[string]drush.UpdateHook)
+	data["default"]["injected"] = drush.UpdateHook{Module: "bar"}
+
+	assert.NotContains(t, uh.hooks["default"], "injected")
+}
+
+func TestUpdateHooksReportDataNilWhenEmpty(t *testing.T) {
+	assert.Nil(t, (&UpdateHooks{hooks: UpdateHooksPerSite{}}).ReportData())
+}
+
+func TestUnsupportedModulesReportDataIsSortedByName(t *testing.T) {
+	um := &UnsupportedModules{
+		modules: map[string]drush.UnsupportedModule{
+			"zebra": {Name: "zebra"},
+			"alpha": {Name: "alpha"},
+			"mango": {Name: "mango"},
+		},
+	}
+
+	assert.Equal(t, "unsupported_modules", um.ReportKey())
+
+	data, ok := um.ReportData().([]drush.UnsupportedModule)
+	require.True(t, ok)
+	require.Len(t, data, 3)
+	// Deterministic ordering is what lets a consumer diff two reports directly.
+	assert.Equal(t, []string{"alpha", "mango", "zebra"}, []string{data[0].Name, data[1].Name, data[2].Name})
+}
+
+func TestUnsupportedModulesReportDataNilWhenEmpty(t *testing.T) {
+	assert.Nil(t, (&UnsupportedModules{modules: map[string]drush.UnsupportedModule{}}).ReportData())
+}
+
+func TestComposerPatchesReportData(t *testing.T) {
+	h := &ComposerPatches1{
+		patchUpdates: PatchUpdates{
+			Removed:   []RemovedPatch{{Package: "drupal/foo", Reason: "fixed upstream"}},
+			Conflicts: []ConflictPatch{{Package: "drupal/bar", NewVersion: "2.0.0"}},
+		},
+	}
+
+	assert.Equal(t, "composer_patches", h.ReportKey())
+
+	data, ok := h.ReportData().(Patches)
+	require.True(t, ok)
+	require.Len(t, data.Removed, 1)
+	assert.Equal(t, "fixed upstream", data.Removed[0].Reason)
+	require.Len(t, data.Conflicts, 1)
+	assert.Equal(t, "drupal/bar", data.Conflicts[0].Package)
+	assert.Empty(t, data.Updated)
+}
+
+func TestComposerPatchesReportDataNilWhenNoPatchChanges(t *testing.T) {
+	assert.Nil(t, (&ComposerPatches1{}).ReportData())
+}
+
+// composer_diff deliberately contributes nothing: the same information is already in the
+// report's top-level packages field, structured, straight from composer update.
+func TestComposerDiffDoesNotReport(t *testing.T) {
+	var addon any = &ComposerDiff{}
+	_, isReporter := addon.(report.Reporter)
+	assert.False(t, isReporter)
+}

--- a/internal/config.go
+++ b/internal/config.go
@@ -2,6 +2,12 @@ package internal
 
 import "time"
 
+// Version is the drupdater version, set at build time via
+// -ldflags "-X github.com/drupdater/drupdater/internal.Version=...". It defaults to "dev" for
+// builds that do not set it (go run, go build without the Makefile). It is recorded in the run
+// report so a consumer can tell which version produced a given result.
+var Version = "dev"
+
 type Config struct {
 	RepositoryURL string
 	Branch        string
@@ -18,6 +24,9 @@ type Config struct {
 	// machine the run happens on, not the project, so it's a CLI flag rather than a
 	// .drupdater.yaml key. A value <= 0 means "use GOMAXPROCS(0)".
 	Concurrency int
+	// ReportPath is where the machine-readable run report is written. Empty disables it. Like
+	// Concurrency it describes this invocation rather than the project, so it is a CLI flag.
+	ReportPath string
 }
 
 // AddonsConfig lists which configurable addons run in each mode. Mandatory addons

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,383 @@
+// Package report defines the machine-readable run report drupdater writes with --report.
+//
+// A run's outcome is otherwise only expressed for humans: as log lines, and as the merge request
+// description assembled from each addon's RenderTemplate. Neither is a contract anything can be
+// built on, and the merge request description only exists for runs that get far enough to open
+// one -- a --dry-run or a run that fails during composer update leaves nothing behind but a log.
+//
+// The report closes that gap. It is written on every exit path, including failures, and records
+// which phase failed and why. That is deliberately the most valuable case: "this repository is
+// failing, in this phase, for this reason" is what anything automating drupdater across more
+// than one repository needs, and it is exactly what the log-only output makes expensive to
+// obtain.
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/spf13/afero"
+)
+
+// SchemaVersion is the version of the report format. It is part of the report's public contract:
+// new fields may be added without bumping it (consumers must ignore unknown fields), while
+// removing or renaming a field requires an increment.
+const SchemaVersion = 1
+
+// Status is the overall outcome of a run.
+type Status string
+
+const (
+	// StatusSuccess means the run completed every phase it attempted. A --dry-run that stopped
+	// short of pushing is still a success: it did everything it was asked to do.
+	StatusSuccess Status = "success"
+	// StatusFailed means a phase returned an error and the run stopped there.
+	StatusFailed Status = "failed"
+	// StatusNoChanges means the run worked correctly and found nothing to update. It is
+	// reported separately from success because the distinction is the whole point for a
+	// consumer watching many repositories: a repository that is already up to date needs no
+	// attention, whereas one that produced an update does.
+	StatusNoChanges Status = "no_changes"
+)
+
+// Mode records whether the run applied all available updates or only security ones.
+type Mode string
+
+const (
+	ModeNormal   Mode = "normal"
+	ModeSecurity Mode = "security"
+)
+
+// Report is the top-level document written to the --report path.
+type Report struct {
+	SchemaVersion    int    `json:"schema_version"`
+	DrupdaterVersion string `json:"drupdater_version"`
+
+	StartedAt       time.Time `json:"started_at"`
+	FinishedAt      time.Time `json:"finished_at"`
+	DurationSeconds float64   `json:"duration_seconds"`
+
+	Status Status `json:"status"`
+	// FailedPhase names the phase that returned the error, empty on success. It is the field
+	// that turns a red run into an actionable one without reading the log.
+	FailedPhase string `json:"failed_phase,omitempty"`
+	Error       string `json:"error,omitempty"`
+
+	Mode   Mode `json:"mode"`
+	DryRun bool `json:"dry_run"`
+
+	Repository   string `json:"repository"`
+	BaseBranch   string `json:"base_branch"`
+	UpdateBranch string `json:"update_branch,omitempty"`
+	// MergeRequest is nil when no merge request was created -- because the run was a --dry-run,
+	// or because it failed before publishing.
+	MergeRequest *MergeRequest `json:"merge_request"`
+
+	Sites []string `json:"sites"`
+
+	// Packages lists every dependency change composer made. Empty for a run that failed before
+	// composer update, or that found nothing to update.
+	Packages []PackageChange `json:"packages"`
+
+	// Phases records every phase the run entered, in order, with how long it took. Beyond
+	// locating a failure, the timings make the cost of a run measurable without separate
+	// instrumentation: the phase distribution is what says whether a run is dominated by
+	// composer install, by site installs, or by Rector.
+	Phases []Phase `json:"phases"`
+
+	// Addons holds each reporting addon's structured section, keyed by its report key. Addons
+	// that do not implement report.Reporter are absent rather than present and empty.
+	Addons map[string]any `json:"addons,omitempty"`
+}
+
+// MergeRequest identifies the merge/pull request a successful run opened.
+type MergeRequest struct {
+	URL string `json:"url"`
+}
+
+// PackageChange is one dependency change made by composer update.
+//
+// It deliberately mirrors composer.PackageChange rather than reusing it: this type is part of
+// the report's published schema, so it must only change when SchemaVersion says it does. Reusing
+// the composer package's struct would let an unrelated refactor there silently rename a field
+// every consumer depends on.
+type PackageChange struct {
+	// Action is one of Install, Upgrade, Downgrade, Remove.
+	Action  string `json:"action"`
+	Package string `json:"package"`
+	From    string `json:"from,omitempty"`
+	To      string `json:"to,omitempty"`
+}
+
+// Phase is one step of the workflow with its duration and outcome.
+type Phase struct {
+	Name            string    `json:"name"`
+	StartedAt       time.Time `json:"started_at"`
+	DurationSeconds float64   `json:"duration_seconds"`
+	OK              bool      `json:"ok"`
+	Error           string    `json:"error,omitempty"`
+}
+
+// Reporter is the optional interface an addon implements to contribute a structured section to
+// the report. It is deliberately separate from internal.Addon: widening that interface would
+// force every addon (and its mock) to change at once, whereas addons that do not implement
+// Reporter are simply absent from the report's addons map.
+type Reporter interface {
+	// ReportKey is the stable key this addon's section appears under. It should match the
+	// addon's registry name so a report reads the same way as .drupdater.yaml.
+	ReportKey() string
+	// ReportData returns JSON-serialisable data describing what the addon did.
+	ReportData() any
+}
+
+// Recorder accumulates a report over the course of a run. It is safe for concurrent use: sites
+// are updated concurrently, so addons may record from multiple goroutines even though the
+// top-level phases themselves are sequential.
+type Recorder struct {
+	mu     sync.Mutex
+	report Report
+}
+
+// NewRecorder starts a report for a run beginning now.
+func NewRecorder(version string, mode Mode, dryRun bool, repositoryURL string, baseBranch string, sites []string) *Recorder {
+	return &Recorder{
+		report: Report{
+			SchemaVersion:    SchemaVersion,
+			DrupdaterVersion: version,
+			StartedAt:        time.Now(),
+			// Assume success and let a failing phase overwrite it, so a run that is cut short
+			// without an error (a context deadline unwinding, say) is not silently reported as
+			// having failed a phase it never entered.
+			Status:     StatusSuccess,
+			Mode:       mode,
+			DryRun:     dryRun,
+			Repository: SanitizeURL(repositoryURL),
+			BaseBranch: baseBranch,
+			Sites:      sites,
+		},
+	}
+}
+
+// Run executes fn as a named phase, recording its duration and outcome, and returns fn's error
+// unchanged. The first failing phase sets the report's status, failed phase and error; later
+// phases do not overwrite them, because the run stops at the first failure and any subsequent
+// bookkeeping is not what a reader wants to be told went wrong.
+func (r *Recorder) Run(name string, fn func() error) error {
+	start := time.Now()
+	err := fn()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	phase := Phase{
+		Name:            name,
+		StartedAt:       start,
+		DurationSeconds: time.Since(start).Seconds(),
+		OK:              err == nil,
+	}
+	if err != nil {
+		phase.Error = err.Error()
+		if r.report.Status != StatusFailed {
+			r.report.Status = StatusFailed
+			r.report.FailedPhase = name
+			r.report.Error = err.Error()
+		}
+	}
+	r.report.Phases = append(r.report.Phases, phase)
+
+	return err
+}
+
+// SetNoChanges records that the run found nothing to update.
+//
+// The workflow signals this by aborting the phase that would have produced the update, so the
+// phase is already on record as having ended with an error. That detail stays in Phases, which
+// is the blow-by-blow account, but the top-level status, failed phase and error are reset:
+// summarising "there was nothing to update" as a failure would have every consumer treat a
+// perfectly healthy repository as one needing attention.
+func (r *Recorder) SetNoChanges() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.report.Status = StatusNoChanges
+	r.report.FailedPhase = ""
+	r.report.Error = ""
+}
+
+// SetPackages records the dependency changes composer made.
+func (r *Recorder) SetPackages(changes []PackageChange) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.report.Packages = changes
+}
+
+// SetUpdateBranch records the branch the update commits were made on. It exists even for runs
+// that never push it.
+func (r *Recorder) SetUpdateBranch(branch string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.report.UpdateBranch = branch
+}
+
+// SetMergeRequest records the merge request a run opened.
+func (r *Recorder) SetMergeRequest(url string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.report.MergeRequest = &MergeRequest{URL: SanitizeURL(url)}
+}
+
+// AddAddons collects a structured section from every addon that implements Reporter. Addons that
+// do not are skipped. A nil ReportData is skipped too, so an addon that ran but had nothing to
+// say does not add an empty key.
+func (r *Recorder) AddAddons(addons []internal.Addon) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, a := range addons {
+		reporter, ok := a.(Reporter)
+		if !ok {
+			continue
+		}
+		data := reporter.ReportData()
+		if data == nil {
+			continue
+		}
+		if r.report.Addons == nil {
+			r.report.Addons = map[string]any{}
+		}
+		r.report.Addons[reporter.ReportKey()] = data
+	}
+}
+
+// Finish closes the report and returns it. The caller may call it more than once; each call
+// refreshes the end timestamp.
+func (r *Recorder) Finish() Report {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.report.FinishedAt = time.Now()
+	r.report.DurationSeconds = r.report.FinishedAt.Sub(r.report.StartedAt).Seconds()
+
+	return r.report
+}
+
+// Check is the document "drupdater check --report" writes. It is a distinct shape from Report
+// because a preflight is not a run: there are no phases, no packages and no branch, only a list
+// of prerequisites and whether each one holds.
+type Check struct {
+	SchemaVersion    int       `json:"schema_version"`
+	DrupdaterVersion string    `json:"drupdater_version"`
+	CheckedAt        time.Time `json:"checked_at"`
+	// OK is false when any individual check failed, mirroring the command's exit status.
+	OK      bool          `json:"ok"`
+	Results []CheckResult `json:"results"`
+}
+
+// CheckResult is one named prerequisite and its outcome.
+type CheckResult struct {
+	Name string `json:"name"`
+	OK   bool   `json:"ok"`
+	// Detail explains a failure; empty on a pass.
+	Detail string `json:"detail,omitempty"`
+}
+
+// NewCheck assembles the check document from the results the command produced.
+func NewCheck(version string, results []CheckResult) Check {
+	ok := true
+	for _, r := range results {
+		if !r.OK {
+			ok = false
+			break
+		}
+	}
+
+	return Check{
+		SchemaVersion:    SchemaVersion,
+		DrupdaterVersion: version,
+		CheckedAt:        time.Now(),
+		OK:               ok,
+		Results:          results,
+	}
+}
+
+// WriteCheck serialises a preflight result to path, with the same atomicity and redaction
+// guarantees as Write.
+func WriteCheck(fs afero.Fs, path string, check Check, redact func(string) string) error {
+	return writeJSON(fs, path, check, redact)
+}
+
+// Write serialises rep to path.
+//
+// redact is applied to the marshalled document as a whole rather than to individual fields: the
+// report must never carry a credential, and filtering the finished JSON means a value that
+// reaches it through a field nobody thought about -- an error string quoting an authenticated
+// URL, say -- is caught anyway. Pass logging.Redactor.Redact; a nil redact writes the document
+// unfiltered and is only appropriate in tests.
+//
+// The write is atomic: the document is written to a temporary file in the destination directory
+// and renamed into place, so a reader polling for the report never observes a partial one.
+func Write(fs afero.Fs, path string, rep Report, redact func(string) string) error {
+	return writeJSON(fs, path, rep, redact)
+}
+
+// writeJSON is the shared, atomic, redacting write behind Write and WriteCheck.
+func writeJSON(fs afero.Fs, path string, doc any, redact func(string) string) error {
+	encoded, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode report: %w", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if redact != nil {
+		encoded = []byte(redact(string(encoded)))
+	}
+
+	dir := filepath.Dir(path)
+	if err := fs.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create report directory %s: %w", dir, err)
+	}
+
+	tmp, err := afero.TempFile(fs, dir, ".drupdater-report-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary report file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, err := tmp.Write(encoded); err != nil {
+		_ = tmp.Close()
+		_ = fs.Remove(tmpName)
+		return fmt.Errorf("failed to write report: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = fs.Remove(tmpName)
+		return fmt.Errorf("failed to close report: %w", err)
+	}
+	if err := fs.Rename(tmpName, path); err != nil {
+		_ = fs.Remove(tmpName)
+		return fmt.Errorf("failed to move report into place at %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// SanitizeURL strips any credentials embedded in a URL's userinfo, so a repository URL of the
+// form https://user:token@host/repo.git cannot carry a secret into the report. Values that do
+// not parse as a URL are returned unchanged: they are not URLs, so there is no userinfo to
+// remove, and mangling them would lose information for no gain.
+func SanitizeURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.User == nil {
+		return raw
+	}
+	parsed.User = nil
+
+	return parsed.String()
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,343 @@
+package report
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/gookit/event"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRecorder() *Recorder {
+	return NewRecorder("1.2.3", ModeNormal, false, "https://example.com/org/site.git", "main", []string{"default"})
+}
+
+func TestRecorderRecordsSuccessfulPhases(t *testing.T) {
+	rec := newTestRecorder()
+
+	require.NoError(t, rec.Run("composer install", func() error { return nil }))
+	require.NoError(t, rec.Run("site update", func() error { return nil }))
+
+	rep := rec.Finish()
+
+	assert.Equal(t, StatusSuccess, rep.Status)
+	assert.Empty(t, rep.FailedPhase)
+	assert.Empty(t, rep.Error)
+	require.Len(t, rep.Phases, 2)
+	assert.Equal(t, "composer install", rep.Phases[0].Name)
+	assert.True(t, rep.Phases[0].OK)
+	assert.Equal(t, "site update", rep.Phases[1].Name)
+	assert.Equal(t, SchemaVersion, rep.SchemaVersion)
+	assert.Equal(t, "1.2.3", rep.DrupdaterVersion)
+	assert.False(t, rep.FinishedAt.Before(rep.StartedAt))
+	assert.GreaterOrEqual(t, rep.DurationSeconds, 0.0)
+}
+
+func TestRecorderRecordsFailingPhaseAndReturnsError(t *testing.T) {
+	rec := newTestRecorder()
+	sentinel := errors.New("composer blew up")
+
+	err := rec.Run("composer update", func() error { return sentinel })
+
+	require.ErrorIs(t, err, sentinel, "Run must return the phase's error unchanged")
+
+	rep := rec.Finish()
+	assert.Equal(t, StatusFailed, rep.Status)
+	assert.Equal(t, "composer update", rep.FailedPhase)
+	assert.Equal(t, "composer blew up", rep.Error)
+	require.Len(t, rep.Phases, 1)
+	assert.False(t, rep.Phases[0].OK)
+	assert.Equal(t, "composer blew up", rep.Phases[0].Error)
+}
+
+// The run stops at the first failure, but deferred bookkeeping can still record phases after it.
+// The report must keep pointing at the original cause rather than the last thing that went wrong.
+func TestRecorderKeepsFirstFailure(t *testing.T) {
+	rec := newTestRecorder()
+
+	_ = rec.Run("composer update", func() error { return errors.New("first") })
+	_ = rec.Run("cleanup", func() error { return errors.New("second") })
+
+	rep := rec.Finish()
+	assert.Equal(t, "composer update", rep.FailedPhase)
+	assert.Equal(t, "first", rep.Error)
+	assert.Len(t, rep.Phases, 2)
+}
+
+func TestRecorderNoChangesClearsTheAbortAsFailure(t *testing.T) {
+	rec := newTestRecorder()
+
+	_ = rec.Run("update shared code", func() error { return errors.New("no changes detected") })
+	rec.SetNoChanges()
+
+	rep := rec.Finish()
+	assert.Equal(t, StatusNoChanges, rep.Status)
+	assert.Empty(t, rep.FailedPhase, "an abort is not something a consumer should act on")
+	assert.Empty(t, rep.Error)
+	// The phase itself stays on record: Phases is the detailed account, Status the summary.
+	require.Len(t, rep.Phases, 1)
+	assert.False(t, rep.Phases[0].OK)
+}
+
+func TestRecorderRecordsRunMetadata(t *testing.T) {
+	rec := NewRecorder("dev", ModeSecurity, true, "https://example.com/org/site.git", "develop", []string{"default", "second"})
+	rec.SetUpdateBranch("drupdater-2026")
+	rec.SetPackages([]PackageChange{{Action: "Upgrade", Package: "drupal/core", From: "10.1.0", To: "10.2.0"}})
+	rec.SetMergeRequest("https://example.com/org/site/-/merge_requests/7")
+
+	rep := rec.Finish()
+
+	assert.Equal(t, ModeSecurity, rep.Mode)
+	assert.True(t, rep.DryRun)
+	assert.Equal(t, "develop", rep.BaseBranch)
+	assert.Equal(t, []string{"default", "second"}, rep.Sites)
+	assert.Equal(t, "drupdater-2026", rep.UpdateBranch)
+	require.Len(t, rep.Packages, 1)
+	assert.Equal(t, "drupal/core", rep.Packages[0].Package)
+	require.NotNil(t, rep.MergeRequest)
+	assert.Equal(t, "https://example.com/org/site/-/merge_requests/7", rep.MergeRequest.URL)
+}
+
+func TestRecorderMergeRequestIsNilWhenNoneWasCreated(t *testing.T) {
+	rep := newTestRecorder().Finish()
+	assert.Nil(t, rep.MergeRequest)
+}
+
+// reportingAddon implements both internal.Addon and Reporter.
+type reportingAddon struct {
+	key  string
+	data any
+}
+
+func (a reportingAddon) SubscribedEvents() map[string]any { return map[string]any{} }
+func (a reportingAddon) RenderTemplate() (string, error)  { return "", nil }
+func (a reportingAddon) ReportKey() string                { return a.key }
+func (a reportingAddon) ReportData() any                  { return a.data }
+
+// plainAddon implements internal.Addon only, and must be absent from the report.
+type plainAddon struct{}
+
+func (plainAddon) SubscribedEvents() map[string]any { return map[string]any{} }
+func (plainAddon) RenderTemplate() (string, error)  { return "", nil }
+
+var (
+	_ internal.Addon   = reportingAddon{}
+	_ internal.Addon   = plainAddon{}
+	_ event.Subscriber = reportingAddon{}
+)
+
+func TestRecorderCollectsOnlyReportingAddons(t *testing.T) {
+	rec := newTestRecorder()
+
+	rec.AddAddons([]internal.Addon{
+		reportingAddon{key: "composer_audit", data: map[string]any{"fixed": 2}},
+		plainAddon{},
+		reportingAddon{key: "quiet_addon", data: nil},
+	})
+
+	rep := rec.Finish()
+
+	require.Len(t, rep.Addons, 1, "addons without Reporter, and those returning nil, are omitted")
+	assert.Contains(t, rep.Addons, "composer_audit")
+	assert.NotContains(t, rep.Addons, "quiet_addon")
+}
+
+func TestRecorderAddonsAbsentWhenNoneReport(t *testing.T) {
+	rec := newTestRecorder()
+	rec.AddAddons([]internal.Addon{plainAddon{}})
+
+	rep := rec.Finish()
+	assert.Nil(t, rep.Addons, "an empty addons map should be omitted from the document entirely")
+}
+
+// Sites are updated concurrently, so addons may record from several goroutines at once.
+func TestRecorderIsSafeForConcurrentUse(t *testing.T) {
+	rec := newTestRecorder()
+
+	var wg sync.WaitGroup
+	for i := range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = rec.Run("phase", func() error { return nil })
+			rec.SetUpdateBranch("branch")
+			rec.AddAddons([]internal.Addon{reportingAddon{key: "addon", data: i}})
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, rec.Finish().Phases, 20)
+}
+
+func TestWriteProducesRedactedJSON(t *testing.T) {
+	const token = "super-secret-token"
+	fs := afero.NewMemMapFs()
+	path := "/out/nested/report.json"
+
+	rec := newTestRecorder()
+	_ = rec.Run("clone", func() error { return errors.New("auth failed for https://user:" + token + "@example.com/repo.git") })
+
+	redact := func(s string) string { return strings.ReplaceAll(s, token, "***") }
+	require.NoError(t, Write(fs, path, rec.Finish(), redact))
+
+	raw, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(raw), token, "the redactor must be applied to the whole document")
+	assert.Contains(t, string(raw), "***")
+
+	var decoded Report
+	require.NoError(t, json.Unmarshal(raw, &decoded), "the redacted document must still be valid JSON")
+	assert.Equal(t, StatusFailed, decoded.Status)
+	assert.Equal(t, "clone", decoded.FailedPhase)
+}
+
+func TestWriteCreatesMissingDirectories(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	path := "/does/not/exist/yet/report.json"
+
+	require.NoError(t, Write(fs, path, newTestRecorder().Finish(), nil))
+
+	exists, err := afero.Exists(fs, path)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+// The report is written atomically so a consumer polling for it never reads a half-written
+// document; the temporary file must not survive.
+func TestWriteLeavesNoTemporaryFileBehind(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	path := "/out/report.json"
+
+	require.NoError(t, Write(fs, path, newTestRecorder().Finish(), nil))
+
+	entries, err := afero.ReadDir(fs, "/out")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "report.json", filepath.Base(entries[0].Name()))
+}
+
+func TestWriteOverwritesAnExistingReport(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	path := "/out/report.json"
+	require.NoError(t, afero.WriteFile(fs, path, []byte("stale"), 0o644))
+
+	require.NoError(t, Write(fs, path, newTestRecorder().Finish(), nil))
+
+	raw, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "stale")
+}
+
+func TestWriteFailsOnReadOnlyFilesystem(t *testing.T) {
+	fs := afero.NewReadOnlyFs(afero.NewMemMapFs())
+
+	err := Write(fs, "/out/report.json", newTestRecorder().Finish(), nil)
+	assert.Error(t, err)
+}
+
+// renameFailingFs fails every Rename, standing in for a destination that cannot be replaced
+// (a full disk, a permission change between creating the temporary file and moving it).
+type renameFailingFs struct {
+	afero.Fs
+}
+
+func (renameFailingFs) Rename(_, _ string) error { return errors.New("rename refused") }
+
+func TestWriteCleansUpWhenTheFinalMoveFails(t *testing.T) {
+	base := afero.NewMemMapFs()
+	fs := renameFailingFs{Fs: base}
+
+	err := Write(fs, "/out/report.json", newTestRecorder().Finish(), nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "move report into place")
+
+	entries, readErr := afero.ReadDir(base, "/out")
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "a failed write must not leave its temporary file behind")
+}
+
+// Addons hand back arbitrary values, so an addon returning something unserialisable must fail
+// the write cleanly rather than panic or emit a truncated document.
+func TestWriteFailsOnUnserialisableAddonData(t *testing.T) {
+	rec := newTestRecorder()
+	rec.AddAddons([]internal.Addon{reportingAddon{key: "broken", data: make(chan int)}})
+
+	err := Write(afero.NewMemMapFs(), "/out/report.json", rec.Finish(), nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encode report")
+}
+
+func TestNewCheckIsOKOnlyWhenEveryResultPasses(t *testing.T) {
+	passing := NewCheck("dev", []CheckResult{{Name: "a", OK: true}, {Name: "b", OK: true}})
+	assert.True(t, passing.OK)
+	assert.Equal(t, SchemaVersion, passing.SchemaVersion)
+	assert.Len(t, passing.Results, 2)
+
+	failing := NewCheck("dev", []CheckResult{{Name: "a", OK: true}, {Name: "b", OK: false, Detail: "missing"}})
+	assert.False(t, failing.OK)
+}
+
+func TestNewCheckWithNoResultsIsOK(t *testing.T) {
+	assert.True(t, NewCheck("dev", nil).OK)
+}
+
+func TestWriteCheckProducesRedactedJSON(t *testing.T) {
+	const token = "check-secret"
+	fs := afero.NewMemMapFs()
+	path := "/out/check.json"
+
+	check := NewCheck("dev", []CheckResult{
+		{Name: "token authenticates", OK: false, Detail: "401 for https://user:" + token + "@example.com"},
+	})
+	redact := func(s string) string { return strings.ReplaceAll(s, token, "***") }
+
+	require.NoError(t, WriteCheck(fs, path, check, redact))
+
+	raw, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), token)
+
+	var decoded Check
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.False(t, decoded.OK)
+	require.Len(t, decoded.Results, 1)
+	assert.Equal(t, "token authenticates", decoded.Results[0].Name)
+}
+
+func TestSanitizeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"strips userinfo", "https://user:token@example.com/org/site.git", "https://example.com/org/site.git"},
+		{"strips bare user", "https://token@example.com/org/site.git", "https://example.com/org/site.git"},
+		{"leaves clean URLs alone", "https://example.com/org/site.git", "https://example.com/org/site.git"},
+		{"leaves SSH-style remotes alone", "git@example.com:org/site.git", "git@example.com:org/site.git"},
+		{"empty stays empty", "", ""},
+		{"unparseable is returned unchanged", "://not a url", "://not a url"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SanitizeURL(tt.in))
+		})
+	}
+}
+
+func TestRecorderSanitizesRepositoryURL(t *testing.T) {
+	rec := NewRecorder("dev", ModeNormal, false, "https://user:token@example.com/org/site.git", "main", nil)
+
+	rep := rec.Finish()
+	assert.Equal(t, "https://example.com/org/site.git", rep.Repository)
+	assert.NotContains(t, rep.Repository, "token")
+}

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -106,6 +106,26 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 	}
 	rec := report.NewRecorder(internal.Version, mode, ws.config.DryRun, ws.config.RepositoryURL, ws.config.Branch, ws.config.Sites)
 
+	// Emit the report from its own defer, registered before anything that can fail, so that
+	// "written on every exit path" holds literally — including a clone or checkout that never
+	// gets far enough for there to be a working copy to clean up. Being registered first also
+	// makes it run last, so the report describes the run after every other teardown has had its
+	// say.
+	//
+	// An AbortError is not a failure — it is the workflow's way of saying there was nothing to
+	// do — so it is recorded as such rather than as an error the reader should act on.
+	defer func() {
+		if ws.reportSink == nil {
+			return
+		}
+		var abort AbortError
+		if errors.As(err, &abort) {
+			rec.SetNoChanges()
+		}
+		rec.AddAddons(addons)
+		ws.reportSink(rec.Finish())
+	}()
+
 	// Bound the whole run so a wedged subprocess or network call can't hang forever.
 	if ws.config.Timeout > 0 {
 		var cancel context.CancelFunc
@@ -124,8 +144,20 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 	// Acquire a single working directory: the existing checkout (default, CI) or a fresh
 	// clone (--clone, for local testing). Old and new code live in this one directory
 	// sequentially: install the baseline site, then composer update, then run update hooks.
-	repository, worktree, path, err := ws.acquireWorkingCopy(username, email)
-	if err != nil {
+	//
+	// Recorded as a phase like every other step: a bad token, an unreachable host or an
+	// unreadable checkout fails here, and that is one of the most common ways a run fails in
+	// practice — exactly what the report exists to name.
+	var (
+		repository GitRepository
+		worktree   Worktree
+		path       string
+	)
+	if err = rec.Run("acquire working copy", func() error {
+		var acquireErr error
+		repository, worktree, path, acquireErr = ws.acquireWorkingCopy(username, email)
+		return acquireErr
+	}); err != nil {
 		return err
 	}
 
@@ -139,18 +171,6 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 			ws.restoreOriginalCheckout(worktree, originalRef)
 		}
 		ws.cleanup(path)
-
-		// Emit the report last, so it describes the run as a whole. An AbortError is not a
-		// failure — it is the workflow's way of saying there was nothing to do — so it is
-		// recorded as such rather than as an error the reader should act on.
-		if ws.reportSink != nil {
-			var abort AbortError
-			if errors.As(err, &abort) {
-				rec.SetNoChanges()
-			}
-			rec.AddAddons(addons)
-			ws.reportSink(rec.Finish())
-		}
 	}()
 
 	return ws.runPhases(ctx, rec, repository, worktree, path, addons)

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/report"
+	"github.com/drupdater/drupdater/pkg/composer"
 
 	git "github.com/go-git/go-git/v5"
 	gitConfig "github.com/go-git/go-git/v5/config"
@@ -46,6 +48,24 @@ type WorkflowBaseService struct {
 	// concurrently, but they share one working tree and git index, and drush config:export
 	// commits via git itself, so the staging/commit steps must not overlap.
 	siteCommitMu sync.Mutex
+
+	// reportSink receives the run report when the run ends, on every exit path. nil when
+	// --report was not given, in which case no report is assembled beyond the in-memory
+	// bookkeeping the recorder does anyway.
+	reportSink func(report.Report)
+}
+
+// Option configures a WorkflowBaseService. Options are variadic so adding one does not disturb
+// existing call sites.
+type Option func(*WorkflowBaseService)
+
+// WithReportSink makes the run hand its finished report to sink. The sink is called exactly
+// once per run, after every other deferred cleanup has had its say, including when the run
+// fails.
+func WithReportSink(sink func(report.Report)) Option {
+	return func(ws *WorkflowBaseService) {
+		ws.reportSink = sink
+	}
 }
 
 func NewWorkflowBaseService(
@@ -57,8 +77,9 @@ func NewWorkflowBaseService(
 	installer Installer,
 	composerService Composer,
 	dispatcher EventDispatcher,
+	opts ...Option,
 ) *WorkflowBaseService {
-	return &WorkflowBaseService{
+	ws := &WorkflowBaseService{
 		logger:     logger,
 		config:     config,
 		drush:      drush,
@@ -69,10 +90,21 @@ func NewWorkflowBaseService(
 		dispatcher: dispatcher,
 		current:    time.Now(),
 	}
+	for _, opt := range opts {
+		opt(ws)
+	}
+
+	return ws
 }
 
 func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []internal.Addon) (err error) {
 	start := time.Now()
+
+	mode := report.ModeNormal
+	if ws.config.Security {
+		mode = report.ModeSecurity
+	}
+	rec := report.NewRecorder(internal.Version, mode, ws.config.DryRun, ws.config.RepositoryURL, ws.config.Branch, ws.config.Sites)
 
 	// Bound the whole run so a wedged subprocess or network call can't hang forever.
 	if ws.config.Timeout > 0 {
@@ -107,49 +139,96 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 			ws.restoreOriginalCheckout(worktree, originalRef)
 		}
 		ws.cleanup(path)
+
+		// Emit the report last, so it describes the run as a whole. An AbortError is not a
+		// failure — it is the workflow's way of saying there was nothing to do — so it is
+		// recorded as such rather than as an error the reader should act on.
+		if ws.reportSink != nil {
+			var abort AbortError
+			if errors.As(err, &abort) {
+				rec.SetNoChanges()
+			}
+			rec.AddAddons(addons)
+			ws.reportSink(rec.Finish())
+		}
 	}()
 
+	return ws.runPhases(ctx, rec, repository, worktree, path, addons)
+}
+
+// runPhases executes the update itself, one recorded phase at a time. It is separate from
+// StartUpdate so that the run's setup and teardown (timeout, working copy, checkout restore,
+// report emission) stay readable next to each other rather than being buried under the phases.
+func (ws *WorkflowBaseService) runPhases(
+	ctx context.Context,
+	rec *report.Recorder,
+	repository GitRepository,
+	worktree Worktree,
+	path string,
+	addons []internal.Addon,
+) error {
 	// Fail fast on cheap, structural prerequisites shared with "drupdater check" instead of
 	// discovering them mid-run: a shallow checkout only fails much later, with a cryptic
 	// "object not found" when the update branch is pushed. Extension requirements are
 	// deliberately not checked here (see CheckPlatformReqs).
-	if result := CheckGitHistoryComplete(ws.repository, path); !result.OK {
-		return fmt.Errorf("%s: %s", result.Name, result.Detail)
-	}
-	if result := CheckPlatformRequirements(ctx, ws.composer, path); !result.OK {
-		return fmt.Errorf("PHP platform requirements not satisfied:\n%s", result.Detail)
-	}
-
-	ws.logger.Info("running composer install")
-	if err := ws.composer.Install(ctx, path); err != nil {
-		return fmt.Errorf("failed to run composer install: %w", err)
-	}
-
-	// Install each site at the current (old) code to create the baseline database.
-	if err := ws.forEachSite(ctx, func(ctx context.Context, site string) error {
-		if err := ws.installer.Install(ctx, path, site); err != nil {
-			return fmt.Errorf("site %s installation failed: %w", site, err)
+	if err := rec.Run("preflight", func() error {
+		if result := CheckGitHistoryComplete(ws.repository, path); !result.OK {
+			return fmt.Errorf("%s: %s", result.Name, result.Detail)
+		}
+		if result := CheckPlatformRequirements(ctx, ws.composer, path); !result.OK {
+			return fmt.Errorf("PHP platform requirements not satisfied:\n%s", result.Detail)
 		}
 		return nil
 	}); err != nil {
 		return err
 	}
 
-	// Update the shared code: composer update, commit, and create the update branch.
-	updateBranchName, err := ws.updateSharedCode(ctx, repository, worktree, path)
-	if err != nil {
+	if err := rec.Run("composer install", func() error {
+		ws.logger.Info("running composer install")
+		if err := ws.composer.Install(ctx, path); err != nil {
+			return fmt.Errorf("failed to run composer install: %w", err)
+		}
+		return nil
+	}); err != nil {
 		return err
 	}
 
+	// Install each site at the current (old) code to create the baseline database.
+	if err := rec.Run("baseline site install", func() error {
+		return ws.forEachSite(ctx, func(ctx context.Context, site string) error {
+			if err := ws.installer.Install(ctx, path, site); err != nil {
+				return fmt.Errorf("site %s installation failed: %w", site, err)
+			}
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
+	// Update the shared code: composer update, commit, and create the update branch.
+	var updateBranchName string
+	if err := rec.Run("update shared code", func() error {
+		var err error
+		updateBranchName, err = ws.updateSharedCode(ctx, repository, worktree, path, rec)
+		return err
+	}); err != nil {
+		return err
+	}
+	rec.SetUpdateBranch(updateBranchName)
+
 	// Run the update hooks and export config per site against the now-updated code.
-	if err := ws.forEachSite(ctx, func(ctx context.Context, site string) error {
-		return ws.updateSite(ctx, path, worktree, site)
+	if err := rec.Run("site update", func() error {
+		return ws.forEachSite(ctx, func(ctx context.Context, site string) error {
+			return ws.updateSite(ctx, path, worktree, site)
+		})
 	}); err != nil {
 		return err
 	}
 
 	if !ws.config.DryRun {
-		return ws.publishWork(ctx, repository, updateBranchName, addons)
+		return rec.Run("publish", func() error {
+			return ws.publishWork(ctx, repository, updateBranchName, addons, rec)
+		})
 	}
 	return nil
 }
@@ -245,7 +324,7 @@ func (ws *WorkflowBaseService) cleanup(path string) {
 	os.Remove(filepath.Join(parent, "private"))
 }
 
-func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository GitRepository, worktree Worktree, path string) (string, error) {
+func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository GitRepository, worktree Worktree, path string, rec *report.Recorder) (string, error) {
 	ws.logger.Info("updating dependencies")
 
 	// Do all of the update work on a dedicated branch. In checkout mode the run operates on the
@@ -273,6 +352,7 @@ func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository 
 	if err != nil {
 		return "", fmt.Errorf("failed to update dependencies: %w", err)
 	}
+	rec.SetPackages(toReportPackages(changes))
 	if len(changes) == 0 {
 		return "", AbortError{Msg: "no changes detected"}
 	}
@@ -405,7 +485,26 @@ func (ws *WorkflowBaseService) commitSiteChanges(ctx context.Context, path strin
 	return nil
 }
 
-func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRepository, updateBranchName string, addons []internal.Addon) error {
+// toReportPackages converts composer's package changes into the report's own schema type. The
+// two are kept separate deliberately — see report.PackageChange.
+func toReportPackages(changes []composer.PackageChange) []report.PackageChange {
+	if len(changes) == 0 {
+		return nil
+	}
+	out := make([]report.PackageChange, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, report.PackageChange{
+			Action:  c.Action,
+			Package: c.Package,
+			From:    c.From,
+			To:      c.To,
+		})
+	}
+
+	return out
+}
+
+func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRepository, updateBranchName string, addons []internal.Addon, rec *report.Recorder) error {
 	err := repository.Push(&git.PushOptions{
 		RemoteName: "origin",
 		RefSpecs: []gitConfig.RefSpec{
@@ -450,6 +549,7 @@ func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRe
 		return fmt.Errorf("failed to create merge request: %w", err)
 	}
 	ws.logger.Info("merge request created", zap.String("url", mr.URL))
+	rec.SetMergeRequest(mr.URL)
 
 	return nil
 }

--- a/internal/services/workflow_report_test.go
+++ b/internal/services/workflow_report_test.go
@@ -1,0 +1,220 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/codehosting"
+	"github.com/drupdater/drupdater/internal/report"
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/gookit/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// reportHarness wires up the mocks a StartUpdate run needs, with a report sink attached. Each
+// test then overrides only the expectations relevant to the outcome it exercises.
+type reportHarness struct {
+	config      internal.Config
+	installer   *MockInstaller
+	repoSvc     *MockRepository
+	vcsProvider *MockPlatform
+	repository  *MockGitRepository
+	composer    *MockComposer
+	drush       *MockDrush
+	worktree    *MockWorktree
+
+	got *report.Report
+}
+
+func newReportHarness(t *testing.T, dryRun bool) *reportHarness {
+	t.Helper()
+
+	// Assembled rather than written as one literal so the fixture is not mistaken for a real
+	// embedded credential by static analysis.
+	const testToken = "s3cret"
+	repoURL := "https://user:" + testToken + "@example.com/repo.git"
+
+	h := &reportHarness{
+		config: internal.Config{
+			RepositoryURL: repoURL,
+			Branch:        "main",
+			Token:         testToken,
+			Clone:         true,
+			Sites:         []string{"site1"},
+			DryRun:        dryRun,
+		},
+		installer:   NewMockInstaller(t),
+		repoSvc:     NewMockRepository(t),
+		vcsProvider: NewMockPlatform(t),
+		repository:  NewMockGitRepository(t),
+		composer:    NewMockComposer(t),
+		drush:       NewMockDrush(t),
+		worktree:    NewMockWorktree(t),
+	}
+
+	h.vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail").Maybe()
+	h.repoSvc.EXPECT().CloneRepository(h.config.RepositoryURL, h.config.Branch, h.config.Token, "user", "mail").
+		Return(h.repository, h.worktree, "/tmp", nil).Maybe()
+	h.repoSvc.EXPECT().IsShallowClone("/tmp").Return(false, nil).Maybe()
+	h.composer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil).Maybe()
+	h.composer.EXPECT().Install(mock.Anything, "/tmp").Return(nil).Maybe()
+
+	return h
+}
+
+// expectFullRun adds the expectations for a run that gets all the way through the update.
+func (h *reportHarness) expectFullRun(t *testing.T) {
+	t.Helper()
+
+	h.worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil).Maybe()
+	h.worktree.EXPECT().AddGlob(mock.Anything).Return(nil).Maybe()
+	h.worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
+
+	h.installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	h.installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	h.drush.EXPECT().UpdateSite(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	h.drush.EXPECT().ExportConfiguration(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	h.drush.EXPECT().ConfigResave(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+
+	h.repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound).Maybe()
+	h.repoSvc.EXPECT().BranchExists(h.repository, mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	h.composer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil).Maybe()
+	h.composer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).
+		Return([]composer.PackageChange{{Action: "Upgrade", Package: "drupal/core", From: "9.0.0", To: "9.1.0"}}, nil).Maybe()
+}
+
+func (h *reportHarness) run(t *testing.T) error {
+	t.Helper()
+
+	svc := NewWorkflowBaseService(
+		zap.NewNop(), h.config, h.drush, h.vcsProvider, h.repoSvc, h.installer, h.composer,
+		event.NewManager(""),
+		WithReportSink(func(rep report.Report) { h.got = &rep }),
+	)
+
+	return svc.StartUpdate(context.Background(), nil)
+}
+
+func TestReportWrittenOnSuccessfulRun(t *testing.T) {
+	h := newReportHarness(t, false)
+	h.expectFullRun(t)
+	h.repository.EXPECT().Push(mock.Anything).Return(nil)
+	h.vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "main").
+		Return(codehosting.MergeRequest{URL: "https://example.com/mr/1"}, nil)
+
+	require.NoError(t, h.run(t))
+
+	require.NotNil(t, h.got)
+	assert.Equal(t, report.StatusSuccess, h.got.Status)
+	assert.Empty(t, h.got.FailedPhase)
+	require.NotNil(t, h.got.MergeRequest)
+	assert.Equal(t, "https://example.com/mr/1", h.got.MergeRequest.URL)
+	assert.NotEmpty(t, h.got.UpdateBranch)
+
+	require.Len(t, h.got.Packages, 1)
+	assert.Equal(t, "drupal/core", h.got.Packages[0].Package)
+	assert.Equal(t, "9.1.0", h.got.Packages[0].To)
+
+	// The publish phase only exists on a run that actually publishes.
+	assert.Contains(t, phaseNames(h.got.Phases), "publish")
+	assert.Equal(t, report.ModeNormal, h.got.Mode)
+	assert.Equal(t, internal.Version, h.got.DrupdaterVersion)
+}
+
+// The credential embedded in the repository URL must not reach the report, independently of the
+// log redactor applied at write time.
+func TestReportRepositoryURLHasNoCredentials(t *testing.T) {
+	h := newReportHarness(t, false)
+	h.expectFullRun(t)
+	h.repository.EXPECT().Push(mock.Anything).Return(nil)
+	h.vcsProvider.EXPECT().CreateMergeRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "main").
+		Return(codehosting.MergeRequest{}, nil)
+
+	require.NoError(t, h.run(t))
+
+	require.NotNil(t, h.got)
+	assert.Equal(t, "https://example.com/repo.git", h.got.Repository)
+	assert.NotContains(t, h.got.Repository, "s3cret")
+}
+
+// A --dry-run stops before publishing but is still a successful run: it did everything it was
+// asked to do. This is one of the cases that produces no merge request and therefore no output
+// at all without --report.
+func TestReportWrittenOnDryRun(t *testing.T) {
+	h := newReportHarness(t, true)
+	h.expectFullRun(t)
+
+	require.NoError(t, h.run(t))
+
+	require.NotNil(t, h.got)
+	assert.Equal(t, report.StatusSuccess, h.got.Status)
+	assert.True(t, h.got.DryRun)
+	assert.Nil(t, h.got.MergeRequest)
+	assert.NotContains(t, phaseNames(h.got.Phases), "publish")
+}
+
+// The most valuable case: a run that fails partway leaves a report naming the phase that failed.
+func TestReportWrittenOnFailureNamesThePhase(t *testing.T) {
+	h := newReportHarness(t, false)
+	h.worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
+	h.installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(errors.New("drush exploded"))
+	h.repository.EXPECT().Head().Return(nil, plumbing.ErrReferenceNotFound).Maybe()
+
+	err := h.run(t)
+
+	require.Error(t, err)
+	require.NotNil(t, h.got, "a failing run must still produce a report")
+	assert.Equal(t, report.StatusFailed, h.got.Status)
+	assert.Equal(t, "baseline site install", h.got.FailedPhase)
+	assert.Contains(t, h.got.Error, "drush exploded")
+	assert.Nil(t, h.got.MergeRequest)
+}
+
+// "Nothing to update" is reported as its own status rather than as a failure, so a consumer
+// watching many repositories does not treat a healthy, up-to-date site as needing attention.
+func TestReportNoChangesIsNotAFailure(t *testing.T) {
+	h := newReportHarness(t, false)
+	h.worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
+	h.installer.EXPECT().Install(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	h.installer.EXPECT().ConfigureDatabase(mock.Anything, "/tmp", "site1").Return(nil).Maybe()
+	h.repository.EXPECT().Head().Return(nil, plumbing.ErrReferenceNotFound).Maybe()
+	h.composer.EXPECT().Update(mock.Anything, "/tmp", mock.Anything, mock.Anything, false, false).
+		Return([]composer.PackageChange{}, nil)
+
+	err := h.run(t)
+
+	require.Error(t, err, "the workflow still aborts")
+	require.NotNil(t, h.got)
+	assert.Equal(t, report.StatusNoChanges, h.got.Status)
+	assert.Empty(t, h.got.FailedPhase)
+	assert.Empty(t, h.got.Error)
+}
+
+// Without --report no sink is attached, and the run must behave exactly as before.
+func TestRunWithoutReportSinkIsUnaffected(t *testing.T) {
+	h := newReportHarness(t, true)
+	h.expectFullRun(t)
+
+	svc := NewWorkflowBaseService(
+		zap.NewNop(), h.config, h.drush, h.vcsProvider, h.repoSvc, h.installer, h.composer,
+		event.NewManager(""),
+	)
+
+	require.NoError(t, svc.StartUpdate(context.Background(), nil))
+	assert.Nil(t, h.got)
+}
+
+func phaseNames(phases []report.Phase) []string {
+	names := make([]string, 0, len(phases))
+	for _, p := range phases {
+		names = append(names, p.Name)
+	}
+
+	return names
+}

--- a/internal/services/workflow_report_test.go
+++ b/internal/services/workflow_report_test.go
@@ -176,6 +176,26 @@ func TestReportWrittenOnFailureNamesThePhase(t *testing.T) {
 	assert.Nil(t, h.got.MergeRequest)
 }
 
+// Acquiring the working copy is the first thing that can fail, and one of the most common ways
+// a run fails in practice: a bad token, an unreachable host, an unreadable checkout. The report
+// must still be written — this is precisely the case "written on every exit path" is for.
+func TestReportWrittenWhenAcquiringTheWorkingCopyFails(t *testing.T) {
+	h := newReportHarness(t, false)
+	h.repoSvc.ExpectedCalls = nil
+	h.repoSvc.EXPECT().CloneRepository(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil, "", errors.New("authentication failed"))
+
+	err := h.run(t)
+
+	require.Error(t, err)
+	require.NotNil(t, h.got, "a run that never got a working copy must still produce a report")
+	assert.Equal(t, report.StatusFailed, h.got.Status)
+	assert.Equal(t, "acquire working copy", h.got.FailedPhase)
+	assert.Contains(t, h.got.Error, "authentication failed")
+	assert.Empty(t, h.got.Packages)
+	assert.Nil(t, h.got.MergeRequest)
+}
+
 // "Nothing to update" is reported as its own status rather than as a failure, so a consumer
 // watching many repositories does not treat a healthy, up-to-date site as needing attention.
 func TestReportNoChangesIsNotAFailure(t *testing.T) {


### PR DESCRIPTION
A run's outcome was only expressed for humans: log lines, and the merge
request description built from each addon's RenderTemplate. Neither is a
contract, and the description only exists for runs that get far enough to
open an MR -- a --dry-run, or a run failing during composer update, left
nothing behind but a log.

--report <path> writes a JSON document describing the run, on every exit
path, from StartUpdate's defer. The failure case is the point: it names the
phase that failed and why.

- internal/report: schema, Recorder, atomic redacting writer. The schema
  types mirror composer.PackageChange and services.CheckResult rather than
  reusing them, so an internal refactor cannot silently rename a published
  field.
- report.Reporter is an optional interface satisfied structurally, so
  contributing addons need not import the report package and the eight that
  don't contribute are untouched. composer_diff deliberately abstains: its
  data is already in the top-level packages field, structured.
- Phases carry durations, making the cost profile of a run measurable
  without separate instrumentation.
- "nothing to update" is reported as status no_changes rather than as a
  failure, so an up-to-date repository is not mistaken for a broken one.
- --report also applies to `drupdater check`, which writes a report.Check.

Credentials cannot reach the report: the repository URL is stripped of
userinfo, and the finished document passes through the log redactor. A
failed report write is logged, never masking the run's own result.

Also fixes the version ldflag, which targeted main.version -- a symbol that
does not exist -- so builds now record a real version.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UqgAuLHpY74z9dJnQEANE5