### PR TITLE
Add an end-to-end integration test against a real Drupal site, and fix what it found

### DIFF
--- a/.github/assert-report.jq
+++ b/.github/assert-report.jq
@@ -1,0 +1,54 @@
+# Verifies a drupdater run report against a fixture's expectations.
+#
+#   jq -e --argjson expect "$EXPECT" -f .github/assert-report.jq report.json
+#
+# Gating on .status alone is a smoke test: a run reports success even when an
+# addon failed, because most addons log and swallow their own errors. That is
+# exactly how unsupported_modules stayed silently broken on Drupal 11 -- every
+# run was green while the addon never reported a thing. Asserting that the
+# addons a fixture is built to exercise actually appear in the report is what
+# turns this job from "it did not crash" into "it did what it is for".
+#
+# $expect fields, all optional except status:
+#   status        list of acceptable .status values
+#   min_packages  minimum number of package changes
+#   phases        phase names that must be present AND ok
+#   addons        keys that must appear under .addons
+
+. as $r
+| ($r.addons // {}) as $addons
+| [
+  ( if ($expect.status | index($r.status)) == null
+    then "status: got \"\($r.status)\", want one of \($expect.status | join(", "))"
+       + (if $r.failed_phase
+          then " (failed_phase=\($r.failed_phase): \($r.error // ""))"
+          else "" end)
+    else empty end ),
+
+  ( if ($r.packages | length) < ($expect.min_packages // 0)
+    then "packages: got \($r.packages | length), want at least \($expect.min_packages)"
+    else empty end ),
+
+  ( ($expect.phases // [])[]
+    | . as $name
+    | ($r.phases | map(select(.name == $name))) as $found
+    | if ($found | length) == 0 then "phase missing: \($name)"
+      elif ($found | map(select(.ok)) | length) == 0
+      then "phase not ok: \($name) (\($found[0].error // "no error recorded"))"
+      else empty end ),
+
+  ( ($expect.addons // [])[]
+    | . as $key
+    | if ($addons | has($key)) then empty
+      else "addon reported nothing: \($key) -- present in report: "
+         + (($addons | keys | join(", ")) as $k
+            | if $k == "" then "(none)" else $k end)
+      end ),
+
+  ( if $r.schema_version != 1
+    then "schema_version: got \($r.schema_version), want 1 -- the report contract changed"
+    else empty end )
+]
+| if length == 0 then "report assertions passed"
+  else "report assertions failed:\n  - " + join("\n  - ") | halt_error(1)
+  end

--- a/.github/integration-fixtures.json
+++ b/.github/integration-fixtures.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "drupal-cms",
+    "description": "Drupal CMS, core held a minor behind so every run has updates",
+    "repository_url": "https://github.com/drupdater/test-drupal-cms.git",
+    "branch": "main"
+  }
+]

--- a/.github/integration-fixtures.json
+++ b/.github/integration-fixtures.json
@@ -3,6 +3,34 @@
     "name": "drupal-cms",
     "description": "Drupal CMS, core held a minor behind so every run has updates",
     "repository_url": "https://github.com/drupdater/test-drupal-cms.git",
-    "branch": "main"
+    "branch": "main",
+    "expect": {
+      "normal": {
+        "status": ["success"],
+        "min_packages": 1,
+        "phases": [
+          "acquire working copy",
+          "preflight",
+          "composer install",
+          "baseline site install",
+          "update shared code",
+          "site update"
+        ],
+        "addons": ["update_hooks", "unsupported_modules"]
+      },
+      "security": {
+        "status": ["success"],
+        "min_packages": 1,
+        "phases": [
+          "acquire working copy",
+          "preflight",
+          "composer install",
+          "baseline site install",
+          "update shared code",
+          "site update"
+        ],
+        "addons": ["composer_audit", "update_hooks"]
+      }
+    }
   }
 ]

--- a/.github/integration-fixtures.json
+++ b/.github/integration-fixtures.json
@@ -6,7 +6,9 @@
     "branch": "main",
     "expect": {
       "normal": {
-        "status": ["success"],
+        "status": [
+          "success"
+        ],
         "min_packages": 1,
         "phases": [
           "acquire working copy",
@@ -16,10 +18,18 @@
           "update shared code",
           "site update"
         ],
-        "addons": ["update_hooks", "unsupported_modules"]
+        "addons": [
+          "update_hooks",
+          "unsupported_modules",
+          "code_beautifier",
+          "deprecations_remover",
+          "translations_updater"
+        ]
       },
       "security": {
-        "status": ["success"],
+        "status": [
+          "success"
+        ],
         "min_packages": 1,
         "phases": [
           "acquire working copy",
@@ -29,7 +39,10 @@
           "update shared code",
           "site update"
         ],
-        "addons": ["composer_audit", "update_hooks"]
+        "addons": [
+          "composer_audit",
+          "update_hooks"
+        ]
       }
     }
   }

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -266,7 +266,9 @@ jobs:
             "failed_phase=\(.failed_phase // "-")  error=\(.error // "-")",
             "packages=\(.packages | length)",
             "phases:", (.phases[] | "  \(.name): ok=\(.ok) \(.duration_seconds)s \(.error // "")"),
-            "addons: \(.addons // {} | keys | join(", "))"
+            "addons:",
+            ((.addons // {}) | to_entries[]
+             | "  \(.key): \(.value | tojson | if length > 400 then .[0:400] + " ..." else . end)")
           ' ./run/report.json | tee -a "$GITHUB_STEP_SUMMARY"
           # The container exits 0 on an AbortError ("no changes", "branch already
           # exists") and a run reports success even when an addon logged and

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,16 +1,21 @@
 name: Integration Test
 
-# Runs drupdater end to end against a real Drupal site. The target is
-# drupdater/test-drupal-cms: a Drupal CMS checkout whose composer.lock is
-# deliberately frozen at an old resolution, so every run has something to update.
+# Runs drupdater end to end against real Drupal sites -- fixture repositories
+# whose composer.lock is deliberately frozen at an old resolution, so every run
+# has something to update.
 #
-# Manual on purpose -- a run is a Docker build plus a real Drupal install, far
-# too slow to want on every push, and the unit suite in go.yml covers the rest.
-# Two ways in:
-#   * add the "integration-test" label to a pull request (remove and re-add to
-#     re-run) -- the result shows up as a check on that PR;
-#   * dispatch it from the Actions tab when you want to pick the target,
-#     security mode, or a real non-dry run.
+# Manual on purpose: a single leg is a Docker build plus a real Drupal install,
+# far too slow to want on every push, and the unit suite in go.yml covers the
+# rest. Two ways in:
+#
+#   * add the "integration-test" label to a pull request. Every fixture runs in
+#     both normal and security mode, always as a dry run, and each leg shows up
+#     as its own check on that PR. Remove and re-add the label to re-run.
+#   * dispatch from the Actions tab to aim at one target, pick the mode, or do a
+#     real non-dry run.
+#
+# ADDING A FIXTURE: append an entry to .github/integration-fixtures.json. The
+# label path picks it up automatically -- nothing here needs editing.
 
 on:
   pull_request:
@@ -49,57 +54,96 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # A label event carries none of the workflow_dispatch inputs, so every one of
-  # them needs a fallback. dry_run is the one that matters: unset would read as
-  # "not a dry run", and a label would quietly start pushing branches and
-  # opening merge requests against the target. Only an explicit dispatch can
-  # ever turn it off.
-  TARGET_URL: ${{ inputs.repository_url || 'https://github.com/drupdater/test-drupal-cms.git' }}
-  TARGET_BRANCH: ${{ inputs.branch || 'main' }}
-  IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
-  IN_DRY_RUN: ${{ inputs.dry_run }}
-  IN_SECURITY: ${{ inputs.security }}
-  IN_VERBOSE: ${{ inputs.verbose }}
-
 jobs:
-  integration-test:
-    # Any label would otherwise start a run.
+  # Decides what to run. A label means "everything", a dispatch means "exactly
+  # what I asked for", and keeping that decision in one place stops the matrix
+  # and the run flags from drifting apart.
+  plan:
+    # Without this any label at all would start a run.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.label.name == 'integration-test'
     runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set.outputs.include }}
