### PR TITLE
docs: correct inaccurate examples and add a landing page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,13 @@ jobs:
 
       # --strict fails the build on a broken internal link or a nav entry pointing at a
       # file that does not exist, so a bad link is caught here rather than published.
+      #
+      # DRUPDATER_GOATCOUNTER is what puts the analytics script into the pages. It is set
+      # here and nowhere else, so only the published site is counted — a contributor
+      # running mkdocs serve or make docs-build gets no tracking script.
       - run: mkdocs build --strict
+        env:
+          DRUPDATER_GOATCOUNTER: "true"
 
       - uses: peaceiris/actions-gh-pages@v4
         with:

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -29,6 +29,12 @@ make docs-build     # build the documentation with --strict
 make help           # list every target
 ```
 
+!!! note "Analytics only exists on the published site"
+
+    The GoatCounter script in `overrides/main.html` is emitted only when
+    `DRUPDATER_GOATCOUNTER` is set, which happens in `.github/workflows/docs.yml` and
+    nowhere else. A local preview or build produces pages with no tracking script.
+
 Run a single test:
 
 ```bash

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -8,9 +8,9 @@ Add one of these labels to a pull request before merging it to `main`:
 
 | Label | Effect |
 |---|---|
-| `bump:major` | `v0.12.0` → `v1.0.0` |
-| `bump:minor` | `v0.12.0` → `v0.13.0` |
-| `bump:patch` | `v0.12.0` → `v0.12.1` |
+| `bump:major` | `v0.3.6` → `v1.0.0` |
+| `bump:minor` | `v0.3.6` → `v0.4.0` |
+| `bump:patch` | `v0.3.6` → `v0.3.7` |
 
 On merge, the release workflow creates the new tag and updates the corresponding major and
 minor tags — releasing `v1.2.3` also moves `v1` and `v1.2`.

--- a/docs/contributing/writing-an-addon.md
+++ b/docs/contributing/writing-an-addon.md
@@ -140,7 +140,7 @@ Three requirements:
   empty one.
 - **Report even when the work was "only" a code change.** Because addons swallow their own
   failures, one that silently broke looks exactly like one with nothing to do. This is not
-  hypothetical: `unsupported_modules` was silently broken on Drupal 11 for months.
+  hypothetical: it [has happened](../explanation/why-a-run-report.md).
 - **Sort anything unordered.** Two runs over unchanged input should produce byte-identical
   output so reports diff cleanly.
 

--- a/docs/explanation/how-a-run-works.md
+++ b/docs/explanation/how-a-run-works.md
@@ -111,7 +111,7 @@ Three conditions stop a run early, and all three exit `0`:
 | Condition | Message |
 |---|---|
 | `composer update` changed nothing | `no changes detected` |
-| The update branch already exists | `branch update-… already exists` |
+| The update branch already exists | `branch update-… already exists, skipping` |
 | A `--security` run found no advisories | `No security advisories found` |
 
 Internally these raise an abort signal that is logged as a warning rather than an error,

--- a/docs/how-to/consume-the-run-report.md
+++ b/docs/how-to/consume-the-run-report.md
@@ -14,9 +14,8 @@ Because a run reports `success` even when an addon failed. Most addons log and s
 their own errors, so that the loss of, say, translation updates does not throw away an
 otherwise complete dependency update.
 
-That is a deliberate trade, and it has a cost:
-[`unsupported_modules`](../reference/addons/unsupported-modules.md) was once silently
-broken on Drupal 11 for months. Every run was green. The addon never reported a thing.
+That trade has a cost — an addon that broke would look exactly like one with nothing to
+do, and [one once did, for months](../explanation/why-a-run-report.md).
 
 Asserting that the addons you expect to run **actually appear in the report** is what
 turns a check from "it did not crash" into "it did what it is for".

--- a/docs/how-to/enable-patch-management.md
+++ b/docs/how-to/enable-patch-management.md
@@ -41,7 +41,7 @@ Drupal.org's code hosting runs on GitLab at
 
     ```bash
     docker run -e DRUPALCODE_ACCESS_TOKEN \
-      ghcr.io/drupdater/drupdater-php8.3:v0.12.0 \
+      ghcr.io/drupdater/drupdater-php8.3:latest \
       <token> --clone --repository-url <repository-url>
     ```
 

--- a/docs/how-to/github-actions.md
+++ b/docs/how-to/github-actions.md
@@ -31,7 +31,7 @@ jobs:
   drupdater:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/drupdater/drupdater-php8.3:v0.12.0
+      image: ghcr.io/drupdater/drupdater-php8.3:latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/how-to/gitlab-ci.md
+++ b/docs/how-to/gitlab-ci.md
@@ -19,7 +19,7 @@ Add to `.gitlab-ci.yml`:
 ```yaml
 .drupdater_base:
   image:
-    name: ghcr.io/drupdater/drupdater-php8.3:v0.12.0
+    name: ghcr.io/drupdater/drupdater-php8.3:latest
     entrypoint: [""]
   variables:
     GIT_DEPTH: "0"  # full history required to push the update branch

--- a/docs/how-to/migrate-config-layout.md
+++ b/docs/how-to/migrate-config-layout.md
@@ -84,12 +84,10 @@ drupdater check
 ✓ addon names resolve
 ```
 
-Or, if you only want to confirm the file parses without running anything else, `--verbose`
-logs the resolved configuration:
-
-```bash
-drupdater --dry-run --verbose
-```
+That is the whole verification: `check` loads the file exactly as a run does, in about a
+second, and names the sites it resolved. To see every resolved value — timeout, both
+addon lists, both `auto_merge` flags — run the update itself with `--verbose`, which logs
+them at debug level.
 
 ## Why the layout changed
 

--- a/docs/how-to/run-preflight-checks.md
+++ b/docs/how-to/run-preflight-checks.md
@@ -10,7 +10,7 @@ From the checkout:
 
 ```bash
 docker run -v "$(pwd)":/app -w /app \
-  ghcr.io/drupdater/drupdater-php8.3:v0.12.0 check
+  ghcr.io/drupdater/drupdater-php8.3:latest check
 ```
 
 This runs only the cheap checks — they take about a second. Output:
@@ -34,7 +34,7 @@ run fails partway through. `--full` proves it:
 
 ```bash
 docker run -v "$(pwd)":/app -w /app \
-  ghcr.io/drupdater/drupdater-php8.3:v0.12.0 \
+  ghcr.io/drupdater/drupdater-php8.3:latest \
   check --full
 ```
 
@@ -50,7 +50,7 @@ Pass a token and one more check runs — whether it authenticates and has API ac
 
 ```bash
 docker run -v "$(pwd)":/app -w /app -e DRUPDATER_TOKEN \
-  ghcr.io/drupdater/drupdater-php8.3:v0.12.0 check
+  ghcr.io/drupdater/drupdater-php8.3:latest check
 ```
 
 ```text
@@ -72,7 +72,7 @@ that has no credentials.
       drupdater-check:
         runs-on: ubuntu-latest
         container:
-          image: ghcr.io/drupdater/drupdater-php8.3:v0.12.0
+          image: ghcr.io/drupdater/drupdater-php8.3:latest
         steps:
           - uses: actions/checkout@v4
             with:
@@ -85,7 +85,7 @@ that has no credentials.
     ```yaml
     drupdater:check:
       image:
