### PR TITLE
ci: run the test suite under the race detector

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,8 +33,13 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    # -race is the point of this step beyond running the tests: drupdater installs and updates
+    # sites concurrently (one goroutine per site, via errgroup) and addons accumulate state
+    # across those goroutines behind a mutex. A dropped or misplaced lock produces no failure
+    # on its own -- the tests pass, and the corruption only shows up as a wrong report or a
+    # crash under load on a real project.
     - name: Test
-      run: go test -v ./... -coverprofile=coverage.txt
+      run: go test -race -v ./... -coverprofile=coverage.txt
 
     - name: Coverage Summary
       if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Changing a golden file changes the published example. `internal/addon/testdata/c
 ```bash
 make build          # Build binary
 make test           # Run all tests (go test -v ./...)
+make test-race      # Run tests under the race detector, as CI does
 make mutate         # Mutation testing over the whole module (mutago, pinned in go.mod)
 make lint           # golangci-lint (govet, staticcheck, gosec, etc. — see .golangci.yml) + hadolint on the Dockerfile
 make fmt            # Format code

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test mutate clean mock lint fmt fix run docker-build docker-run docs-serve docs-build help
+.PHONY: build test test-race mutate clean mock lint fmt fix run docker-build docker-run docs-serve docs-build help
 
 # Variables
 BINARY_NAME=drupdater
@@ -15,6 +15,9 @@ build: ## Build the binary
 
 test: ## Run tests
 	go test -v ./...
+
+test-race: ## Run tests under the race detector (as CI does)
+	go test -race ./...
 
 clean: ## Clean build artifacts
 	rm -f ${BINARY_NAME}

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -17,6 +17,7 @@ make build
 ```bash
 make build          # build the binary (injects the version via -ldflags)
 make test           # go test -v ./...
+make test-race      # go test -race ./... (what CI runs)
 make mutate         # mutation testing over the whole module (mutago)
 make lint           # golangci-lint + hadolint on the Dockerfile
 make fmt            # go fmt ./...
@@ -101,6 +102,23 @@ get past it — fix the code.
 
 Changed packages must reach **≥ 90%** coverage. The hook prints per-package totals; add
 tests before committing if any package is below.
+
+## The race detector
+
+CI runs the test suite with `-race`. Reproduce a CI-only failure locally with:
+
+```bash
+make test-race
+```
+
+It is on because drupdater is concurrent where it matters: sites are installed and updated one
+goroutine per site through an `errgroup`, and addons accumulate state across those goroutines
+behind a mutex. A dropped or misplaced lock does not fail a test on its own — the suite passes
+and the corruption surfaces later as a wrong report, or as a crash under load on a real
+project. The race detector is the only thing in the pipeline that catches that class at all.
+
+It costs roughly six times the runtime (about 20 s to about 2 min on the CI runner), which is
+why `make test` stays fast for the edit-run loop and only CI pays the full price.
 
 ## Mutation testing
 


### PR DESCRIPTION
## Why

drupdater is concurrent where it matters: `StartUpdate` installs and updates sites one goroutine per site through an `errgroup`, and addons accumulate state across those goroutines behind a mutex (`CLAUDE.md` calls this out as an invariant).

A dropped or misplaced lock produces **no test failure on its own**. The suite passes, and the corruption surfaces later — as a wrong run report, or as a crash under load on a real project with several sites. Nothing in the pipeline caught that class.

## What found it

Mutation testing, in the follow-up to #196. One mutator turns

```go
defer r.mu.Unlock()   // internal/logging/redact.go, Register()
```

into an immediate `r.mu.Unlock()`, leaving the map writes unsynchronised. That mutant **survives the entire suite**. It dies as soon as `-race` is on.

The test that should catch it already exists — `TestRedactorRegisterIsSafeForConcurrentUse` — the suite simply was not looking. That is the gap this closes.

## What changed

| File | Change |
|---|---|
| `.github/workflows/go.yml` | `go test` → `go test -race` in the `test` job |
| `Makefile` | new `make test-race` target |
| `docs/contributing/development.md` | new "The race detector" section, target listed |
| `CLAUDE.md` | target listed in the commands block |

`make test` stays fast for the edit-run loop; `make test-race` reproduces a CI-only failure locally.

## Cost

Roughly **six times the runtime** — about 20 s to about 2 min, measured on a cold cache in this environment. That is why only CI pays it rather than every local run.

## Verification

- `go test -race ./...` — **clean**, all 14 packages, no data race reported. This adds a gate rather than fixing a live bug.
- `make test-race` — passes
- `golangci-lint run ./...` — 0 issues
- `mkdocs build --strict` — clean

## Note on scope

Independent of the mutation-testing work and branched from current `main`; it touches only CI config, the Makefile and docs. No production or test code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVzEKAHHatNqVLvhs9vLhx)_