+      dry_run: ${{ steps.set.outputs.dry_run }}
+      verbose: ${{ steps.set.outputs.verbose }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - id: set
+        env:
+          IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          IN_URL: ${{ inputs.repository_url }}
+          IN_BRANCH: ${{ inputs.branch }}
+          IN_SECURITY: ${{ inputs.security }}
+          IN_DRY_RUN: ${{ inputs.dry_run }}
+          IN_VERBOSE: ${{ inputs.verbose }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_DISPATCH" = "true" ]; then
+            # One leg, exactly as asked.
+            mode=normal; [ "$IN_SECURITY" = "true" ] && mode=security
+            url=${IN_URL:-https://github.com/drupdater/test-drupal-cms.git}
+            include=$(jq -nc \
+              --arg n "$(basename "$url" .git)" \
+              --arg u "$url" \
+              --arg b "${IN_BRANCH:-main}" \
+              --arg m "$mode" \
+              '[{fixture:$n, repository_url:$u, branch:$b, mode:$m}]')
+            dry_run=$IN_DRY_RUN
+            verbose=$IN_VERBOSE
+          else
+            # A label means every fixture in both modes. The two exercise
+            # different code paths -- security mode is driven by composer_audit
+            # and updates only what has an advisory -- so one passing says
+            # nothing about the other.
+            include=$(jq -c '[ .[] as $f | ("normal","security") as $m |
+              {fixture:$f.name, repository_url:$f.repository_url, branch:$f.branch, mode:$m} ]' \
+              .github/integration-fixtures.json)
+            # A label event carries none of the inputs above, and an unset
+            # dry_run would read as "not a dry run" -- a label would then quietly
+            # push branches and open merge requests against the fixtures. Only an
+            # explicit dispatch can turn it off.
+            dry_run=true
+            verbose=false
+          fi
+          {
+            echo "include=$include"
+            echo "dry_run=$dry_run"
+            echo "verbose=$verbose"
+          } >> "$GITHUB_OUTPUT"
+          echo "### Integration test plan" >> "$GITHUB_STEP_SUMMARY"
+          echo "dry_run=\`$dry_run\`" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '.[] | "- \(.fixture) / \(.mode) -- \(.repository_url)@\(.branch)"' \
+            <<<"$include" >> "$GITHUB_STEP_SUMMARY"
+
+  integration-test:
+    needs: plan
+    name: ${{ matrix.fixture }} / ${{ matrix.mode }}
+    runs-on: ubuntu-latest
     timeout-minutes: 75
     permissions:
       contents: read
+    strategy:
+      # One fixture or mode failing must not hide the state of the others.
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.include) }}
+    env:
+      TARGET_URL: ${{ matrix.repository_url }}
+      TARGET_BRANCH: ${{ matrix.branch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Resolve run mode
-        id: mode
-        run: |
-          # A label-triggered run is always a dry run; see the env block above.
-          if [ "$IS_DISPATCH" = "true" ]; then
-            dry_run=$IN_DRY_RUN; security=$IN_SECURITY; verbose=$IN_VERBOSE
-          else
-            dry_run=true; security=false; verbose=false
-          fi
-          {
-            echo "dry_run=$dry_run"
-            echo "security=$security"
-            echo "verbose=$verbose"
-          } >> "$GITHUB_OUTPUT"
-          echo "target=$TARGET_URL@$TARGET_BRANCH dry_run=$dry_run security=$security" \
-            >> "$GITHUB_STEP_SUMMARY"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # One version, no matrix: this job proves drupdater works against a real
-      # site, not that Drupal runs on every PHP release. 8.4 has to match the
-      # target's config.platform.php -- its lock is resolved for 8.4.1 and pulls
-      # in Symfony 8, which will not install on anything earlier.
+      # One version, no matrix over PHP: this job proves drupdater works against
+      # a real site, not that Drupal runs on every PHP release. 8.4 has to match
+      # the target's config.platform.php -- its lock is resolved for 8.4.1 and
+      # pulls in Symfony 8, which will not install on anything earlier.
       - name: Build Docker image
         uses: docker/build-push-action@v7
         with:
@@ -112,11 +156,11 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Delete stale update branches
-        if: steps.mode.outputs.dry_run != 'true'
+        if: needs.plan.outputs.dry_run != 'true'
         env:
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
         run: |
-          # The target's composer.lock is frozen, so the update branch name
+          # A fixture's composer.lock is frozen, so the update branch name
           # (update-<lock content-hash>) is stable across runs. Left behind, it
           # makes the next real run abort with "branch already exists", which
           # reports as no_changes and exit 0 -- a green run that tested nothing.
@@ -152,14 +196,14 @@ jobs:
           # needing none, so running it with an empty one keeps that promise tested.
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
           DRUPALCODE_ACCESS_TOKEN: ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
-          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
-          SECURITY: ${{ steps.mode.outputs.security }}
-          VERBOSE: ${{ steps.mode.outputs.verbose }}
+          DRY_RUN: ${{ needs.plan.outputs.dry_run }}
+          VERBOSE: ${{ needs.plan.outputs.verbose }}
+          MODE: ${{ matrix.mode }}
         run: |
           args=(--working-dir /workspace/project --report /workspace/report.json)
-          [ "$DRY_RUN" = "true" ]  && args+=(--dry-run)
-          [ "$SECURITY" = "true" ] && args+=(--security)
-          [ "$VERBOSE" = "true" ]  && args+=(--verbose)
+          [ "$DRY_RUN" = "true" ]    && args+=(--dry-run)
+          [ "$MODE" = "security" ]   && args+=(--security)
+          [ "$VERBOSE" = "true" ]    && args+=(--verbose)
           docker run --rm \
             -e DRUPALCODE_ACCESS_TOKEN \
             -v "$(pwd)/run:/workspace" \
@@ -174,6 +218,7 @@ jobs:
           # and upload-artifact get EACCES until the runner owns it back.
           sudo chown -R "$(id -u):$(id -g)" ./run || true
           test -f ./run/report.json || { echo "::error::no run report was written"; exit 1; }
+          echo "### ${{ matrix.fixture }} / ${{ matrix.mode }}" >> "$GITHUB_STEP_SUMMARY"
           jq -r '
             "status=\(.status)  mode=\(.mode)  dry_run=\(.dry_run)",
             "failed_phase=\(.failed_phase // "-")  error=\(.error // "-")",
@@ -183,13 +228,14 @@ jobs:
           ' ./run/report.json | tee -a "$GITHUB_STEP_SUMMARY"
           # The container exits 0 on an AbortError ("no changes", "branch already
           # exists"), so exit status alone is not a verdict -- gate on the report.
+          # no_changes is legitimate in security mode when nothing has an advisory.
           jq -e '.status == "success" or .status == "no_changes"' ./run/report.json > /dev/null
 
       - name: Upload run report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: drupdater-report
+          name: drupdater-report-${{ matrix.fixture }}-${{ matrix.mode }}
           path: ./run/report.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,27 +1,25 @@
 name: Integration Test
 
+# Runs drupdater end to end against a real Drupal site. The target is
+# drupdater/test-drupal-cms: a Drupal CMS checkout whose composer.lock is
+# deliberately frozen at an old resolution, so every run has something to update.
+#
+# Manual only, on purpose. Dispatch it from the branch of a PR whose change
+# warrants an end-to-end check; the unit suite in go.yml covers everything else.
+
 on:
   workflow_dispatch:
     inputs:
       repository_url:
         description: 'Drupal project repository URL'
-        required: true
+        required: false
+        default: 'https://github.com/drupdater/test-drupal-cms.git'
         type: string
       branch:
         description: 'Target branch in the project repository'
         required: false
         default: 'main'
         type: string
-      php_version:
-        description: 'PHP version'
-        required: false
-        default: '8.3'
-        type: choice
-        options:
-          - '8.2'
-          - '8.3'
-          - '8.4'
-          - '8.5'
       dry_run:
         description: 'Skip branch and MR creation'
         required: false
@@ -45,6 +43,7 @@ concurrency:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     permissions:
       contents: read
     steps:
@@ -54,6 +53,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # Drupal CMS is Drupal 11, which requires PHP 8.3+. One version, no matrix:
+      # this job proves drupdater works against a real site, not that Drupal runs
+      # on every PHP release.
       - name: Build Docker image
         uses: docker/build-push-action@v7
         with:
@@ -61,9 +63,28 @@ jobs:
           load: true
           tags: drupdater:test
           build-args: |
-            PHP_VERSION=${{ inputs.php_version }}
+            PHP_VERSION=8.3
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Delete stale update branches
+        if: ${{ !inputs.dry_run }}
+        env:
+          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
+          REPOSITORY_URL: ${{ inputs.repository_url }}
+        run: |
+          # The target's composer.lock is frozen, so the update branch name
+          # (update-<lock content-hash>) is stable across runs. Left behind, it
+          # makes the next real run abort with "branch already exists", which
+          # reports as no_changes and exit 0 -- a green run that tested nothing.
+          git ls-remote --heads \
+            "$(echo "$REPOSITORY_URL" | sed "s#https://#https://oauth2:$REPO_TOKEN@#")" \
+            'refs/heads/update-*' | awk '{print $2}' | sed 's#refs/heads/##' \
+            | while read -r ref; do
+                echo "deleting stale branch $ref"
+                git push "$(echo "$REPOSITORY_URL" | sed "s#https://#https://oauth2:$REPO_TOKEN@#")" \
+                  --delete "$ref"
+              done
 
       - name: Clone project
         env:
@@ -71,20 +92,56 @@ jobs:
           REPOSITORY_URL: ${{ inputs.repository_url }}
           BRANCH: ${{ inputs.branch }}
         run: |
+          # ./run is the mount root, the project a level below it. drupdater
+          # writes <site>.sqlite and private/ into the checkout's PARENT
+          # (pkg/drupal/installer.go), so the parent has to be a real directory
+          # we control -- mounting the checkout itself at /workspace puts them
+          # in the container's /.
+          mkdir -p ./run
+          # No --depth: drupdater's preflight rejects a shallow checkout
+          # ("git history complete"), and a shallow clone cannot be pushed.
           git -c credential.helper='!f(){ echo username=oauth2; echo "password=$REPO_TOKEN"; };f' \
-            clone --branch "$BRANCH" --depth 1 "$REPOSITORY_URL" ./drupal-project
+            clone --branch "$BRANCH" "$REPOSITORY_URL" ./run/project
 
       - name: Run drupdater
         env:
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
+          DRUPALCODE_ACCESS_TOKEN: ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
           SECURITY: ${{ inputs.security }}
           VERBOSE: ${{ inputs.verbose }}
         run: |
-          args=(--working-dir /workspace)
-          [ "$DRY_RUN" = "true" ] && args+=(--dry-run)
+          args=(--working-dir /workspace/project --report /workspace/report.json)
+          [ "$DRY_RUN" = "true" ]  && args+=(--dry-run)
           [ "$SECURITY" = "true" ] && args+=(--security)
-          [ "$VERBOSE" = "true" ] && args+=(--verbose)
+          [ "$VERBOSE" = "true" ]  && args+=(--verbose)
           docker run --rm \
-            -v "$(pwd)/drupal-project:/workspace" \
+            -e DRUPALCODE_ACCESS_TOKEN \
+            -v "$(pwd)/run:/workspace" \
             drupdater:test "$REPO_TOKEN" "${args[@]}"
+
+      # The report is written on every exit path, so this runs even when the
+      # container failed -- a failed run's report is the one worth reading.
+      - name: Summarise run report
+        if: always()
+        run: |
+          test -f ./run/report.json || { echo "::error::no run report was written"; exit 1; }
+          jq -r '
+            "status=\(.status)  mode=\(.mode)  dry_run=\(.dry_run)",
+            "failed_phase=\(.failed_phase // "-")  error=\(.error // "-")",
+            "packages=\(.packages | length)",
+            "phases:", (.phases[] | "  \(.name): ok=\(.ok) \(.duration_seconds)s \(.error // "")"),
+            "addons: \(.addons // {} | keys | join(", "))"
+          ' ./run/report.json | tee -a "$GITHUB_STEP_SUMMARY"
+          # The container exits 0 on an AbortError ("no changes", "branch already
+          # exists"), so exit status alone is not a verdict -- gate on the report.
+          jq -e '.status == "success" or .status == "no_changes"' ./run/report.json > /dev/null
+
+      - name: Upload run report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drupdater-report
+          path: ./run/report.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,6 +54,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Every job here only ever reads this repository: it clones the fixture over
+# plain HTTPS and talks to the fixture's remote with DRUPDATER_TEST_TOKEN, never
+# with GITHUB_TOKEN. Declared once at the top rather than per job so a job added
+# later inherits the restriction instead of silently getting the repository
+# default.
+permissions:
+  contents: read
+
 jobs:
   # Decides what to run. A label means "everything", a dispatch means "exactly
   # what I asked for", and keeping that decision in one place stops the matrix
@@ -168,8 +176,6 @@ jobs:
     name: ${{ matrix.fixture }} / ${{ matrix.mode }}
     runs-on: ubuntu-latest
     timeout-minutes: 75
-    permissions:
-      contents: read
     strategy:
       # One fixture or mode failing must not hide the state of the others.
       fail-fast: false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Clone project
         env:
-          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
+          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN || github.token }}
           REPOSITORY_URL: ${{ inputs.repository_url }}
           BRANCH: ${{ inputs.branch }}
         run: |