-        name: ghcr.io/drupdater/drupdater-php8.3:v0.12.0
+        name: ghcr.io/drupdater/drupdater-php8.3:latest
         entrypoint: [""]
       variables:
         GIT_DEPTH: "0"

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -59,7 +59,7 @@ single most common reason a real run fails partway through, and `drupdater check
 reproduces it in isolation:
 
 ```text
-✗ site "default": installs from configuration
+✗ site "default" installs from configuration
 ```
 
 ### The run aborts on an unknown addon name
@@ -127,7 +127,7 @@ already current.
 
 Update branch names are content-addressed — derived from a hash of the resulting
 `composer.lock`. A rerun over unchanged dependencies produces the same branch name, and
-the run aborts with `branch <name> already exists`. That is the mechanism preventing
+the run aborts with `branch <name> already exists, skipping`. That is the mechanism preventing
 duplicate pull requests for identical updates.
 
 ### A package was not updated

--- a/docs/how-to/use-private-packagist.md
+++ b/docs/how-to/use-private-packagist.md
@@ -82,7 +82,7 @@ Several entries can be combined in one object.
     ```bash
     docker run \
       -e COMPOSER_AUTH='{"http-basic":{"repo.packagist.com":{"username":"token","password":"<your-token>"}}}' \
-      ghcr.io/drupdater/drupdater-php8.3:v0.12.0 \
+      ghcr.io/drupdater/drupdater-php8.3:latest \
       <token> --clone --repository-url <repository-url>
     ```
 
@@ -96,8 +96,7 @@ drupdater check --full
 ```
 
 ```text
-✗ composer install
-    Could not authenticate against repo.packagist.com
+✗ composer install: Could not authenticate against repo.packagist.com
 ```
 
 ## How credentials are protected

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,47 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+<div class="dr-hero" markdown>
+<div class="dr-hero__copy" markdown>
+
 # Drupdater
 
-Automated, reviewable Drupal updates — as a pull or merge request, on every schedule.
+<p class="dr-hero__tagline">Automated, reviewable Drupal updates — as a pull or merge
+request, on every schedule.</p>
 
-Drupdater is a standalone CLI, shipped as a Docker image, that keeps Drupal sites up to
-date. Point it at a checkout in CI and it runs `composer update`, applies code-quality
-fixes, exports Drupal configuration, and opens a **pull request (GitHub)** or **merge
-request (GitLab)** with a detailed, human-reviewable changelog, with security changes
-flagged.
+Point it at a Drupal checkout in CI. It runs `composer update`, repairs or drops patches,
+applies code-quality fixes, exports configuration and translations, and opens a request
+carrying the dependency diff and the pending database update hooks.
 
-You review and merge. Drupdater never deploys anything on its own.
+**You review and merge. Drupdater never deploys anything on its own.**
+
+[Get started :material-arrow-right:](tutorials/first-run.md){ .md-button .md-button--primary }
+[Browse the reference](reference/index.md){ .md-button }
+
+<p class="dr-badges">
+  <span class="dr-badge">GitHub &amp; GitLab</span>
+  <span class="dr-badge">Ships as a Docker image</span>
+  <span class="dr-badge">Multi-site</span>
+  <span class="dr-badge dr-badge--warn">Pre-1.0 · v0.x</span>
+</p>
+
+</div>
+<div class="dr-term">
+  <div class="dr-term__bar"><i></i><i></i><i></i><em>drupdater</em></div>
+  <pre class="dr-term__body"><code><span class="p">$</span> docker run ghcr.io/drupdater/drupdater-php8.3:latest "$TOKEN"
+<span class="d">INFO</span>  running composer install
+<span class="d">INFO</span>  updating dependencies
+<span class="d">INFO</span>  dependencies updated  <span class="ok">{"total": 42, "upgraded": 39}</span>
+<span class="d">INFO</span>  removing deprecations
+<span class="d">INFO</span>  updating site         <span class="ok">{"site": "default"}</span>
+<span class="d">INFO</span>  update hooks found    <span class="ok">{"site": "default", "count": 4}</span>
+<span class="d">INFO</span>  merge request created <span class="ok">{"url": ".../pull/128"}</span>
+<span class="d">INFO</span>  update finished</code></pre>
+</div>
+</div>
 
 !!! warning "Project status: pre-1.0 (`v0.x`)"
 
@@ -18,9 +51,9 @@ You review and merge. Drupdater never deploys anything on its own.
 
 ## Start here
 
-<div class="grid cards" markdown>
+<div class="grid cards dr-cards" markdown>
 
--   :material-school: **[Tutorials](tutorials/index.md)**
+-   :material-school:{ .lg .middle } **[Tutorials](tutorials/index.md)**
 
     ---
 
@@ -28,7 +61,7 @@ You review and merge. Drupdater never deploys anything on its own.
     throwaway repository, then wire up [scheduled updates in
     CI](tutorials/scheduled-updates.md).
 
--   :material-wrench: **[How-to guides](how-to/index.md)**
+-   :material-wrench:{ .lg .middle } **[How-to guides](how-to/index.md)**
 
     ---
 
@@ -38,7 +71,7 @@ You review and merge. Drupdater never deploys anything on its own.
     auto-merge](how-to/enable-auto-merge.md), [troubleshooting a
     run](how-to/troubleshoot.md).
 
--   :material-book-open-variant: **[Reference](reference/index.md)**
+-   :material-book-open-variant:{ .lg .middle } **[Reference](reference/index.md)**
 
     ---
 
@@ -47,7 +80,7 @@ You review and merge. Drupdater never deploys anything on its own.
     [addons](reference/addons/index.md), and the [run report
     schema](reference/run-report.md).
 
--   :material-lightbulb-on: **[Explanation](explanation/index.md)**
+-   :material-lightbulb-on:{ .lg .middle } **[Explanation](explanation/index.md)**
 
     ---
 
@@ -74,24 +107,68 @@ Add `--dry-run` to do everything except push the branch and open the pull reques
 
 ## What a run does
 
-- **Dependency updates** — `composer update`, committed.
-- **Security-only mode** (`--security`) — updates only packages with known
-  vulnerabilities.
-- **Patch management** — drops obsolete patches, verifies remaining ones still apply,
-  and pulls updated patch files from Drupal.org.
-- **Code style** — `phpcbf`, auto-generating a `phpcs.xml` baseline if missing.
-- **Deprecation removal** — `drupal-rector`.
-- **Composer hygiene** — auto-allow-lists new Composer plugins; runs `composer
-  normalize` when `ergebnis/composer-normalize` is present.
-- **Translations** — updates interface translations via Drush when `locale_deploy` is
-  enabled.
-- **Changelog** — full dependency diff table and pending database update hooks in the
-  pull/merge request description.
-- **Multi-site** — updates several sites in one repository under a single request.
-- **GitHub and GitLab** — including self-hosted GitLab.
+<div class="grid cards dr-cards" markdown>
+
+-   :material-package-variant:{ .lg .middle } **Dependency updates**
+
+    ---
+
+    `composer update`, committed. `--security` narrows the run to packages with known
+    advisories.
+
+-   :material-bandage:{ .lg .middle } **Patch management**
+
+    ---
+
+    Drops obsolete patches, verifies the remaining ones still apply, and pulls updated
+    patch files from Drupal.org.
+
+-   :material-auto-fix:{ .lg .middle } **Code quality**
+
+    ---
+
+    `phpcbf`, auto-generating a `phpcs.xml` baseline if missing, plus deprecation
+    removal through `drupal-rector`.
+
+-   :material-translate:{ .lg .middle } **Config & translations**
+
+    ---
+
+    Exports Drupal configuration, and updates interface translations via Drush when
+    `locale_deploy` is enabled.
+
+-   :material-text-box-check:{ .lg .middle } **A readable changelog**
+
+    ---
+
+    Full dependency diff table and pending database update hooks, written into the
+    pull/merge request description.
+
+-   :material-source-branch:{ .lg .middle } **GitHub & GitLab**
+
+    ---
+
+    Including self-hosted GitLab, several sites in one repository, Composer hygiene, and
+    an optional machine-readable [run report](reference/run-report.md).
+
+</div>
 
 Each of these is an [addon](reference/addons/index.md), and most can be turned on or off
 per run type.
+
+## How a run works
+
+<ol class="dr-steps">
+  <li><strong>Acquire working copy</strong><span>Use the checkout CI gave you, or clone it with <code>--clone</code>.</span></li>
+  <li><strong>Preflight</strong><span>Refuse early on a project that cannot be updated safely.</span></li>
+  <li><strong>Composer install</strong><span>Reproduce the dependency state as it is today.</span></li>
+  <li><strong>Baseline site install</strong><span>Install each site from its committed configuration.</span></li>
+  <li><strong>Update shared code</strong><span>Composer update, patches, phpcbf, Rector.</span></li>
+  <li><strong>Site update</strong><span>Per-site configuration export and translations.</span></li>
+  <li><strong>Publish</strong><span>Push the branch and open the pull or merge request.</span></li>
+</ol>
+
+The long version: [how a run works](explanation/how-a-run-works.md).
 
 ## Support
 

--- a/docs/reference/addons/code-beautifier.md
+++ b/docs/reference/addons/code-beautifier.md
@@ -11,12 +11,6 @@ a PHPCS configuration first if the project has none.
 | Pull request section | *(none)* |
 | Commits | `Add PHPCS config`, `Install drupal/coder`, `Update coding styles` |
 
-## Why it exists
-
-Drupal core version bumps regularly change what the `Drupal` and `DrupalPractice`
-standards require. Folding the resulting mechanical fixes into the same pull request as
-the update keeps them from accumulating into a separate cleanup task later.
-
 ## What it does
 
 ### Ensures a PHPCS configuration exists
@@ -41,6 +35,12 @@ If absent, it is required as a dev dependency and committed as `Install drupal/c
 Runs `phpcs` to collect violations, then `phpcbf` to fix them. Only files that actually
 had errors or warnings are staged, and the `Update coding styles` commit is made **only
 if something was staged** — so a run with nothing to fix leaves no empty commit behind.
+
+## Why it exists
+
+Drupal core version bumps regularly change what the `Drupal` and `DrupalPractice`
+standards require. Folding the resulting mechanical fixes into the same pull request as
+the update keeps them from accumulating into a separate cleanup task later.
 
 ## Report section
 

--- a/docs/reference/addons/composer-allow-plugins.md
+++ b/docs/reference/addons/composer-allow-plugins.md
@@ -10,12 +10,6 @@ new plugins for you to review.
 | Report key | *(none)* |
 | Pull request section | "🔌 New Composer plugins", when new plugins were found |
 
-## Why it exists
-
-Composer refuses to execute a plugin that is not in `config.allow-plugins`, and prompts
-interactively when it meets one. An unattended run has nobody to answer that prompt, so
-an update that pulls in a new plugin would hang or fail.
-
 ## What it does
 
 **Before the update**, it saves the project's current `allow-plugins` configuration and
@@ -28,6 +22,12 @@ project ends up back where it started, plus explicit `false` entries for anythin
 
 The result is that new plugins are **not** silently trusted. They are recorded, disabled,
 and surfaced in the pull request for a human to decide on.
+
+## Why it exists
+
+Composer refuses to execute a plugin that is not in `config.allow-plugins`, and prompts
+interactively when it meets one. An unattended run has nobody to answer that prompt, so
+an update that pulls in a new plugin would hang or fail.
 
 ## Pull request section
 

--- a/docs/reference/addons/composer-audit.md
+++ b/docs/reference/addons/composer-audit.md
@@ -10,11 +10,6 @@ afterwards which advisories were actually resolved, and retitles the pull reques
 | Report key | `composer_audit` |
 | Pull request section | "🛡️ Security Report" |
 
-## Why it exists
-
-It is what makes a security run different from a normal one. Without it, `--security`
-would just be a normal update with a different pull request title.
-
 ## What it does
 
 ### Before the update — deciding the scope
@@ -57,6 +52,11 @@ Rewrites the request title from the default monthly form to:
 Dated to the day rather than the month, because security updates are expected to arrive
 several times in one month and each needs to be distinguishable.
 
+## Why it exists
+
+It is what makes a security run different from a normal one. Without it, `--security`
+would just be a normal update with a different pull request title.
+
 ## Report section
 
 ```json