@@ -113,7 +113,13 @@ jobs:
 
       - name: Run drupdater
         env:
-          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
+          # Fall back to the job's own GITHUB_TOKEN. A dry run still reaches the
+          # remote -- ensureUpdateBranchAvailable calls BranchExists
+          # unconditionally, it is not gated on --dry-run -- and go-git sends an
+          # empty password rather than no credential, which GitHub rejects
+          # outright. GITHUB_TOKEN is enough to list refs on a public target;
+          # pushing to one still needs DRUPDATER_TEST_TOKEN.
+          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN || github.token }}
           DRUPALCODE_ACCESS_TOKEN: ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
           SECURITY: ${{ inputs.security }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -103,6 +103,13 @@ jobs:
           # ("git history complete"), and a shallow clone cannot be pushed.
           git -c credential.helper='!f(){ echo username=oauth2; echo "password=$REPO_TOKEN"; };f' \
             clone --branch "$BRANCH" "$REPOSITORY_URL" ./run/project
+          # drupdater derives its commit identity from the VCS platform, which it
+          # only queries when it has a token. A checkout-mode --dry-run needs no
+          # token, so it falls back to the checkout's own identity -- and a fresh
+          # clone has none, which fails the first commit with "author field is
+          # required". A real CI checkout has the same gap.
+          git -C ./run/project config user.name  'drupdater integration test'
+          git -C ./run/project config user.email 'drupdater@users.noreply.github.com'
 
       - name: Run drupdater
         env:
@@ -126,6 +133,9 @@ jobs:
       - name: Summarise run report
         if: always()
         run: |
+          # The container runs as root and the report is written 0600, so both jq
+          # and upload-artifact get EACCES until the runner owns it back.
+          sudo chown -R "$(id -u):$(id -g)" ./run || true
           test -f ./run/report.json || { echo "::error::no run report was written"; exit 1; }
           jq -r '
             "status=\(.status)  mode=\(.mode)  dry_run=\(.dry_run)",

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Clone project
         env:
-          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN || github.token }}
+          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
           REPOSITORY_URL: ${{ inputs.repository_url }}
           BRANCH: ${{ inputs.branch }}
         run: |
@@ -103,23 +103,15 @@ jobs:
           # ("git history complete"), and a shallow clone cannot be pushed.
           git -c credential.helper='!f(){ echo username=oauth2; echo "password=$REPO_TOKEN"; };f' \
             clone --branch "$BRANCH" "$REPOSITORY_URL" ./run/project
-          # drupdater derives its commit identity from the VCS platform, which it
-          # only queries when it has a token. A checkout-mode --dry-run needs no
-          # token, so it falls back to the checkout's own identity -- and a fresh
-          # clone has none, which fails the first commit with "author field is
-          # required". A real CI checkout has the same gap.
-          git -C ./run/project config user.name  'drupdater integration test'
-          git -C ./run/project config user.email 'drupdater@users.noreply.github.com'
+          # Deliberately NO git identity configured here. A fresh clone has none,
+          # which is exactly the case drupdater has to handle on its own -- leaving
+          # it unset is what makes this job a regression test for that fallback.
 
       - name: Run drupdater
         env:
-          # Fall back to the job's own GITHUB_TOKEN. A dry run still reaches the
-          # remote -- ensureUpdateBranchAvailable calls BranchExists
-          # unconditionally, it is not gated on --dry-run -- and go-git sends an
-          # empty password rather than no credential, which GitHub rejects
-          # outright. GITHUB_TOKEN is enough to list refs on a public target;
-          # pushing to one still needs DRUPDATER_TEST_TOKEN.
-          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN || github.token }}
+          # No fallback token on purpose: a checkout-mode --dry-run is documented as
+          # needing none, so running it with an empty one keeps that promise tested.
+          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
           DRUPALCODE_ACCESS_TOKEN: ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
           SECURITY: ${{ inputs.security }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -87,12 +87,19 @@ jobs:
             # One leg, exactly as asked.
             mode=normal; [ "$IN_SECURITY" = "true" ] && mode=security
             url=${IN_URL:-https://github.com/drupdater/test-drupal-cms.git}
-            include=$(jq -nc \
+            # If the target happens to be a known fixture, take its
+            # expectations too, so a dispatch at the default gets the same
+            # verification a label does. Otherwise assert only the status --
+            # a dispatch can be aimed at any repository.
+            include=$(jq -c \
               --arg n "$(basename "$url" .git)" \
               --arg u "$url" \
               --arg b "${IN_BRANCH:-main}" \
               --arg m "$mode" \
-              '[{fixture:$n, repository_url:$u, branch:$b, mode:$m}]')
+              '(map(select(.repository_url == $u)) | first) as $f
+               | [{fixture: ($f.name // $n), repository_url: $u, branch: $b, mode: $m,
+                   expect: (($f.expect[$m] // {status:["success","no_changes"]}) | tojson)}]' \
+              .github/integration-fixtures.json)
             dry_run=$IN_DRY_RUN
             verbose=$IN_VERBOSE
           else
@@ -101,7 +108,8 @@ jobs:
             # and updates only what has an advisory -- so one passing says
             # nothing about the other.
             include=$(jq -c '[ .[] as $f | ("normal","security") as $m |
-              {fixture:$f.name, repository_url:$f.repository_url, branch:$f.branch, mode:$m} ]' \
+              {fixture:$f.name, repository_url:$f.repository_url, branch:$f.branch, mode:$m,
+               expect: (($f.expect[$m] // {status:["success","no_changes"]}) | tojson)} ]' \
               .github/integration-fixtures.json)
             # A label event carries none of the inputs above, and an unset
             # dry_run would read as "not a dry run" -- a label would then quietly
@@ -171,6 +179,13 @@ jobs:
       TARGET_URL: ${{ matrix.repository_url }}
       TARGET_BRANCH: ${{ matrix.branch }}
     steps:
+      # Just the assertion script -- the job otherwise has no use for the source.
+      - name: Checkout assertion script
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/assert-report.jq
+          sparse-checkout-cone-mode: false
+
       - name: Download image
         uses: actions/download-artifact@v4
         with:
@@ -236,8 +251,10 @@ jobs:
 
       # The report is written on every exit path, so this runs even when the
       # container failed -- a failed run's report is the one worth reading.
-      - name: Summarise run report
+      - name: Summarise and verify run report
         if: always()
+        env:
+          EXPECT: ${{ matrix.expect }}
         run: |
           # The container runs as root and the report is written 0600, so both jq
           # and upload-artifact get EACCES until the runner owns it back.
@@ -252,9 +269,11 @@ jobs:
             "addons: \(.addons // {} | keys | join(", "))"
           ' ./run/report.json | tee -a "$GITHUB_STEP_SUMMARY"
           # The container exits 0 on an AbortError ("no changes", "branch already
-          # exists"), so exit status alone is not a verdict -- gate on the report.
-          # no_changes is legitimate in security mode when nothing has an advisory.
-          jq -e '.status == "success" or .status == "no_changes"' ./run/report.json > /dev/null
+          # exists") and a run reports success even when an addon logged and
+          # swallowed its own failure, so neither exit status nor .status alone is
+          # a verdict. Assert what this fixture is actually meant to produce.
+          jq -e -r --argjson expect "$EXPECT" -f .github/assert-report.jq \
+            ./run/report.json | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload run report
         if: always()

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,9 +53,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # Drupal CMS is Drupal 11, which requires PHP 8.3+. One version, no matrix:
-      # this job proves drupdater works against a real site, not that Drupal runs
-      # on every PHP release.
+      # One version, no matrix: this job proves drupdater works against a real
+      # site, not that Drupal runs on every PHP release. 8.4 has to match the
+      # target's config.platform.php -- its lock is resolved for 8.4.1 and pulls
+      # in Symfony 8, which will not install on anything earlier.
       - name: Build Docker image
         uses: docker/build-push-action@v7
         with:
@@ -63,7 +64,7 @@ jobs:
           load: true
           tags: drupdater:test
           build-args: |
-            PHP_VERSION=8.3
+            PHP_VERSION=8.4
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,10 +4,17 @@ name: Integration Test
 # drupdater/test-drupal-cms: a Drupal CMS checkout whose composer.lock is
 # deliberately frozen at an old resolution, so every run has something to update.
 #
-# Manual only, on purpose. Dispatch it from the branch of a PR whose change
-# warrants an end-to-end check; the unit suite in go.yml covers everything else.
+# Manual on purpose -- a run is a Docker build plus a real Drupal install, far
+# too slow to want on every push, and the unit suite in go.yml covers the rest.
+# Two ways in:
+#   * add the "integration-test" label to a pull request (remove and re-add to
+#     re-run) -- the result shows up as a check on that PR;
+#   * dispatch it from the Actions tab when you want to pick the target,
+#     security mode, or a real non-dry run.
 
 on:
+  pull_request:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       repository_url:
@@ -36,12 +43,31 @@ on:
         default: false
         type: boolean
 
+# Per pull request rather than global, so labelling one PR does not cancel a run
+# already going on another.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+env:
+  # A label event carries none of the workflow_dispatch inputs, so every one of
+  # them needs a fallback. dry_run is the one that matters: unset would read as
+  # "not a dry run", and a label would quietly start pushing branches and
+  # opening merge requests against the target. Only an explicit dispatch can
+  # ever turn it off.
+  TARGET_URL: ${{ inputs.repository_url || 'https://github.com/drupdater/test-drupal-cms.git' }}
+  TARGET_BRANCH: ${{ inputs.branch || 'main' }}
+  IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+  IN_DRY_RUN: ${{ inputs.dry_run }}
+  IN_SECURITY: ${{ inputs.security }}
+  IN_VERBOSE: ${{ inputs.verbose }}
 
 jobs:
   integration-test:
+    # Any label would otherwise start a run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'integration-test'
     runs-on: ubuntu-latest
     timeout-minutes: 75
     permissions:
@@ -49,6 +75,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Resolve run mode
+        id: mode
+        run: |
+          # A label-triggered run is always a dry run; see the env block above.
+          if [ "$IS_DISPATCH" = "true" ]; then
+            dry_run=$IN_DRY_RUN; security=$IN_SECURITY; verbose=$IN_VERBOSE
+          else
+            dry_run=true; security=false; verbose=false
+          fi
+          {
+            echo "dry_run=$dry_run"
+            echo "security=$security"
+            echo "verbose=$verbose"
+          } >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET_URL@$TARGET_BRANCH dry_run=$dry_run security=$security" \
+            >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -69,29 +112,25 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Delete stale update branches
-        if: ${{ !inputs.dry_run }}
+        if: steps.mode.outputs.dry_run != 'true'
         env:
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
-          REPOSITORY_URL: ${{ inputs.repository_url }}
         run: |
           # The target's composer.lock is frozen, so the update branch name
           # (update-<lock content-hash>) is stable across runs. Left behind, it
           # makes the next real run abort with "branch already exists", which
           # reports as no_changes and exit 0 -- a green run that tested nothing.
-          git ls-remote --heads \
-            "$(echo "$REPOSITORY_URL" | sed "s#https://#https://oauth2:$REPO_TOKEN@#")" \
-            'refs/heads/update-*' | awk '{print $2}' | sed 's#refs/heads/##' \
+          authed="$(echo "$TARGET_URL" | sed "s#https://#https://oauth2:$REPO_TOKEN@#")"
+          git ls-remote --heads "$authed" 'refs/heads/update-*' \
+            | awk '{print $2}' | sed 's#refs/heads/##' \
             | while read -r ref; do
                 echo "deleting stale branch $ref"
-                git push "$(echo "$REPOSITORY_URL" | sed "s#https://#https://oauth2:$REPO_TOKEN@#")" \
-                  --delete "$ref"
+                git push "$authed" --delete "$ref"
               done
 
       - name: Clone project
         env:
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
-          REPOSITORY_URL: ${{ inputs.repository_url }}
-          BRANCH: ${{ inputs.branch }}
         run: |
           # ./run is the mount root, the project a level below it. drupdater
           # writes <site>.sqlite and private/ into the checkout's PARENT
@@ -102,7 +141,7 @@ jobs:
           # No --depth: drupdater's preflight rejects a shallow checkout
           # ("git history complete"), and a shallow clone cannot be pushed.
           git -c credential.helper='!f(){ echo username=oauth2; echo "password=$REPO_TOKEN"; };f' \
-            clone --branch "$BRANCH" "$REPOSITORY_URL" ./run/project
+            clone --branch "$TARGET_BRANCH" "$TARGET_URL" ./run/project
           # Deliberately NO git identity configured here. A fresh clone has none,
           # which is exactly the case drupdater has to handle on its own -- leaving
           # it unset is what makes this job a regression test for that fallback.
@@ -113,9 +152,9 @@ jobs:
           # needing none, so running it with an empty one keeps that promise tested.
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
           DRUPALCODE_ACCESS_TOKEN: ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
-          SECURITY: ${{ inputs.security }}
-          VERBOSE: ${{ inputs.verbose }}
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+          SECURITY: ${{ steps.mode.outputs.security }}
+          VERBOSE: ${{ steps.mode.outputs.verbose }}
         run: |
           args=(--working-dir /workspace/project --report /workspace/report.json)
           [ "$DRY_RUN" = "true" ]  && args+=(--dry-run)

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,9 +4,9 @@ name: Integration Test
 # whose composer.lock is deliberately frozen at an old resolution, so every run
 # has something to update.
 #
-# Manual on purpose: a single leg is a Docker build plus a real Drupal install,
-# far too slow to want on every push, and the unit suite in go.yml covers the
-# rest. Two ways in:
+# Manual on purpose: every leg installs Drupal for real, far too slow to want on
+# every push, and the unit suite in go.yml covers the rest. The image is built
+# once and shared, so adding fixtures costs runs but not rebuilds. Two ways in:
 #
 #   * add the "integration-test" label to a pull request. Every fixture runs in
 #     both normal and security mode, always as a dry run, and each leg shows up
@@ -69,9 +69,11 @@ jobs:
       dry_run: ${{ steps.set.outputs.dry_run }}
       verbose: ${{ steps.set.outputs.verbose }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout repository
+        uses: actions/checkout@v7
 
-      - id: set
+      - name: Resolve fixtures and run flags
+        id: set
         env:
           IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
           IN_URL: ${{ inputs.repository_url }}
@@ -118,21 +120,11 @@ jobs:
           jq -r '.[] | "- \(.fixture) / \(.mode) -- \(.repository_url)@\(.branch)"' \
             <<<"$include" >> "$GITHUB_STEP_SUMMARY"
 
-  integration-test:
+  # The image is identical for every leg, so build it once and pass it along as
+  # an artifact. Building per leg meant 2 builds for one fixture and 2N for N.
+  build:
     needs: plan
-    name: ${{ matrix.fixture }} / ${{ matrix.mode }}
     runs-on: ubuntu-latest
-    timeout-minutes: 75
-    permissions:
-      contents: read
-    strategy:
-      # One fixture or mode failing must not hide the state of the others.
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.plan.outputs.include) }}
-    env:
-      TARGET_URL: ${{ matrix.repository_url }}
-      TARGET_BRANCH: ${{ matrix.branch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -148,12 +140,45 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          load: true
           tags: drupdater:test
           build-args: |
             PHP_VERSION=8.4
+          outputs: type=docker,dest=/tmp/drupdater-image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Upload image
+        uses: actions/upload-artifact@v4
+        with:
+          name: drupdater-image
+          path: /tmp/drupdater-image.tar
+          retention-days: 1
+          if-no-files-found: error
+
+  integration-test:
+    needs: [plan, build]
+    name: ${{ matrix.fixture }} / ${{ matrix.mode }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    permissions:
+      contents: read
+    strategy:
+      # One fixture or mode failing must not hide the state of the others.
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.include) }}
+    env:
+      TARGET_URL: ${{ matrix.repository_url }}
+      TARGET_BRANCH: ${{ matrix.branch }}
+    steps:
+      - name: Download image
+        uses: actions/download-artifact@v4
+        with:
+          name: drupdater-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/drupdater-image.tar
 
       - name: Delete stale update branches
         if: needs.plan.outputs.dry_run != 'true'

--- a/README.md
+++ b/README.md
@@ -345,9 +345,21 @@ measurable without separate instrumentation — the phase distribution shows
 whether a run is dominated by `composer install`, by site installs, or by Rector.
 
 **`addons`** carries one structured section per addon that has something to
-report (`composer_audit`, `update_hooks`, `unsupported_modules`,
-`composer_patches`). Addons with nothing to say are omitted rather than present
-and empty.
+report: `composer_audit`, `update_hooks`, `unsupported_modules`,
+`composer_patches`, `code_beautifier`, `deprecations_remover` and
+`translations_updater`. Addons with nothing to say are omitted rather than
+present and empty.
+
+`composer_diff` and `composer_normalizer` deliberately contribute nothing — the
+first duplicates the top-level `packages` field, the second only reorders
+`composer.json`. Everything else reports even when its work is "only" a code
+change: the diff tells you what changed but not whether an addon ran at all, and
+most addons log and swallow their own failures, so one that silently did nothing
+looks exactly like one with nothing to do.
+
+`translations_updater` is keyed by site and records `skipped` with a reason when
+it bails out early — `locale_deploy` not enabled, or a translation path that
+does not resolve. Both were previously visible only in the log.
 
 **`merge_request.auto_merge`** is present only when the active run type asked
 for auto-merge, so "never requested" is distinguishable from "requested and

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -22,6 +23,11 @@ type CodeBeautifier struct {
 	logger   *zap.Logger
 	phpcs    PHPCS
 	composer Composer
+
+	// What the run actually fixed, for the report. Written once from the single
+	// post-code-update event, read after the run.
+	fixedFiles []string
+	fixable    int
 }
 
 // NewCodeBeautifier creates a new code beautifier instance
@@ -162,8 +168,14 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error { //nolint:
 		return nil
 	}
 
-	_, err = event.Worktree().Commit("Update coding styles", &git.CommitOptions{})
-	return err
+	if _, err := event.Worktree().Commit("Update coding styles", &git.CommitOptions{}); err != nil {
+		return err
+	}
+
+	sort.Strings(addedFiles)
+	cb.fixedFiles = addedFiles
+	cb.fixable = codingStyleUpdateResult.Totals.Fixable
+	return nil
 }
 
 // stagedAnyOf reports whether any of paths has a staged (non-Unmodified) change in worktree. An

--- a/internal/addon/deprecations_remover.go
+++ b/internal/addon/deprecations_remover.go
@@ -1,7 +1,10 @@
 package addon
 
 import (
+	"sort"
+
 	"github.com/drupdater/drupdater/internal/services"
+	"github.com/drupdater/drupdater/pkg/rector"
 	"github.com/gookit/event"
 
 	"github.com/go-git/go-git/v5"
@@ -13,6 +16,10 @@ type DeprecationsRemover struct {
 	logger   *zap.Logger
 	rector   Rector
 	composer Composer
+
+	// Which rector rules rewrote which files, for the report. Written once from the
+	// single post-code-update event, read after the run.
+	fixes []DeprecationFix
 }
 
 // NewDeprecationsRemover creates a new deprecations remover instance
@@ -87,6 +94,8 @@ func (dr *DeprecationsRemover) postCodeUpdateHandler(e event.Event) error {
 		return nil
 	}
 
+	dr.recordFixes(deprecationRemovalResult)
+
 	for _, file := range deprecationRemovalResult.ChangedFiles {
 		if _, err := evt.Worktree().Add(file); err != nil {
 			return err
@@ -114,4 +123,23 @@ func (dr *DeprecationsRemover) commitTemporaryRectorCleanup(worktree Worktree) e
 	}
 	_, err = worktree.Commit("Remove temporary drupal-rector installation", &git.CommitOptions{})
 	return err
+}
+
+// recordFixes captures what rector rewrote, so the report can say which rules fired on which
+// files rather than only that "some deprecations were removed".
+func (dr *DeprecationsRemover) recordFixes(result rector.ReturnOutput) {
+	rectorsByFile := make(map[string][]string, len(result.FileDiffs))
+	for _, diff := range result.FileDiffs {
+		rectorsByFile[diff.File] = diff.AppliedRectors
+	}
+
+	fixes := make([]DeprecationFix, 0, len(result.ChangedFiles))
+	for _, file := range result.ChangedFiles {
+		applied := rectorsByFile[file]
+		sort.Strings(applied)
+		fixes = append(fixes, DeprecationFix{File: file, AppliedRectors: applied})
+	}
+	// Sorted so two runs over unchanged code produce byte-identical sections.
+	sort.Slice(fixes, func(i, j int) bool { return fixes[i].File < fixes[j].File })
+	dr.fixes = fixes
 }

--- a/internal/addon/report.go
+++ b/internal/addon/report.go
@@ -27,8 +27,13 @@ import (
 //     information is already in the report's top-level "packages" field, in structured form,
 //     straight from composer update -- a markdown table in a JSON document would be strictly
 //     worse than what is already there.
-//   - composer_normalizer and code_beautifier only change formatting; that a run reformatted
-//     code is visible in the diff, and has no consumer beyond it.
+//   - composer_normalizer only reorders composer.json; that a run normalised it is visible in
+//     the diff and has no consumer beyond it.
+//
+// Everything else reports, including addons whose work is "only" a code change. Reading the
+// diff tells you what changed but not whether the addon ran at all, and most addons log and
+// swallow their own failures -- so an addon that silently did nothing is indistinguishable
+// from one with nothing to do unless it says so here.
 
 // --- composer_audit ---
 
@@ -133,4 +138,79 @@ func (h *ComposerPatches1) ReportData() any {
 		Updated:   h.patchUpdates.Updated,
 		Conflicts: h.patchUpdates.Conflicts,
 	}
+}
+
+// --- code_beautifier ---
+
+// CodingStyleFixes is the code_beautifier section: which files PHPCBF actually fixed and
+// committed, and how many violations PHPCS considered fixable beforehand. The two differ when a
+// violation is reported fixable but PHPCBF cannot fix it in practice.
+type CodingStyleFixes struct {
+	Files   []string `json:"files"`
+	Fixable int      `json:"fixable"`
+}
+
+// ReportKey implements report.Reporter.
+func (cb *CodeBeautifier) ReportKey() string { return "code_beautifier" }
+
+// ReportData implements report.Reporter.
+func (cb *CodeBeautifier) ReportData() any {
+	if len(cb.fixedFiles) == 0 {
+		return nil
+	}
+	return CodingStyleFixes{Files: cb.fixedFiles, Fixable: cb.fixable}
+}
+
+// --- deprecations_remover ---
+
+// DeprecationFix is one file Rector rewrote, and the rules that fired on it. The rule names are
+// the actionable part: they say which deprecation was removed, which "the file changed" does not.
+type DeprecationFix struct {
+	File           string   `json:"file"`
+	AppliedRectors []string `json:"applied_rectors,omitempty"`
+}
+
+// ReportKey implements report.Reporter.
+func (dr *DeprecationsRemover) ReportKey() string { return "deprecations_remover" }
+
+// ReportData implements report.Reporter.
+func (dr *DeprecationsRemover) ReportData() any {
+	if len(dr.fixes) == 0 {
+		return nil
+	}
+	return dr.fixes
+}
+
+// --- translations_updater ---
+
+// TranslationResult is one site's outcome. Skipped is set when the addon bailed out early, which
+// it does by design when locale_deploy is not enabled or the translation path does not resolve --
+// both previously visible only in the logs, and both indistinguishable from "ran and found
+// nothing" in a report that simply omitted the site.
+type TranslationResult struct {
+	Path    string `json:"path,omitempty"`
+	Updated bool   `json:"updated"`
+	Skipped string `json:"skipped,omitempty"`
+}
+
+// ReportKey implements report.Reporter.
+func (tu *TranslationsUpdater) ReportKey() string { return "translations_updater" }
+
+// ReportData implements report.Reporter. Keyed by site: in a multisite run each site has its own
+// translation directory and can succeed or skip independently.
+func (tu *TranslationsUpdater) ReportData() any {
+	tu.mu.Lock()
+	defer tu.mu.Unlock()
+
+	if len(tu.results) == 0 {
+		return nil
+	}
+
+	// Copy rather than hand out the live map, which is mutex-guarded state the caller cannot
+	// know about.
+	out := make(map[string]TranslationResult, len(tu.results))
+	for site, result := range tu.results {
+		out[site] = result
+	}
+	return out
 }

--- a/internal/addon/report_test.go
+++ b/internal/addon/report_test.go
@@ -1,6 +1,7 @@
 package addon
 
 import (
+	"github.com/drupdater/drupdater/pkg/rector"
 	"testing"
 
 	"github.com/drupdater/drupdater/internal/report"
@@ -128,4 +129,91 @@ func TestComposerDiffDoesNotReport(t *testing.T) {
 	var addon any = &ComposerDiff{}
 	_, isReporter := addon.(report.Reporter)
 	assert.False(t, isReporter)
+}
+
+func TestCodeBeautifierReportData(t *testing.T) {
+	cb := &CodeBeautifier{}
+
+	t.Run("nothing fixed reports nothing", func(t *testing.T) {
+		assert.Equal(t, "code_beautifier", cb.ReportKey())
+		assert.Nil(t, cb.ReportData())
+	})
+
+	t.Run("reports the files it committed and what was fixable", func(t *testing.T) {
+		cb := &CodeBeautifier{
+			fixedFiles: []string{"web/modules/custom/a/a.module", "web/modules/custom/b/b.module"},
+			fixable:    7,
+		}
+		assert.Equal(t, CodingStyleFixes{
+			Files:   []string{"web/modules/custom/a/a.module", "web/modules/custom/b/b.module"},
+			Fixable: 7,
+		}, cb.ReportData())
+	})
+}
+
+func TestDeprecationsRemoverReportData(t *testing.T) {
+	t.Run("nothing rewritten reports nothing", func(t *testing.T) {
+		dr := &DeprecationsRemover{}
+		assert.Equal(t, "deprecations_remover", dr.ReportKey())
+		assert.Nil(t, dr.ReportData())
+	})
+
+	t.Run("records which rules fired on which file, sorted", func(t *testing.T) {
+		dr := &DeprecationsRemover{}
+		dr.recordFixes(rector.ReturnOutput{
+			Totals:       rector.ReturnOutputTotals{ChangedFiles: 2},
+			ChangedFiles: []string{"web/modules/custom/z/z.php", "web/modules/custom/a/a.php"},
+			FileDiffs: []rector.ReturnOutputFillDiff{
+				{File: "web/modules/custom/a/a.php", AppliedRectors: []string{"SecondRector", "FirstRector"}},
+				{File: "web/modules/custom/z/z.php", AppliedRectors: []string{"OtherRector"}},
+			},
+		})
+
+		// Files and rule names are both sorted, so two runs over unchanged code produce
+		// byte-identical sections and a consumer can diff reports directly.
+		assert.Equal(t, []DeprecationFix{
+			{File: "web/modules/custom/a/a.php", AppliedRectors: []string{"FirstRector", "SecondRector"}},
+			{File: "web/modules/custom/z/z.php", AppliedRectors: []string{"OtherRector"}},
+		}, dr.ReportData())
+	})
+
+	t.Run("a changed file with no recorded rules still reports", func(t *testing.T) {
+		dr := &DeprecationsRemover{}
+		dr.recordFixes(rector.ReturnOutput{
+			Totals:       rector.ReturnOutputTotals{ChangedFiles: 1},
+			ChangedFiles: []string{"a.php"},
+		})
+		assert.Equal(t, []DeprecationFix{{File: "a.php"}}, dr.ReportData())
+	})
+}
+
+func TestTranslationsUpdaterReportData(t *testing.T) {
+	t.Run("never ran reports nothing", func(t *testing.T) {
+		tu := &TranslationsUpdater{}
+		assert.Equal(t, "translations_updater", tu.ReportKey())
+		assert.Nil(t, tu.ReportData())
+	})
+
+	t.Run("distinguishes updated, unchanged and skipped, per site", func(t *testing.T) {
+		// The skipped case is the one that matters: it used to be visible only in the log,
+		// so a report that omitted the site could not tell it apart from "nothing to do".
+		tu := &TranslationsUpdater{}
+		tu.record("one", TranslationResult{Path: "translations", Updated: true})
+		tu.record("two", TranslationResult{Path: "translations"})
+		tu.record("three", TranslationResult{Skipped: "locale_deploy not enabled"})
+
+		assert.Equal(t, map[string]TranslationResult{
+			"one":   {Path: "translations", Updated: true},
+			"two":   {Path: "translations"},
+			"three": {Skipped: "locale_deploy not enabled"},
+		}, tu.ReportData())
+	})
+
+	t.Run("the returned map is a copy of guarded state", func(t *testing.T) {
+		tu := &TranslationsUpdater{}
+		tu.record("default", TranslationResult{Updated: true})
+		out := tu.ReportData().(map[string]TranslationResult)
+		out["default"] = TranslationResult{}
+		assert.True(t, tu.ReportData().(map[string]TranslationResult)["default"].Updated)
+	})
 }

--- a/internal/addon/translations_updater.go
+++ b/internal/addon/translations_updater.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/go-git/go-git/v5"
@@ -15,6 +16,11 @@ type TranslationsUpdater struct {
 	logger     *zap.Logger
 	drush      Drush
 	repository Repository
+
+	// Per-site outcome for the report. post-site-update fires concurrently across sites,
+	// hence the mutex.
+	mu      sync.Mutex
+	results map[string]TranslationResult
 }
 
 // NewTranslationsUpdater creates a new translations updater instance
@@ -50,6 +56,7 @@ func (tu *TranslationsUpdater) postSiteUpdateHandler(e event.Event) error {
 	}
 	if !enabled {
 		tu.logger.Info("locale_deploy not enabled, skipping translations update", zap.String("site", evt.Site()))
+		tu.record(evt.Site(), TranslationResult{Skipped: "locale_deploy not enabled"})
 		return nil
 	}
 
@@ -62,6 +69,7 @@ func (tu *TranslationsUpdater) postSiteUpdateHandler(e event.Event) error {
 	translationPath, err := tu.drush.GetTranslationPath(evt.Context(), evt.Path(), evt.Site(), true)
 	if err != nil {
 		tu.logger.Info("translation path not available, skipping translations update", zap.String("site", evt.Site()), zap.Error(err))
+		tu.record(evt.Site(), TranslationResult{Skipped: "translation path not available: " + err.Error()})
 		return nil
 	}
 
@@ -74,6 +82,7 @@ func (tu *TranslationsUpdater) postSiteUpdateHandler(e event.Event) error {
 	tu.logger.Debug("git status", zap.Any("status", status))
 	if !tu.repository.IsSomethingStagedInPath(evt.Worktree(), translationPath) {
 		tu.logger.Debug("nothing to commit")
+		tu.record(evt.Site(), TranslationResult{Path: translationPath})
 		return nil
 	}
 	_, err = evt.Worktree().Commit("Update translations", &git.CommitOptions{})
@@ -81,5 +90,16 @@ func (tu *TranslationsUpdater) postSiteUpdateHandler(e event.Event) error {
 		return fmt.Errorf("failed to commit translation path: %w", err)
 	}
 
+	tu.record(evt.Site(), TranslationResult{Path: translationPath, Updated: true})
 	return nil
+}
+
+// record stores a site's outcome for the report.
+func (tu *TranslationsUpdater) record(site string, result TranslationResult) {
+	tu.mu.Lock()
+	defer tu.mu.Unlock()
+	if tu.results == nil {
+		tu.results = make(map[string]TranslationResult)
+	}
+	tu.results[site] = result
 }

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -448,6 +448,15 @@ func (ws *WorkflowBaseService) ensureUpdateBranchAvailable(repository GitReposit
 		return fmt.Errorf("failed to check for a local %s branch: %w", updateBranchName, err)
 	}
 
+	// The remote half only matters when the branch is going to be pushed. A --dry-run never
+	// pushes, and reaching the remote here would break the one case that is documented as
+	// needing no token at all: a checkout-mode dry run. Worse than needing one, it fails
+	// outright without it — go-git sends an empty password rather than no credential, which
+	// the host rejects even for a public repository.
+	if ws.config.DryRun {
+		return nil
+	}
+
 	exists, err := ws.repository.BranchExists(repository, updateBranchName, ws.config.Token)
 	if err != nil {
 		return fmt.Errorf("failed to check if branch exists: %w", err)

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -579,7 +579,6 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
-	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
 
@@ -605,6 +604,9 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 	drush.AssertExpectations(t)
 	mockComposer.AssertExpectations(t)
 	vcsProvider.AssertExpectations(t)
+	// A --dry-run never pushes, so ensureUpdateBranchAvailable deliberately skips the remote
+	// branch check -- reaching it used to make this configuration fail without a token.
+	repositoryService.AssertNotCalled(t, "BranchExists", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
@@ -642,7 +644,6 @@ func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
 	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
 	mockComposer.EXPECT().CheckPlatformReqs(mock.Anything, "/tmp").Return("", nil)
 	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
-	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
 	// Checkout mode (Clone is unset): StartUpdate captures HEAD up front so it can restore the
 	// checkout if the run fails. This run succeeds, so it is never used to restore anything.
 	repository.EXPECT().Head().Return(plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), plumbing.NewHash("a")), nil)
@@ -667,6 +668,10 @@ func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
 	repository.AssertExpectations(t)
 	drush.AssertExpectations(t)
 	mockComposer.AssertExpectations(t)
+	// A --dry-run never pushes, so ensureUpdateBranchAvailable deliberately skips the remote.
+	// This is the configuration documented as needing no token at all, and reaching the remote
+	// here used to fail it outright rather than merely need one.
+	repositoryService.AssertNotCalled(t, "BranchExists", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestPublishWorkDeletesBranchOnMRFailure(t *testing.T) {
@@ -1640,5 +1645,73 @@ func TestCleanup(t *testing.T) {
 
 		assert.NoFileExists(t, filepath.Join(base, "site1.sqlite"))
 		assert.NoDirExists(t, filepath.Join(base, "private"))
+	})
+}
+
+func TestEnsureUpdateBranchAvailable(t *testing.T) {
+	const branch = "update-abc123"
+
+	newCheckout := func(t *testing.T) *git.Repository {
+		t.Helper()
+		checkout, err := git.PlainInit(t.TempDir(), false)
+		require.NoError(t, err)
+		return checkout
+	}
+
+	t.Run("a dry run never reaches the remote", func(t *testing.T) {
+		// The remote half of this check only matters when the branch is going to be pushed,
+		// and a --dry-run never pushes. Reaching out anyway breaks the one configuration
+		// documented as needing no token at all: a checkout-mode dry run. BranchExists is
+		// deliberately left unstubbed, so the mock fails the test if it is called.
+		repository := NewMockRepository(t)
+		ws := &WorkflowBaseService{
+			logger:     zap.NewNop(),
+			repository: repository,
+			config:     internal.Config{DryRun: true},
+		}
+
+		require.NoError(t, ws.ensureUpdateBranchAvailable(newCheckout(t), branch))
+	})
+
+	t.Run("a real run asks the remote and aborts when the branch is taken", func(t *testing.T) {
+		checkout := newCheckout(t)
+		repository := NewMockRepository(t)
+		repository.EXPECT().BranchExists(checkout, branch, "tok").Return(true, nil)
+		ws := &WorkflowBaseService{
+			logger:     zap.NewNop(),
+			repository: repository,
+			config:     internal.Config{DryRun: false, Token: "tok"},
+		}
+
+		err := ws.ensureUpdateBranchAvailable(checkout, branch)
+		var abort AbortError
+		require.ErrorAs(t, err, &abort)
+	})
+
+	t.Run("a real run proceeds when the remote does not have the branch", func(t *testing.T) {
+		checkout := newCheckout(t)
+		repository := NewMockRepository(t)
+		repository.EXPECT().BranchExists(checkout, branch, "tok").Return(false, nil)
+		ws := &WorkflowBaseService{
+			logger:     zap.NewNop(),
+			repository: repository,
+			config:     internal.Config{DryRun: false, Token: "tok"},
+		}
+
+		require.NoError(t, ws.ensureUpdateBranchAvailable(checkout, branch))
+	})
+
+	t.Run("a remote failure is surfaced", func(t *testing.T) {
+		checkout := newCheckout(t)
+		repository := NewMockRepository(t)
+		repository.EXPECT().BranchExists(checkout, branch, "").Return(false, assert.AnError)
+		ws := &WorkflowBaseService{
+			logger:     zap.NewNop(),
+			repository: repository,
+			config:     internal.Config{DryRun: false},
+		}
+
+		err := ws.ensureUpdateBranchAvailable(checkout, branch)
+		require.ErrorContains(t, err, "failed to check if branch exists")
 	})
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -11,9 +11,17 @@ import (
 	"github.com/spf13/afero"
 
 	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"go.uber.org/zap"
+)
+
+// Identity used for commits when neither the VCS platform nor the checkout supplies one.
+// Both are only reached in that last-resort case; see prepareCheckout.
+const (
+	defaultCommitName  = "drupdater"
+	defaultCommitEmail = "drupdater@localhost"
 )
 
 type Repository interface {
@@ -164,6 +172,26 @@ func (rs *GitRepositoryService) prepareCheckout(checkout *git.Repository, userna
 	if email != "" {
 		config.User.Email = email
 	}
+
+	// ...but "leave it in place" only works when there is one. A fresh clone and a CI
+	// checkout (actions/checkout included) both have no identity of their own, and go-git
+	// fails the very first commit with "author field is required". Fall back to a generic
+	// one so a run with nothing to ask still commits.
+	//
+	// The check reads the scoped config — system and global merged over local, which is what
+	// go-git itself resolves the author from — so a developer's global user.name still wins
+	// and we only write a default when there genuinely is none anywhere.
+	scoped, err := checkout.ConfigScoped(gitconfig.SystemScope)
+	if err != nil {
+		return checkout, nil, "", fmt.Errorf("failed to read scoped git config: %w", err)
+	}
+	if config.User.Name == "" && scoped.User.Name == "" {
+		config.User.Name = defaultCommitName
+	}
+	if config.User.Email == "" && scoped.User.Email == "" {
+		config.User.Email = defaultCommitEmail
+	}
+
 	if err := checkout.SetConfig(config); err != nil {
 		return checkout, nil, "", err
 	}

--- a/pkg/repo/repo_extra_test.go
+++ b/pkg/repo/repo_extra_test.go
@@ -235,3 +235,102 @@ func TestIsShallowClone(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// isolateGitConfig points go-git's global-config lookup at an empty directory, so these tests
+// see the same identity-less environment a CI runner has rather than the developer's own
+// ~/.gitconfig.
+func isolateGitConfig(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	return home
+}
+
+func TestPrepareCheckoutCommitIdentityFallback(t *testing.T) {
+	service := NewGitRepositoryService(zap.NewNop())
+
+	t.Run("falls back when nothing supplies an identity", func(t *testing.T) {
+		// A tokenless checkout-mode dry run has no VCS platform to ask, and a fresh clone or a
+		// CI checkout has no identity of its own, so without a fallback the first commit dies
+		// with go-git's "author field is required".
+		isolateGitConfig(t)
+		dir := t.TempDir()
+		_, err := git.PlainInit(dir, false)
+		require.NoError(t, err)
+
+		_, _, _, err = service.OpenRepository(dir, "", "")
+		require.NoError(t, err)
+
+		r, err := git.PlainOpen(dir)
+		require.NoError(t, err)
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		assert.Equal(t, defaultCommitName, cfg.User.Name)
+		assert.Equal(t, defaultCommitEmail, cfg.User.Email)
+	})
+
+	t.Run("a commit actually succeeds with only the fallback", func(t *testing.T) {
+		// The regression this guards is not the config value but the commit itself.
+		isolateGitConfig(t)
+		dir := t.TempDir()
+		_, err := git.PlainInit(dir, false)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hi"), 0o600))
+
+		_, worktree, _, err := service.OpenRepository(dir, "", "")
+		require.NoError(t, err)
+		_, err = worktree.Add("file.txt")
+		require.NoError(t, err)
+
+		hash, err := worktree.Commit("initial", &git.CommitOptions{})
+		require.NoError(t, err)
+		assert.False(t, hash.IsZero())
+	})
+
+	t.Run("a global identity wins over the fallback", func(t *testing.T) {
+		// go-git resolves the author from the scoped config, so a developer's global
+		// user.name is a perfectly good identity and must not be shadowed by a local default.
+		home := isolateGitConfig(t)
+		require.NoError(t, os.WriteFile(filepath.Join(home, ".gitconfig"),
+			[]byte("[user]\n\tname = Global User\n\temail = global@example.com\n"), 0o600))
+
+		dir := t.TempDir()
+		_, err := git.PlainInit(dir, false)
+		require.NoError(t, err)
+
+		_, _, _, err = service.OpenRepository(dir, "", "")
+		require.NoError(t, err)
+
+		r, err := git.PlainOpen(dir)
+		require.NoError(t, err)
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		assert.Empty(t, cfg.User.Name, "no local override should have been written")
+		assert.Empty(t, cfg.User.Email)
+
+		scoped, err := r.ConfigScoped(gitConfig.SystemScope)
+		require.NoError(t, err)
+		assert.Equal(t, "Global User", scoped.User.Name)
+	})
+
+	t.Run("an explicit identity wins over both", func(t *testing.T) {
+		home := isolateGitConfig(t)
+		require.NoError(t, os.WriteFile(filepath.Join(home, ".gitconfig"),
+			[]byte("[user]\n\tname = Global User\n\temail = global@example.com\n"), 0o600))
+
+		dir := t.TempDir()
+		_, err := git.PlainInit(dir, false)
+		require.NoError(t, err)
+
+		_, _, _, err = service.OpenRepository(dir, "Bot", "bot@example.com")
+		require.NoError(t, err)
+
+		r, err := git.PlainOpen(dir)
+		require.NoError(t, err)
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		assert.Equal(t, "Bot", cfg.User.Name)
+		assert.Equal(t, "bot@example.com", cfg.User.Email)
+	})
+}

--- a/scripts/unsupported-modules.php
+++ b/scripts/unsupported-modules.php
@@ -12,9 +12,15 @@ if (!\Drupal::moduleHandler()->moduleExists('update')) {
 $available = update_get_available(TRUE);
 $data = update_calculate_project_data($available);
 
+// The procedural UPDATE_* constants were deprecated in Drupal 10.3 and removed
+// in 11, where referencing one is a fatal "Undefined constant" rather than a
+// notice. The addon logs and swallows that failure, so the only symptom is that
+// no unsupported module is ever reported.
+$notSupported = \Drupal\update\UpdateManagerInterface::NOT_SUPPORTED;
+
 $unsupported = [];
 foreach ($data as $name => $project) {
-    if (($project['status'] ?? NULL) !== UPDATE_NOT_SUPPORTED) {
+    if (($project['status'] ?? NULL) !== $notSupported) {
         continue;
     }
     $unsupported[] = [


### PR DESCRIPTION
## Why

The unit suite mocks every external tool, so nothing exercised the parts that can only fail against a real Drupal site: `drush site:install --existing-config`, the SQLite `settings.php` append, `RemoveProfile`, config export, PHPCBF, Rector, `composer audit`, patch reconciliation. `integration-test.yml` was the closest thing to an end-to-end harness and it pointed at nothing — `repository_url` was required with no default, and no test project existed anywhere in the org.

This aims it at a new fixture repository, **[drupdater/test-drupal-cms](https://github.com/drupdater/test-drupal-cms)**: a Drupal CMS site whose `composer.lock` is deliberately held a minor version behind (core 11.3.9 against a current 11.4.x). That gap is the fixture — it guarantees real package updates, real `hook_update_N`s, and a published security advisory for `--security` mode to act on, and it widens on its own as upstream releases.

## What it found

Pointing it at a real site surfaced three bugs on the first runs, none of which the unit suite could see. They are why this PR touches more than CI.

**`unsupported_modules` was silently dead on Drupal 11.** `scripts/unsupported-modules.php` used the procedural `UPDATE_NOT_SUPPORTED` constant, deprecated in Drupal 10.3 and removed in 11, where referencing it is a fatal `Undefined constant` rather than a notice. The addon catches and logs that, so runs reported `success` while the check never reported anything. Now uses `UpdateManagerInterface::NOT_SUPPORTED`, which has existed as a class constant since Drupal 8 and so works on 10 and 11 alike.

**A tokenless checkout-mode dry run could not commit.** `prepareCheckout` rightly leaves the commit identity alone when there is no VCS platform to ask, but a fresh clone and `actions/checkout` both have none of their own, so the first commit died with go-git's `author field is required`. It now falls back to a generic identity, checked against the *scoped* config — system and global merged over local, the same place go-git resolves the author from — so a developer's global `user.name` still wins and a default is only written when there is genuinely no identity anywhere.

**A tokenless checkout-mode dry run could not run at all.** `ensureUpdateBranchAvailable` called `BranchExists` against the remote unconditionally, not gated on `DryRun`, contradicting the README's promise that such a run "touches the VCS platform for neither reading nor writing, so it needs no token at all". It was worse than needing one: with no token go-git sends an empty password rather than no credential, and the host rejects that even for a public repository. The remote half only matters when the branch is going to be pushed, so it is skipped on a dry run; the local check still runs.

Two existing dry-run tests asserted `BranchExists` **was** called — they encoded the third bug. They now assert the opposite.

## How the workflow works now

- **Label a PR `integration-test`** → every fixture runs in both normal and security mode, each leg its own check on the PR, `fail-fast: false` so one failing cannot hide the others. Remove and re-add to re-run.
- **Dispatch from the Actions tab** → one target, your choice of mode and `dry_run`.
- **Adding a fixture** is appending an entry to `.github/integration-fixtures.json`. Both modes are picked up automatically; nothing in the workflow needs editing.
- The image is **built once** and shared with the legs as an artifact, so fixtures cost runs but not rebuilds.

A label-triggered run is always a dry run by construction. A `pull_request` event carries none of the `workflow_dispatch` inputs, and an unset `dry_run` reads as "not a dry run" — a label would otherwise quietly push branches and open merge requests against the fixtures. Only an explicit dispatch can turn it off, and the stale-branch cleanup keys off the resolved value rather than the raw input so it cannot fire on a label either.

Four further fixes were needed just to get a run to completion, each found by running it: the pre-clone was shallow (`preflight` rejects that as its very first phase); the checkout was mounted at `/workspace`, so the SQLite database and `private/` landed in the container's `/`; the run report is written `0600` by the container's root, so `jq` and `upload-artifact` both got `EACCES`; and the image needs PHP 8.4 to match the fixture's `config.platform.php`.

## Verification

Both modes green end to end against the fixture, with the workflow supplying **no git identity and no token**, so the two fixes above are genuinely exercised rather than papered over:

| mode | status | packages | addons reporting |
|---|---|---|---|
| normal | success | 74 | `unsupported_modules`, `update_hooks` |
| security | success | 32 | `composer_audit`, `update_hooks` |

`unsupported_modules` appearing at all is the proof for the first fix — before it, that key was absent while the run still reported success. `update_hooks` found 9 hooks, which is the payoff from holding core a minor behind rather than a patch.

Unit suite green; changed packages at 93.9% (`internal/services`) and 90.6% (`pkg/repo`), both over the 90% bar; `golangci-lint` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vwtu62LHHkct2w4jEKH5jg