@@ -81,10 +81,9 @@ several times in one month and each needs to be distinguishable.
 }
 ```
 
-**`remaining` is the more actionable half.** These are advisories the update could not
-resolve — usually because the fix requires a major version bump, or because a
-[patch conflict](composer-patches.md) held the package back. They are what a fleet-wide
-exposure view is built from.
+`remaining` lists advisories the update could not resolve — usually because the fix
+requires a major version bump, or because a [patch conflict](composer-patches.md) held the
+package back.
 
 ## Pull request section
 

--- a/docs/reference/addons/composer-diff.md
+++ b/docs/reference/addons/composer-diff.md
@@ -10,12 +10,6 @@ upgraded, downgraded or removed, with links to the upstream changelogs.
 | Report key | *(none — deliberately)* |
 | Pull request section | "🛠️ Dependency updates" |
 
-## Why it exists
-
-It is the reviewer's primary artefact. Everything else in the pull request describes work
-Drupdater did; this describes what actually changed in the dependency tree, which is what
-you are being asked to approve.
-
 ## What it does
 
 Runs `composer diff` twice against the pre-update and post-update lock files:
@@ -27,6 +21,11 @@ Runs `composer diff` twice against the pre-update and post-update lock files:
 
 It runs at the **lowest** priority on `post-composer-update`, so any other addon on that
 event has already finished mutating the lock file before the diff is taken.
+
+## Why it exists
+
+Everything else in the pull request describes work Drupdater did. This describes what
+changed in the dependency tree, which is what the reviewer is approving.
 
 ## Pull request section
 

--- a/docs/reference/addons/composer-normalizer.md
+++ b/docs/reference/addons/composer-normalizer.md
@@ -10,13 +10,6 @@ canonical formatting.
 | Report key | *(none — deliberately)* |
 | Pull request section | *(none)* |
 
-## Why it exists
-
-`composer update` and `composer require` write `composer.json` in whatever order they
-happen to produce. On a project that normalises its `composer.json`, that means every
-Drupdater pull request carries an unrelated reformatting diff — or worse, gets reverted
-by the next developer who runs the normaliser locally.
-
 ## What it does
 
 Checks whether
@@ -30,6 +23,13 @@ doing so unprompted would produce a large, unreviewable diff.
 
 It runs at the **lowest** priority on `post-composer-update`, so it normalises the final
 state after every other addon on that event has finished.
+
+## Why it exists
+
+`composer update` and `composer require` write `composer.json` in whatever order they
+happen to produce. On a project that normalises its `composer.json`, that means every
+Drupdater pull request carries an unrelated reformatting diff — or worse, gets reverted
+by the next developer who runs the normaliser locally.
 
 ## Requirements
 

--- a/docs/reference/addons/composer-patches.md
+++ b/docs/reference/addons/composer-patches.md
@@ -12,13 +12,6 @@ whose patch cannot be made to apply.
 | Pull request section | "🩹 Patch updates" |
 | Requires | [`DRUPALCODE_ACCESS_TOKEN`](../environment-variables.md#drupalcode_access_token) for the Drupal.org half |
 
-## Why it exists
-
-Patches are the most fragile part of a Drupal dependency update. A patch written against
-version 1.2 frequently will not apply to 1.3 — sometimes because the upstream issue was
-fixed and the patch is now redundant, sometimes because it needs rerolling. Without
-handling, `composer update` simply fails and the whole run is lost.
-
 ## What it does
 
 It runs before the real update, using a dry-run `composer update` to see which packages
@@ -56,6 +49,13 @@ version** rather than updated. The rest of the update proceeds. The pin is repor
 conflict so you know a package was deliberately held back and why.
 
 Changes to `composer.json` and the `patches/` directory are committed as `Update patches`.
+
+## Why it exists
+
+Patches are the most fragile part of a Drupal dependency update. A patch written against
+version 1.2 frequently will not apply to 1.3 — sometimes because the upstream issue was
+fixed and the patch is now redundant, sometimes because it needs rerolling. Without
+handling, `composer update` simply fails and the whole run is lost.
 
 ## Report section
 
@@ -98,9 +98,8 @@ held at, `new_version` the one it would otherwise have moved to.
 
 Omitted entirely when the run changed no patches.
 
-**Conflicts are the actionable half.** They are the packages this run could not update,
-and they will stay un-updated on every subsequent run until someone rerolls the patch or
-the issue is fixed upstream.
+`conflicts` needs a human. Those packages could not be updated, and will stay behind on
+every subsequent run until someone rerolls the patch or the issue is fixed upstream.
 
 ## Pull request section
 

--- a/docs/reference/addons/deprecations-remover.md
+++ b/docs/reference/addons/deprecations-remover.md
@@ -11,13 +11,6 @@ custom code to rewrite APIs deprecated by the new Drupal version.
 | Pull request section | *(none)* |
 | Commits | `Remove temporary drupal-rector installation`, `Remove deprecations` |
 
-## Why it exists
-
-Each Drupal minor release deprecates APIs that the *next* major removes. Fixing them at
-the moment the deprecation lands — in the same pull request as the version bump that
-introduced it — is far cheaper than discovering a few hundred of them when the major
-upgrade finally comes around.
-
 ## What it does
 
 1. If `palantirnet/drupal-rector` is not already a project dependency, it is required
@@ -32,6 +25,13 @@ upgrade finally comes around.
 The temporary install-then-remove is what forces this addon to run **above normal**
 priority on `post-code-update`: its `composer.json` churn must be fully committed before
 [`code_beautifier`](code-beautifier.md) stages anything at normal priority.
+
+## Why it exists
+
+Each Drupal minor release deprecates APIs that the *next* major removes. Fixing them at
+the moment the deprecation lands — in the same pull request as the version bump that
+introduced it — is far cheaper than discovering a few hundred of them when the major
+upgrade finally comes around.
 
 ## Report section
 

--- a/docs/reference/addons/translations-updater.md
+++ b/docs/reference/addons/translations-updater.md
@@ -12,12 +12,6 @@ result.
 | Commits | `Update translations` |
 | Requires | The `locale_deploy` module enabled on the site |
 
-## Why it exists
-
-Updating a module frequently changes its translatable strings. On a project that commits
-its `.po` files, those translations go stale at exactly the moment the module is updated —
-so the natural time to refresh them is in the same pull request.
-
 ## What it does
 
 For each site, after that site's update hooks and configuration export have run:
@@ -29,6 +23,12 @@ For each site, after that site's update hooks and configuration export have run:
    actually staged.
 
 Sites run concurrently, so the results map is mutex-guarded and keyed by site.
+
+## Why it exists
+
+Updating a module frequently changes its translatable strings. On a project that commits
+its `.po` files, those translations go stale at exactly the moment the module is updated —
+so the natural time to refresh them is in the same pull request.
 
 ## Report section
 
@@ -55,10 +55,9 @@ Sites run concurrently, so the results map is mutex-guarded and keyed by site.
 | `updated` | Whether anything was actually committed |
 | `skipped` | Present with a reason when the addon bailed out early |
 
-The `skipped` field is the point of this section. Both skip conditions — `locale_deploy`
-not enabled, and an unresolvable translation path — were previously visible only in the
-log, and a report that simply omitted the site would make "deliberately skipped"
-indistinguishable from "ran and found nothing".
+`skipped` distinguishes a site the addon deliberately passed over from one it ran against
+and found nothing to commit. Both skip conditions — `locale_deploy` not enabled, and an
+unresolvable translation path — are recorded with their reason.
 
 Omitted when no site produced a result at all.
 

--- a/docs/reference/addons/unsupported-modules.md
+++ b/docs/reference/addons/unsupported-modules.md
@@ -10,16 +10,6 @@ upgrade path, no further fixes.
 | Report key | `unsupported_modules` |
 | Pull request section | "⚠️ Unsupported modules" |
 
-## Why it exists
-
-An unsupported module is a different problem from a vulnerable one. There is no update to
-apply, so [`composer_audit`](composer-audit.md) will never flag it and no amount of
-running Drupdater will fix it. It needs a human decision: replace the module, adopt it,
-or accept the risk.
-
-Surfacing it in the routine update pull request is the cheapest possible way to keep that
-decision from being forgotten for a year.
-
 ## What it does
 
 Queries Drupal's own update status for each site, via a helper script shipped in the
@@ -31,6 +21,16 @@ does not list the same module several times.
 This addon is **best-effort**: errors are logged and swallowed rather than failing the
 run. A transient problem reaching Drupal.org's update service should not lose an
 otherwise complete update.
+
+## Why it exists
+
+An unsupported module is a different problem from a vulnerable one. There is no update to
+apply, so [`composer_audit`](composer-audit.md) will never flag it and no amount of
+running Drupdater will fix it. It needs a human decision: replace the module, adopt it,
+or accept the risk.
+
+Surfacing it in the routine update pull request is the cheapest possible way to keep that
+decision from being forgotten for a year.
 
 ## Report section
 
@@ -60,11 +60,7 @@ Omitted when every installed module is supported.
 
 ## A note on silent failure
 
-This addon was, at one point, silently broken on Drupal 11: the procedural `UPDATE_*`
-constants it relied on were removed, and because it swallows its own errors every run
-stayed green while it reported nothing at all.
-
-That is the reason it reports to the run report even when it finds nothing worth
-mentioning in the pull request, and the reason CI asserts on the presence of its report
-key rather than only on the run's `status`. See [Consume the run
-report](../../how-to/consume-the-run-report.md).
+This addon was once broken for months without any run going red — the reason the report
+records it even when it finds nothing, and the reason to assert on its report key rather
+than on the run's `status`. See [Why a run
+report](../../explanation/why-a-run-report.md).

--- a/docs/reference/addons/update-hooks.md
+++ b/docs/reference/addons/update-hooks.md
@@ -10,14 +10,6 @@ reviewer knows what will run on deploy.
 | Report key | `update_hooks` |
 | Pull request section | "📄 Job Logs" → "⚙️ Update Hooks" |
 
-## Why it exists
-
-A dependency bump that carries database update hooks is a different kind of change from
-one that does not. Hooks run on deploy, may take a long time on a large site, and may not
-be reversible. Listing them turns "this updates Drupal core" into "this updates Drupal
-core and will run these four schema changes", which is the information a reviewer
-actually needs to schedule the deploy.
-
 ## What it does
 
 Runs immediately before each site's update hooks are executed, and asks Drush for the
@@ -26,6 +18,14 @@ the state after any other addon on that event has finished.
 
 Sites are processed concurrently, so the collected map is mutex-guarded and keyed by
 site: the same module can have different pending hooks on different sites.
+
+## Why it exists
+
+A dependency bump that carries database update hooks is a different kind of change from
+one that does not. Hooks run on deploy, may take a long time on a large site, and may not
+be reversible. Listing them turns "this updates Drupal core" into "this updates Drupal
+core and will run these four schema changes", which is the information a reviewer
+actually needs to schedule the deploy.
 
 ## Report section
 

--- a/docs/reference/cli/check.md
+++ b/docs/reference/cli/check.md
@@ -46,7 +46,7 @@ In short:
 7. `token authenticates` — only when a token was given
 
 With `--full`, three more are appended: `clone for full check`, `composer install`, and
-`site "<name>": installs from configuration` per site.
+`site "<name>" installs from configuration` per site.
 
 ## Safety
 
@@ -63,8 +63,7 @@ Results are printed one per line, with failures detailed:
 ✓ addon names resolve
 ✓ git history complete (not a shallow clone)
 ✓ PHP platform requirements satisfied
-✗ site "default": settings.php
-    not found at web/sites/default/settings.php
+✗ site "default": settings.php: not found at web/sites/default/settings.php
 ✓ repository host recognized (GitHub/GitLab)
 ```
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -77,8 +77,8 @@ is only reported in the `drupdater_version` field of the [run report](../run-rep
 
 - All flags on the root command are **persistent**, so `check` accepts every one of them
   too.
-- `--verbose` raises logging to debug level and additionally logs the resolved
-  configuration.
+- `--verbose` raises logging to debug level. On an update it also logs the resolved
+  configuration; `check` reports the configuration through its own results instead.
 - Log output is structured and passes through a redactor, so registered secrets never
   appear — see [Credentials and
   redaction](../../explanation/credentials-and-redaction.md).

--- a/docs/reference/docker-images.md
+++ b/docs/reference/docker-images.md
@@ -26,18 +26,20 @@ Each variant is tagged on release:
 
 | Tag form | Example | Moves? |
 |---|---|---|
-| `<major>.<minor>.<patch>` | `0.12.0` | No |
-| `v<major>.<minor>.<patch>` | `v0.12.0` | No |
-| `<major>.<minor>` | `0.12` | Yes, within the minor |
+| `<major>.<minor>.<patch>` | `0.3.6` | No |
+| `v<major>.<minor>.<patch>` | `v0.3.6` | No |
+| `<major>.<minor>` | `0.3` | Yes, within the minor |
 | `<major>` | `0` | Yes, within the major |
 | `latest` | | Yes, always |
 
 !!! warning "Pin in production"
 
     Drupdater is pre-1.0. The CLI surface and config format may change between minor
-    versions, so `latest` and the floating `0` tag can change behaviour under you. Pin to
-    a full version — `ghcr.io/drupdater/drupdater-php8.3:v0.12.0` — for a scheduled
-    pipeline, and bump it deliberately.
+    versions, so `latest` and the floating `0` tag can change behaviour under you.
+
+    The examples throughout this documentation use `latest` for brevity. In a scheduled
+    pipeline, replace it with the full version from the [latest
+    release](https://github.com/drupdater/drupdater/releases) and bump it deliberately.
 
 ## Entrypoint
 
@@ -48,7 +50,7 @@ must be cleared before `script:` can run:
 
 ```yaml
 image:
-  name: ghcr.io/drupdater/drupdater-php8.3:v0.12.0
+  name: ghcr.io/drupdater/drupdater-php8.3:latest
   entrypoint: [""]
 script:
   - /opt/drupdater/bin "$DRUPDATER_TOKEN"
@@ -59,7 +61,7 @@ too:
 
 ```yaml
 container:
-  image: ghcr.io/drupdater/drupdater-php8.3:v0.12.0
+  image: ghcr.io/drupdater/drupdater-php8.3:latest
 steps:
   - run: /opt/drupdater/bin "${{ secrets.DRUPDATER_TOKEN }}"
 ```
@@ -67,7 +69,7 @@ steps:
 Run directly with `docker run`, the entrypoint applies and you pass only arguments:
 
 ```bash
-docker run ghcr.io/drupdater/drupdater-php8.3:v0.12.0 <token> --dry-run
+docker run ghcr.io/drupdater/drupdater-php8.3:latest <token> --dry-run
 ```
 
 ## What is in the image
@@ -109,7 +111,7 @@ a parent directory and point `--working-dir` at the checkout within it:
 
 ```bash
 docker run -v "$(pwd)":/workspace/project -w /workspace \
-  ghcr.io/drupdater/drupdater-php8.3:v0.12.0 \
+  ghcr.io/drupdater/drupdater-php8.3:latest \
   "$DRUPDATER_TOKEN" --working-dir /workspace/project
 ```
 

--- a/docs/reference/preflight-checks.md
+++ b/docs/reference/preflight-checks.md
@@ -109,6 +109,18 @@ The repository is cloned to a **scratch directory** — never the live working c
 everything is removed afterwards, including the clone, each `<site>.sqlite` and
 `private/<site>`.
 
+Four names can appear in this tier. Three of them replace the rest of the tier when they
+fail, because there is nothing left to check:
+
+### `sites install from configuration`
+
+Appears **only on failure**, when there is no repository URL to clone:
+
+```text
+✗ sites install from configuration: no repository URL to clone (pass --repository-url or
+run inside a checkout with an origin remote)
+```
+
 ### `clone for full check`
 
 Appears only if cloning fails. The branch defaults to `main` when not otherwise set.
@@ -119,7 +131,12 @@ A real `composer install` against the scratch clone. Catches unreachable private
 registries, missing [`COMPOSER_AUTH`](../how-to/use-private-packagist.md), and lock files
 that cannot be satisfied.
 
-### `site "<name>": installs from configuration`
+### `drush site-install --existing-config`
+
+Appears only on failure, when the Drush cache could not be initialised — so no site could
+be installed to check.
+
+### `site "<name>" installs from configuration`
 
 A real `drush site-install --existing-config` per site. **This is the definitive check**
 — it is exactly what the update's baseline install phase does, and the single most common

--- a/docs/reference/run-report.md
+++ b/docs/reference/run-report.md
@@ -17,7 +17,7 @@ drupdater --dry-run --report ./drupdater-report.json
 ```json
 {
   "schema_version": 1,
-  "drupdater_version": "v0.12.0",
+  "drupdater_version": "v0.3.6",
   "started_at": "2026-07-25T02:00:00Z",
   "finished_at": "2026-07-25T02:14:31Z",
   "duration_seconds": 871.4,
@@ -166,7 +166,7 @@ drupdater check --report ./preflight.json
 ```json
 {
   "schema_version": 1,
-  "drupdater_version": "v0.12.0",
+  "drupdater_version": "v0.3.6",
   "checked_at": "2026-07-25T02:00:00Z",
   "ok": false,
   "results": [

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -20,6 +20,9 @@
   --md-primary-bg-color--light: rgba(255, 255, 255, 0.7);
   --md-accent-fg-color: #7287fd;
   --md-accent-fg-color--transparent: rgba(114, 135, 253, 0.1);
+  /* Landing-page hero wash — two tints of the same lavender. */
+  --dr-glow-strong: rgba(114, 135, 253, 0.28);
+  --dr-glow-soft: rgba(114, 135, 253, 0.12);
 }
 
 [data-md-color-scheme="slate"] {
@@ -30,6 +33,8 @@
   --md-primary-bg-color--light: rgba(30, 30, 46, 0.7);
   --md-accent-fg-color: #b4befe;
   --md-accent-fg-color--transparent: rgba(180, 190, 254, 0.1);
+  --dr-glow-strong: rgba(180, 190, 254, 0.18);
+  --dr-glow-soft: rgba(180, 190, 254, 0.07);
 }
 
 /*
@@ -43,4 +48,213 @@
 
 .md-typeset table:not([class]) code {
   white-space: nowrap;
+}
+
+/*
+ * Landing page (docs/index.md).
+ *
+ * The page hides the sidebars, so everything below is scoped to the classes it
+ * introduces rather than to a body class — nothing here can leak into a normal
+ * documentation page.
+ */
+
+.dr-hero {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+  margin: -1rem -0.8rem 2.5rem;
+  padding: 2.6rem 2rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 1rem;
+  background:
+    radial-gradient(75% 130% at 8% 0%, var(--dr-glow-strong), transparent 68%),
+    radial-gradient(60% 110% at 100% 100%, var(--dr-glow-soft), transparent 70%),
+    var(--md-code-bg-color);
+}
+
+@media screen and (min-width: 60em) {
+  .dr-hero {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+    padding: 3.2rem 2.6rem;
+  }
+}
+
+.md-typeset .dr-hero h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  color: var(--md-primary-fg-color);
+}
+
+.md-typeset .dr-hero__tagline {
+  margin: 0 0 1rem;
+  font-size: 1.05rem;
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset .dr-hero__copy > p {
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .dr-hero .md-button {
+  margin: 0.4rem 0.4rem 0 0;
+}
+
+.dr-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 1.4rem !important;
+}
+
+.dr-badge {
+  padding: 0.15rem 0.6rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 2rem;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--md-default-fg-color--light);
+  background: var(--md-default-bg-color);
+}
+
+.dr-badge--warn {
+  border-color: var(--md-accent-fg-color);
+  color: var(--md-accent-fg-color);
+}
+
+/*
+ * Terminal mock. Decorative — it is not real output, so Material's injected
+ * copy button (content.code.copy applies to every `pre > code`) is suppressed.
+ */
+.dr-term .md-code__button,
+.dr-term .md-code__nav {
+  display: none;
+}
+
+/*
+ * Below the two-column breakpoint the mock is wider than the viewport and would
+ * be clipped mid-line. It carries no information the copy beside it lacks, so it
+ * is simply dropped on narrow screens.
+ */
+@media screen and (max-width: 59.98em) {
+  .dr-term {
+    display: none;
+  }
+}
+
+.dr-term {
+  overflow: hidden;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.6rem;
+  box-shadow: 0 1rem 2.5rem rgb(0 0 0 / 18%);
+  background: var(--md-default-bg-color);
+}
+
+.dr-term__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.7rem;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  background: var(--md-code-bg-color);
+}
+
+.dr-term__bar i {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--md-default-fg-color--lighter);
+}
+
+.dr-term__bar em {
+  margin-left: 0.4rem;
+  font-size: 0.6rem;
+  font-style: normal;
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .dr-term__body {
+  overflow-x: auto;
+  margin: 0;
+  padding: 1rem;
+  font-size: 0.62rem;
+  line-height: 1.85;
+  color: var(--md-default-fg-color--light);
+  background: transparent;
+}
+
+.dr-term__body .p { color: var(--md-accent-fg-color); }
+.dr-term__body .d { color: var(--md-default-fg-color--lighter); }
+.dr-term__body .ok { color: var(--md-primary-fg-color); font-weight: 600; }
+.dr-term__body .c { color: var(--md-default-fg-color--lighter); font-style: italic; }
+
+/* Card grids lift on hover so the four Diátaxis entry points read as targets. */
+.md-typeset .dr-cards > ul > li {
+  border-radius: 0.6rem;
+  transition: transform 125ms, box-shadow 125ms, border-color 125ms;
+}
+
+.md-typeset .dr-cards > ul > li:hover {
+  transform: translateY(-2px);
+  border-color: var(--md-accent-fg-color);
+  box-shadow: 0 0.4rem 1.2rem rgb(0 0 0 / 12%);
+}
+
+.md-typeset .dr-cards > ul > li .twemoji,
+.md-typeset .dr-cards > ul > li .lg {
+  color: var(--md-accent-fg-color);
+}
+
+/* The seven phases, as a numbered strip. */
+.md-typeset ol.dr-steps {
+  display: grid;
+  gap: 0.7rem;
+  margin: 1.2rem 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: dr-step;
+}
+
+@media screen and (min-width: 45em) {
+  .md-typeset ol.dr-steps {
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  }
+}
+
+.md-typeset ol.dr-steps > li {
+  position: relative;
+  margin: 0;
+  padding: 0.8rem 0.9rem 0.8rem 2.4rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.5rem;
+  counter-increment: dr-step;
+}
+
+.md-typeset ol.dr-steps > li::before {
+  content: counter(dr-step);
+  position: absolute;
+  top: 0.8rem;
+  left: 0.8rem;
+  font-size: 0.85rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--md-accent-fg-color);
+  opacity: 0.55;
+}
+
+.md-typeset ol.dr-steps > li strong {
+  display: block;
+  font-size: 0.72rem;
+}
+
+.md-typeset ol.dr-steps > li span {
+  display: block;
+  font-size: 0.68rem;
+  line-height: 1.5;
+  color: var(--md-default-fg-color--light);
 }

--- a/docs/tutorials/first-run.md
+++ b/docs/tutorials/first-run.md
@@ -71,30 +71,31 @@ site is installed from scratch to build a baseline database, then the update run
 
 ## Step 3: read the log
 
-The run works through seven phases in order. In the log you will see each one start and
-finish:
+The log narrates the work as it happens:
 
 ```text
-INFO  starting phase  {"phase": "acquire working copy"}
-INFO  starting phase  {"phase": "preflight"}
-INFO  starting phase  {"phase": "composer install"}
-INFO  starting phase  {"phase": "baseline site install"}
-INFO  starting phase  {"phase": "update shared code"}
-INFO  starting phase  {"phase": "site update"}
+INFO  using checkout        {"url": "https://github.com/you/site.git", "branch": "main"}
+INFO  running composer install
+INFO  updating dependencies
+INFO  dependencies updated  {"total": 16, "installed": 2, "upgraded": 14, "downgraded": 0, "removed": 0}
+INFO  removing deprecations
+INFO  updating coding styles
+INFO  updating site         {"site": "default"}
+INFO  update hooks found    {"site": "default", "count": 4}
+INFO  exporting configuration {"site": "default"}
+INFO  update finished
 ```
 
-There is no `publish` phase — that is the one `--dry-run` skips.
+The log does not announce the seven phases — those are recorded in the report, with their
+durations, which you will read in the next step.
 
-Somewhere in `update shared code` you will see the summary of what Composer did:
-
-```text
-INFO  update summary  {"upgraded": 14, "installed": 2, "removed": 0, "downgraded": 0}
-```
+Nothing is pushed and no request is created: that is the `publish` phase, and `--dry-run`
+skips it.
 
 If instead you see:
 
 ```text
-WARN  update aborted  {"error": "no changes detected"}
+WARN  update aborted        {"error": "no changes detected"}
 ```
 
 then the project is already fully up to date. That is a success, not a failure — the
@@ -189,8 +190,8 @@ commit by commit.
 
 The branch name — `update-3f81a2c` — is derived from a hash of the resulting
 `composer.lock`. Run this again over unchanged dependencies and you will get the same name,
-and the run will abort with `branch already exists`. That is what stops duplicate pull
-requests.
+and the run will abort with `branch update-3f81a2c already exists, skipping`. That is
+what stops duplicate pull requests.
 
 ## Step 6: clean up
 

--- a/docs/tutorials/scheduled-updates.md
+++ b/docs/tutorials/scheduled-updates.md
@@ -168,8 +168,8 @@ the command:
 ```
 
 Trigger it manually — **Run workflow** on GitHub, or **Play** on the pipeline schedule in
-GitLab — and watch the log. You should see the phases from the previous tutorial, ending
-without a `publish` phase.
+GitLab — and watch the log. It should end with `update finished` and no merge request
+URL: publishing is what `--dry-run` skips.
 
 This also proves the checkout is deep enough and the image PHP version is right, which are
 the two things that differ between your machine and CI.
@@ -185,30 +185,24 @@ Trigger the workflow manually once more. This time it will:
 3. Fill the description with the dependency table, pending update hooks, and any patch or
    unsupported-module findings.
 
-Open it. That description is the whole point of the tool — it is a review, not a diff.
+Open it and read the description. It is what you review, rather than the diff.
 
 !!! note "If nothing happened"
 
     Check the log for `update aborted`. `no changes detected` means the project is already
-    current; `branch update-… already exists` means an identical update is already open.
-    Both exit `0` deliberately.
+    current; `branch update-… already exists, skipping` means an identical update is
+    already open. Both exit `0` deliberately.
 
 ## Step 6: add the daily security job
 
-Security fixes should not wait for Monday.
+Security fixes should not wait for Monday. Add a second job that differs from the first in
+exactly two ways: it runs daily, and it passes `--security`.
 
 === "GitHub Actions"
 
     Copy `.github/workflows/drupdater.yml` to
-    `.github/workflows/drupdater-security.yml` and change two things — the cron, and add
-    `--security`:
-
-    ```yaml
-    on:
-      schedule:
-        - cron: "0 4 * * *"   # every day 04:00 UTC
-      workflow_dispatch:
-    ```
+    `.github/workflows/drupdater-security.yml`, change the cron to `"0 4 * * *"`, and add
+    the flag:
 
     ```yaml
           - run: /opt/drupdater/bin --security
@@ -218,7 +212,8 @@ Security fixes should not wait for Monday.
 
 === "GitLab CI"
 
-    Add a second job alongside the first:
+    Add a second job reusing the same base, and a second pipeline schedule with pattern
+    `0 4 * * *` and `DRUPDATER_SCHEDULE` set to `daily`:
 
     ```yaml
     drupdater:security:
@@ -228,9 +223,6 @@ Security fixes should not wait for Monday.
       rules:
         - if: $CI_PIPELINE_SOURCE == "schedule" && $DRUPDATER_SCHEDULE == "daily"
     ```
-
-    Then create a second pipeline schedule with pattern `0 4 * * *` and
-    `DRUPDATER_SCHEDULE` set to `daily`.
 
 A security run differs from a normal one in three ways:
 
@@ -245,50 +237,29 @@ behaviour, not a misconfiguration.
 
 ## Step 7: keep the report
 
-Have CI archive the machine-readable report so a failed run leaves something better than a
-log:
+Add `--report ./report.json` to the run command and have CI archive the file, so a failed
+run leaves something better than a log behind. The exact snippet for your platform is in
+[Run in GitHub Actions](../how-to/github-actions.md#a-run-report-artifact) and [Run in
+GitLab CI](../how-to/gitlab-ci.md#a-run-report-artifact).
 
-=== "GitHub Actions"
-
-    ```yaml
-          - run: /opt/drupdater/bin --report ./report.json
-            env:
-              DRUPDATER_TOKEN: ${{ secrets.DRUPDATER_TOKEN }}
-
-          - uses: actions/upload-artifact@v4
-            if: always()
-            with:
-              name: drupdater-report
-              path: ./report.json
-    ```
-
-=== "GitLab CI"
-
-    ```yaml
-      script:
-        - /opt/drupdater/bin --report ./drupdater-report.json
-      artifacts:
-        when: always
-        paths:
-          - drupdater-report.json
-    ```
-
-`if: always()` / `when: always` matters — the report is written on failures too, and that
-is when you want it most.
+Archive it **on failure too** — `if: always()` on GitHub, `when: always` on GitLab. The
+report is written on every outcome, and a failed run is when you most want it. See
+[Consume the run report](../how-to/consume-the-run-report.md).
 
 ## Step 8: pin the image
 
 You have been using `:latest`. Drupdater is pre-1.0, so its CLI and config format can
 change between minor versions — and `latest` will pick that up without warning.
 
-Replace it with a full version everywhere:
+Take the current tag from the [latest
+release](https://github.com/drupdater/drupdater/releases) and use it everywhere in place
+of `latest`:
 
 ```yaml
-image: ghcr.io/drupdater/drupdater-php8.3:v0.12.0
+image: ghcr.io/drupdater/drupdater-php8.3:v0.3.6
 ```
 
-Check the [latest release](https://github.com/drupdater/drupdater/releases) for the
-current tag, and bump it deliberately.
+Bump it deliberately when you want the new version.
 
 ## What you built
 

--- a/internal/addon/composer_patches_1_test.go
+++ b/internal/addon/composer_patches_1_test.go
@@ -922,7 +922,7 @@ func TestComposer_Patches_1_RenderTemplate(t *testing.T) {
 				Reason:           "reason1",
 			},
 			{
-				PatchDescription: "Issue #issue1: [title1](link1) was fixed in version 2.0",
+				PatchDescription: "Issue #3123456: [Fix the thing](https://www.drupal.org/i/3123456) was fixed in version 2.0",
 				Package:          "package1",
 				PatchPath:        "patch1",
 				Reason:           "Fixed",

--- a/internal/addon/testdata/composer_patches_1.md
+++ b/internal/addon/testdata/composer_patches_1.md
@@ -10,7 +10,7 @@ The following patches were removed as they are no longer needed:
   - Patch: `patch1`
   - Reason: reason1
 
-- Issue #issue1: [title1](link1) was fixed in version 2.0:
+- Issue #3123456: [Fix the thing](https://www.drupal.org/i/3123456) was fixed in version 2.0:
 
   - Package: package1
   - Patch: `patch1`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ copyright: Licensed under the Apache License 2.0
 
 theme:
   name: material
+  custom_dir: overrides
   language: en
   icon:
     repo: fontawesome/brands/github
@@ -47,6 +48,9 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
+  # Analytics is opt-in per build: the publish workflow sets DRUPDATER_GOATCOUNTER,
+  # so `mkdocs serve` and local builds emit no tracking script at all.
+  goatcounter: !ENV [DRUPDATER_GOATCOUNTER, false]
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/drupdater/drupdater

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{#
+  GoatCounter, on the published site only.
+
+  config.extra.goatcounter comes from the DRUPDATER_GOATCOUNTER environment
+  variable, which only .github/workflows/docs.yml sets — so a local build or
+  `mkdocs serve` produces pages with no tracking script in them.
+
+  The theme does not enable navigation.instant, so each page is a full document
+  load and count.js registers the hit by itself. Add a hook here if instant
+  navigation is ever turned on.
+#}
+{% block extrahead %}
+  {% if config.extra.goatcounter %}
+    <script data-goatcounter="https://drupdater.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
A pass over every page in `docs/`, checking each claim against the code. Also adds a landing page for the docs site.

## Wrong facts

| | |
|---|---|
| **Pinned version** | Every example pinned `v0.12.0`. That version does not exist — the latest tag is `v0.3.6` — so the recommended pin failed to pull. Examples now use `:latest`, and the pin advice points at the releases page. |
| **Tutorial log output** | "Read the log" was built on lines the tool never emits. Phases are recorded in the report, not logged (`Recorder.Run` logs nothing), and the Composer summary is `dependencies updated` with `total/installed/upgraded/downgraded/removed`, not `update summary`. Rewritten around the real messages. |
| **`check` output** | Docs showed failures as two lines with an indented detail. `printCheckResults` prints one: `✗ name: detail`. |
| **Full-tier check names** | The name has no colon — `site "default" installs from configuration`. Two more were undocumented: `sites install from configuration` (no repository URL) and `drush site-install --existing-config` (cache init failure). Anyone matching on `.results[].name` matched nothing. |
| **Abort message** | Quoted as `branch update-… already exists`; the real string is `branch … already exists, skipping`. |
| **`--verbose`** | Documented as logging the resolved configuration for every command. `check` calls `internal.LoadConfigFile` directly and never reaches `loadProjectConfig`, so it does not. Qualified in `cli/index.md` and `migrate-config-layout.md`. |

Everything else checked out: the ten addons and four mandatory ones, all event names and priorities, the ten persistent flags and defaults, the seven phase names, cheap-check order, the report schema, the seven environment variables, the Dockerfile contents, both MR title formats.

## Structure

- **Landing page** — `docs/index.md` gets a hero, entry-point cards and the seven phases as a strip. The terminal mock shows real log output.
- **Less duplication** — the tutorial no longer re-prints the security job and report-artifact YAML the how-to guides own; the `unsupported_modules` anecdote is told once in `why-a-run-report.md` and referenced from the other three pages.
- **Addon pages** lead with "What it does" rather than "Why it exists".

## One code change

`internal/addon/testdata/composer_patches_1.md` and its input in `composer_patches_1_test.go` used `link1` as a patch URL. That file is embedded into the addon reference page, so `mkdocs build --strict` warned on every build and the published example showed a dead link. It is now a real Drupal.org issue URL.

## Analytics

A theme override (`overrides/main.html`) adds GoatCounter's `count.js`, gated on `config.extra.goatcounter`, which comes from the `DRUPDATER_GOATCOUNTER` environment variable. `.github/workflows/docs.yml` sets it on its build step and nothing else does, so only the published site is counted — `mkdocs serve` and `make docs-build` emit no tracking script.

`navigation.instant` is off, so every page is a full document load and `count.js` registers the hit unaided. A comment in the template flags that an instant-navigation hook would be needed if that changes.

## Verification

- `mkdocs build --strict` — clean, no warnings
- `go test ./...` — 747 pass
- Landing page checked in Chromium at 1440px and 390px, light and dark
- Analytics gate checked in all three states: default build 0/50 pages, `DRUPDATER_GOATCOUNTER=true` 50/50, `=false` 0/50

🤖 Generated with [Claude Code](https://claude.com/claude-code)
