### PR TITLE
test: introduce property-based testing with rapid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Changing a golden file changes the published example. `internal/addon/testdata/c
 ```bash
 make build          # Build binary
 make test           # Run all tests (go test -v ./...)
+make test-property  # Only the property tests, with far more generated cases (rapid)
 make mutate         # Mutation testing over the whole module (mutago, pinned in go.mod)
 make lint           # golangci-lint (govet, staticcheck, gosec, etc. — see .golangci.yml) + hadolint on the Dockerfile
 make fmt            # Format code
@@ -124,6 +125,12 @@ Mocks are generated with mockery v3 (config in `.mockery.yml`). After changing a
 ## Mutation testing
 
 `mutago` (pinned via the `tool` directive in `go.mod`, configured in `mutago.yaml`) scores whether the tests *assert* rather than merely execute. CI enforces it on the lines a PR changes (`mutation` job in `.github/workflows/go.yml`, fails below 75 % MSI) and reports the whole module weekly (`.github/workflows/mutation.yml`, one matrix leg per package, never blocking). Suppress a genuinely equivalent mutant with a `// mutator-disable-next-line <mutator>` comment and a reason — never by lowering the threshold. Details: `docs/contributing/development.md`.
+
+## Property-based testing
+
+`pgregory.net/rapid` states invariants over generated input, next to the example-based tests. Convention: file `<subject>_property_test.go`, every test named `TestProperty…` (`make test-property` selects on that prefix). A property must state a law — idempotent, order-independent, round-trips, leaks nothing — never a second implementation of the function.
+
+**The seed is random on every run.** So when a property finds a bug, fix the code *and* add an ordinary test naming the counterexample: the blocking mutation gate must not depend on the exploration happening to hit the right input. Counterexamples rapid records under `testdata/rapid/*.fail` are replayed automatically and belong in the commit. Details: `docs/contributing/development.md`.
 
 ## Docker
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test mutate clean mock lint fmt fix run docker-build docker-run docs-serve docs-build help
+.PHONY: build test test-property mutate clean mock lint fmt fix run docker-build docker-run docs-serve docs-build help
 
 # Variables
 BINARY_NAME=drupdater
@@ -16,6 +16,12 @@ build: ## Build the binary
 test: ## Run tests
 	go test -v ./...
 
+# RAPID_CHECKS rather than -rapid.checks: rapid only registers its flags in test binaries that
+# import it, so passing the flag to ./... fails on every package that has no property tests. The
+# environment variable is read at init and simply ignored by those packages.
+test-property: ## Run only the property tests, with far more generated cases than `make test`
+	RAPID_CHECKS=10000 go test ./... -run TestProperty
+
 clean: ## Clean build artifacts
 	rm -f ${BINARY_NAME}
 	go clean
@@ -30,8 +36,11 @@ lint: ## Run linters
 deadcode: ## Find unreachable functions
 	go tool deadcode -test ./...
 
+# RAPID_NOFAILFILE stops the property tests from recording a counterexample for every mutant
+# they kill. Those files are the point of a mutation run, not a finding about the real code, and
+# rapid replays whatever it finds under testdata/rapid on the next ordinary test run.
 mutate: ## Run mutation testing over the whole module
-	go tool mutago --config mutago.yaml --coverage --quiet --no-diffs \
+	RAPID_NOFAILFILE=1 go tool mutago --config mutago.yaml --coverage --quiet --no-diffs \
 		--logger-summary-json ./...
 
 fmt: ## Format code

--- a/cmd/root_property_test.go
+++ b/cmd/root_property_test.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// COMPOSER_AUTH is a JSON blob of credentials whose shape Composer defines and extends, so the
+// walk that finds the secrets in it has to hold for structures nobody here wrote down. The
+// properties end where it matters: the value that reaches the log.
+
+// authLeafGen generates one credential value.
+func authLeafGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-zA-Z0-9_-]{8,24}`)
+}
+
+// authTreeGen builds a COMPOSER_AUTH-shaped JSON tree and reports, alongside it, exactly which
+// of its string leaves are secrets. key is the object key the value was reached through.
+//
+// The bookkeeping states the documented rule rather than mirroring the walk: a string is a
+// secret unless it was reached through a "username" key — Composer's http-basic form commonly
+// sets that to the literal word "token", and redacting it would black out unrelated log output.
+// An array inherits the key it sits under, an object gives each of its values its own, and
+// numbers and booleans are never secrets. Encoding the rule here is what lets the property
+// generate nesting nobody wrote down and still know the right answer.
+func authTreeGen(depth int, key string) *rapid.Generator[authTree] {
+	leafGen := func(t *rapid.T) authTree {
+		leaf := authLeafGen().Draw(t, "leaf")
+		if key == "username" {
+			return authTree{value: leaf}
+		}
+		return authTree{value: leaf, secrets: []string{leaf}}
+	}
+
+	return rapid.Custom(func(t *rapid.T) authTree {
+		if depth == 0 {
+			return leafGen(t)
+		}
+
+		switch rapid.SampledFrom([]string{"leaf", "number", "bool", "object", "array"}).Draw(t, "kind") {
+		case "number":
+			return authTree{value: float64(rapid.IntRange(0, 1000).Draw(t, "number"))}
+		case "bool":
+			return authTree{value: rapid.Bool().Draw(t, "bool")}
+		case "array":
+			items := rapid.SliceOfN(authTreeGen(depth-1, key), 0, 3).Draw(t, "items")
+			value := make([]any, 0, len(items))
+			var secrets []string
+			for _, item := range items {
+				value = append(value, item.value)
+				secrets = append(secrets, item.secrets...)
+			}
+			return authTree{value: value, secrets: secrets}
+		case "object":
+			keys := rapid.SliceOfNDistinct(
+				rapid.SampledFrom([]string{"http-basic", "bearer", "github-oauth", "gitlab-token", "username", "password", "example.com"}),
+				0, 4, rapid.ID,
+			).Draw(t, "keys")
+			value := map[string]any{}
+			var secrets []string
+			for _, childKey := range keys {
+				child := authTreeGen(depth-1, childKey).Draw(t, "child-"+childKey)
+				value[childKey] = child.value
+				secrets = append(secrets, child.secrets...)
+			}
+			return authTree{value: value, secrets: secrets}
+		default:
+			return leafGen(t)
+		}
+	})
+}
+
+// authTree is a generated COMPOSER_AUTH value together with the leaves that must be redacted.
+type authTree struct {
+	value   any
+	secrets []string
+}
+
+func TestPropertyComposerAuthSecretLeavesFindsEveryCredential(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		tree := authTreeGen(3, "").Draw(t, "tree")
+
+		// Compared as a set: the walk iterates maps, which has no defined order.
+		assert.ElementsMatch(t, tree.secrets, composerAuthSecretLeaves(tree.value, ""))
+	})
+}
+
+func TestPropertyComposerAuthSecretLeavesIgnoresNesting(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		tree := authTreeGen(2, "").Draw(t, "tree")
+		wraps := rapid.IntRange(1, 4).Draw(t, "wraps")
+
+		// An array propagates the key it was reached through, so wrapping a value in any number
+		// of arrays must not change which of its leaves count as secrets. Composer nests its
+		// per-host blocks differently between auth types, and the walk has to be indifferent
+		// to how deep a credential sits.
+		wrapped := tree.value
+		for range wraps {
+			wrapped = []any{wrapped}
+		}
+
+		assert.ElementsMatch(t, composerAuthSecretLeaves(tree.value, ""), composerAuthSecretLeaves(wrapped, ""))
+	})
+}
+
+func TestPropertyRegisterComposerAuthRedactsEveryCredential(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		tree := authTreeGen(3, "").Draw(t, "tree")
+
+		encoded, err := json.Marshal(tree.value)
+		require.NoError(t, err)
+
+		redactor := logging.NewRedactor()
+		registerComposerAuth(redactor, string(encoded))
+
+		// The promise that matters, stated across the two packages that make it: whatever
+		// Composer echoes back of the credentials it was handed, the redactor knows the value.
+		for _, secret := range tree.secrets {
+			assert.Equal(t, "***", redactor.Redact(secret))
+			assert.NotContains(t, redactor.Redact("fetch failed for https://"+secret+"@example.com/x.git"), secret)
+		}
+	})
+}
+
+func TestPropertyRegisterComposerAuthFallsBackToTheRawValue(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Not JSON at all: an operator can put anything in the variable, and a value that fails
+		// to parse still has to be kept out of the log.
+		raw := authLeafGen().Draw(t, "raw")
+
+		redactor := logging.NewRedactor()
+		registerComposerAuth(redactor, raw)
+
+		assert.Equal(t, "***", redactor.Redact(raw))
+	})
+}
+
+func TestPropertyConfigurableAddonsMatchesTheRegistry(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		names := configurableAddons()
+
+		// The list `drupdater addons` prints is what a user may write in .drupdater.yaml, so it
+		// has to be exactly the registry minus the addons that always run. Adding a registry
+		// entry without touching this function would leave the command silent about it.
+		want := make([]string, 0, len(addonRegistry))
+		for name := range addonRegistry {
+			if name != "composer_audit" && !slices.Contains(mandatoryAddons, name) {
+				want = append(want, name)
+			}
+		}
+		assert.ElementsMatch(t, want, names)
+		assert.True(t, slices.IsSorted(names), "the printed list is sorted")
+		assert.Len(t, slices.Compact(slices.Clone(names)), len(names), "and free of duplicates")
+
+		// Round-trip: every name it offers is a name validateAddons accepts, under either run
+		// type, since a typo in one block aborts a run in the other too.
+		split := rapid.IntRange(0, len(names)).Draw(t, "split")
+		assert.NoError(t, validateAddons(internal.Config{RunTypes: internal.RunTypesConfig{
+			Normal:   internal.RunTypeConfig{Addons: names[:split]},
+			Security: internal.RunTypeConfig{Addons: names[split:]},
+		}}))
+	})
+}
+
+func TestPropertyValidateAddonsRejectsUnknownNamesInEitherRunType(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		unknown := rapid.StringMatching(`[a-z_]{1,20}`).
+			Filter(func(s string) bool { _, ok := addonRegistry[s]; return !ok }).
+			Draw(t, "unknown")
+		known := rapid.SliceOfNDistinct(rapid.SampledFrom(configurableAddons()), 0, 3, rapid.ID).Draw(t, "known")
+		inSecurity := rapid.Bool().Draw(t, "inSecurity")
+
+		config := internal.Config{RunTypes: internal.RunTypesConfig{
+			Normal:   internal.RunTypeConfig{Addons: known},
+			Security: internal.RunTypeConfig{Addons: known},
+		}}
+		if inSecurity {
+			config.RunTypes.Security.Addons = append(slices.Clone(known), unknown)
+		} else {
+			config.RunTypes.Normal.Addons = append(slices.Clone(known), unknown)
+		}
+
+		// Symmetric on purpose: a typo under run_types.security is caught on a normal run and
+		// the other way round, so the mistake surfaces the first time the tool runs at all
+		// rather than the first time a security update happens to be due.
+		err := validateAddons(config)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), unknown)
+	})
+}

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -17,6 +17,7 @@ make build
 ```bash
 make build          # build the binary (injects the version via -ldflags)
 make test           # go test -v ./...
+make test-property  # only the property tests, with far more generated cases
 make mutate         # mutation testing over the whole module (mutago)
 make lint           # golangci-lint + hadolint on the Dockerfile
 make fmt            # go fmt ./...
@@ -121,8 +122,11 @@ That takes 25–35 minutes — the module produces roughly 3000 mutants and each
 tests for its package. To iterate on one package, pass it directly:
 
 ```bash
-go tool mutago --config mutago.yaml --coverage ./pkg/phpcs
+RAPID_NOFAILFILE=1 go tool mutago --config mutago.yaml --coverage ./pkg/phpcs
 ```
+
+(`RAPID_NOFAILFILE=1` keeps the property tests from littering `testdata/rapid` — see
+[Property-based testing](#property-based-testing) below. `make mutate` sets it for you.)
 
 Each survivor prints as `ESCAPED <file>:<line> (<mutator>)` with a diff of the change that
 went unnoticed. Read it as a question: *which assertion would have caught this?*
@@ -194,6 +198,88 @@ buf := make([]byte, 0, 64)
 Use the narrowest form that works — name the specific mutator rather than `*` — and add a
 comment saying *why* the mutation is equivalent. If you cannot articulate the reason, the
 mutant is probably telling you about a missing assertion.
+
+## Property-based testing
+
+Mutation testing asks whether a test would notice if the code changed. Property-based testing
+asks the other half of the question: whether what the test asserts is true for every input, or
+only for the one somebody typed. An example test says *`SanitizeURL` removes the password from
+this URL*. A property says *`SanitizeURL` removes the password from **any** URL*, and then goes
+looking for a URL where it does not.
+
+The tool is [rapid](https://github.com/flyingmutant/rapid). It generates inputs, and when one
+fails it shrinks the counterexample to the smallest input that still fails before reporting it.
+
+```bash
+make test                    # properties run with the rest of the suite, 100 cases each
+make test-property           # only the properties, 10 000 cases each
+go test ./internal/logging -run TestProperty -rapid.checks=1000000   # one package, hard
+```
+
+Every `-rapid.*` flag has a `RAPID_*` environment variable twin, and across `./...` the variable
+is the one to use: rapid registers its flags only in test binaries that import it, so
+`-rapid.checks` makes `go test ./...` fail on every package that has no property tests.
+`make test-property` sets `RAPID_CHECKS` for that reason.
+
+### The convention
+
+- Properties live in `<subject>_property_test.go`, next to the ordinary `<subject>_test.go`.
+- Every property is named `TestProperty…`. That prefix is not decoration: `make test-property`
+  selects on it, so a property named anything else silently drops out of the deep run.
+- Generators stay local to the file that uses them. They are type-specific, and a shared package
+  of them would couple the test files together for no gain.
+- **A property must not re-implement the function.** If the expected value is computed the same
+  way the code computes it, the test passes by construction. State a law instead — idempotent,
+  order-independent, leaks nothing, round-trips — or compare against a *rule* that is simpler
+  than the implementation.
+
+### Reproducing a failure
+
+Every run uses a **fresh random seed**, so the suite explores new inputs each time and a
+property that passes once is not proven. When one fails, rapid prints how to get it back and
+writes a `.fail` file next to the test:
+
+```text
+To reproduce, specify -run="TestPropertyRedactCoversURLEncodedForms"
+  -rapid.failfile="testdata/rapid/…/…-20260801210044-6470.fail" (or -rapid.seed=11040429362938902097)
+```
+
+Commit that file. rapid replays every `.fail` file it finds before generating anything new, so a
+counterexample found once is checked forever after — the property-test equivalent of adding a
+regression case. Delete it only when the property itself was wrong.
+
+!!! warning "Run mutation testing with `RAPID_NOFAILFILE=1`"
+
+    A mutation run rewrites the source thousands of times, and every mutant a property kills
+    leaves a `.fail` file behind — hundreds of them, none of which says anything about the real
+    code, all of which would then be replayed by the next ordinary test run. `make mutate` sets
+    `RAPID_NOFAILFILE=1` for exactly that reason. Set it yourself when invoking `mutago`
+    directly:
+
+    ```bash
+    RAPID_NOFAILFILE=1 go tool mutago --config mutago.yaml --coverage ./internal/logging
+    ```
+
+    If you find `testdata/rapid` full of files after a mutation run, delete them — the ones
+    worth keeping came from a plain `go test`.
+
+### Properties and the mutation gate
+
+The mutation gate is blocking and the seed is random, which do not mix: a mutant killed only
+because that run happened to generate the right input would pass on one pull request and fail on
+the next. So when a property finds a real bug, fix the code **and** add an ordinary test naming
+the concrete counterexample. The property is the net; the example test is what reliably kills
+the mutant. Both fixes in `internal/logging` and `internal/addon` are written that way.
+
+Keep properties cheap for the same reason — mutation testing re-runs the suite once per mutant,
+so a property that takes a second at 100 cases costs an hour across the module.
+
+### When not to write one
+
+A function with two branches and no interesting input space is a table test, not a property.
+`ActiveRunType` and `tokenRequired` are covered better by listing their cases than by generating
+them. Properties earn their keep where the input space is large and the promise is absolute:
+parsers, path handling, ordering, serialisation, and anything that must never leak a credential.
 
 ## Mocks
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -189,3 +189,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/internal/addon/composer_audit.go
+++ b/internal/addon/composer_audit.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/drupdater/drupdater/internal"
@@ -138,6 +139,12 @@ func (ca *ComposerAudit) GetFixedAdvisories() []composer.Advisory {
 
 // advisoryKey returns a stable identity for an advisory that does not collapse distinct
 // advisories which happen to lack a CVE.
+//
+// The last fallback quotes both halves rather than joining them on a separator. A plain
+// separator is only unambiguous while neither field contains it, and an advisory title is free
+// text — "Access bypass | SA-CONTRIB" is an ordinary thing for one to say. Two different
+// advisories sharing a key here means one of them is reported as fixed while it is still open,
+// in a security update.
 func advisoryKey(a composer.Advisory) string {
 	if a.CVE != "" {
 		return "cve:" + a.CVE
@@ -145,7 +152,7 @@ func advisoryKey(a composer.Advisory) string {
 	if a.AdvisoryID != "" {
 		return "id:" + a.AdvisoryID
 	}
-	return "pkg:" + a.PackageName + "|" + a.Title
+	return "pkg:" + strconv.Quote(a.PackageName) + strconv.Quote(a.Title)
 }
 
 func (ca *ComposerAudit) preMergeRequestCreateHandler(e event.Event) error {

--- a/internal/addon/composer_audit_property_test.go
+++ b/internal/addon/composer_audit_property_test.go
@@ -1,0 +1,126 @@
+package addon
+
+import (
+	"testing"
+
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// GetFixedAdvisories is a set difference, and it decides what a security merge request claims to
+// have fixed. Getting it wrong in the generous direction — reporting an advisory as fixed while
+// it is still open — is the failure that matters, so the laws of set difference are asserted
+// here rather than sampled.
+
+// advisoryGen generates an advisory in one of the three states the key function distinguishes:
+// with a CVE, with only an advisory ID, and with neither. Free-text fields draw separators on
+// purpose, because that is where a hand-rolled composite key breaks.
+func advisoryGen() *rapid.Generator[composer.Advisory] {
+	text := rapid.StringMatching(`[a-zA-Z0-9 |:"\\-]{0,12}`)
+	return rapid.Custom(func(t *rapid.T) composer.Advisory {
+		return composer.Advisory{
+			CVE:         rapid.StringMatching(`(CVE-20[0-9]{2}-[0-9]{4})?`).Draw(t, "cve"),
+			AdvisoryID:  rapid.StringMatching(`(SA-CONTRIB-20[0-9]{2}-[0-9]{3})?`).Draw(t, "advisoryId"),
+			PackageName: text.Draw(t, "packageName"),
+			Title:       text.Draw(t, "title"),
+			Severity:    rapid.SampledFrom([]string{"low", "medium", "high", "critical"}).Draw(t, "severity"),
+		}
+	})
+}
+
+func advisoriesGen() *rapid.Generator[[]composer.Advisory] {
+	return rapid.SliceOfNDistinct(advisoryGen(), 0, 6, advisoryKey)
+}
+
+func TestPropertyGetFixedAdvisoriesReportsNothingWhenNothingChanged(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		advisories := advisoriesGen().Draw(t, "advisories")
+
+		audit := &ComposerAudit{
+			beforeAudit: composer.Audit{Advisories: advisories},
+			afterAudit:  composer.Audit{Advisories: advisories},
+		}
+
+		assert.Empty(t, audit.GetFixedAdvisories())
+	})
+}
+
+func TestPropertyGetFixedAdvisoriesReportsEverythingThatDisappeared(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		advisories := advisoriesGen().Draw(t, "advisories")
+
+		audit := &ComposerAudit{
+			beforeAudit: composer.Audit{Advisories: advisories},
+			afterAudit:  composer.Audit{},
+		}
+
+		assert.Equal(t, advisories, audit.GetFixedAdvisories())
+	})
+}
+
+func TestPropertyGetFixedAdvisoriesIsASubsequenceOfBefore(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		before := advisoriesGen().Draw(t, "before")
+		kept := rapid.SliceOfN(rapid.Bool(), len(before), len(before)).Draw(t, "kept")
+
+		after := make([]composer.Advisory, 0, len(before))
+		want := make([]composer.Advisory, 0, len(before))
+		for i, advisory := range before {
+			if kept[i] {
+				after = append(after, advisory)
+				continue
+			}
+			want = append(want, advisory)
+		}
+
+		// Order preserved and nothing invented: the fixed list is exactly the advisories that
+		// were there before and are not there now, in the order composer reported them.
+		audit := &ComposerAudit{
+			beforeAudit: composer.Audit{Advisories: before},
+			afterAudit:  composer.Audit{Advisories: after},
+		}
+		got := audit.GetFixedAdvisories()
+		assert.Equal(t, want, got)
+		assert.Equal(t, got, audit.GetFixedAdvisories(), "reading the result must not consume it")
+	})
+}
+
+func TestPropertyAdvisoryKeyTellsDistinctAdvisoriesApart(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		a := advisoryGen().Draw(t, "a")
+		b := advisoryGen().Draw(t, "b")
+
+		// Two advisories may share a key only when they are the same advisory. Titles are free
+		// text and routinely contain the punctuation a composite key is built from, so this is
+		// where an ambiguous separator shows up.
+		sameIdentity := (a.CVE != "" && a.CVE == b.CVE) ||
+			(a.CVE == "" && b.CVE == "" && a.AdvisoryID != "" && a.AdvisoryID == b.AdvisoryID) ||
+			(a.CVE == "" && b.CVE == "" && a.AdvisoryID == "" && b.AdvisoryID == "" &&
+				a.PackageName == b.PackageName && a.Title == b.Title)
+
+		assert.Equal(t, sameIdentity, advisoryKey(a) == advisoryKey(b),
+			"keys %q and %q for %+v / %+v", advisoryKey(a), advisoryKey(b), a, b)
+	})
+}
+
+func TestPropertyAdvisoryKeySurvivesSeparatorsInFreeText(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		left := rapid.StringMatching(`[a-z]{1,6}`).Draw(t, "left")
+		middle := rapid.StringMatching(`[a-z]{1,6}`).Draw(t, "middle")
+		right := rapid.StringMatching(`[a-z]{1,6}`).Draw(t, "right")
+		separator := rapid.SampledFrom([]string{"|", ":", `"`, `\`, "/"}).Draw(t, "separator")
+
+		// Two genuinely different advisories, split at different points around the same
+		// character. Any key that joins the fields on a fixed separator maps both onto one
+		// string, and the second advisory is then reported as fixed while it is still open.
+		// Drawing the two halves independently, as the property above does, would essentially
+		// never line them up like this — the ambiguity has to be constructed to be found.
+		a := composer.Advisory{PackageName: left + separator + middle, Title: right}
+		b := composer.Advisory{PackageName: left, Title: middle + separator + right}
+
+		require.NotEqual(t, a, b)
+		assert.NotEqual(t, advisoryKey(a), advisoryKey(b))
+	})
+}

--- a/internal/addon/composer_audit_test.go
+++ b/internal/addon/composer_audit_test.go
@@ -163,7 +163,17 @@ func TestAdvisoryKey(t *testing.T) {
 	// CVE takes precedence; without it the advisory ID is used; without either, package+title.
 	assert.Equal(t, "cve:CVE-1", advisoryKey(composer.Advisory{CVE: "CVE-1", AdvisoryID: "A1"}))
 	assert.Equal(t, "id:A1", advisoryKey(composer.Advisory{AdvisoryID: "A1", PackageName: "drupal/foo"}))
-	assert.Equal(t, "pkg:drupal/foo|Title", advisoryKey(composer.Advisory{PackageName: "drupal/foo", Title: "Title"}))
+	assert.Equal(t, `pkg:"drupal/foo""Title"`, advisoryKey(composer.Advisory{PackageName: "drupal/foo", Title: "Title"}))
+}
+
+// TestAdvisoryKey_SeparatorInTitle covers the fallback's ambiguity. An advisory title is free
+// text, so joining package and title on a separator lets two different advisories share a key —
+// and a shared key means the second one is reported as fixed while it is still open.
+func TestAdvisoryKey_SeparatorInTitle(t *testing.T) {
+	split := composer.Advisory{PackageName: "drupal/foo|Access", Title: "bypass"}
+	other := composer.Advisory{PackageName: "drupal/foo", Title: "Access|bypass"}
+
+	assert.NotEqual(t, advisoryKey(split), advisoryKey(other))
 }
 
 func TestComposerAudit_GetFixedAdvisories_NoCVEAdvisoriesDoNotCollide(t *testing.T) {

--- a/internal/addon/composer_patches_1_property_test.go
+++ b/internal/addon/composer_patches_1_property_test.go
@@ -1,0 +1,102 @@
+package addon
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+)
+
+// Both helpers below turn untrusted input into a decision about the filesystem: cleanURLString
+// builds a file name out of a drupal.org issue title, and isRemotePatch decides whether a patch
+// reference names a file to remove at all. Titles are written by whoever opened the issue, so
+// "for every input" is the only useful scope for their promises.
+
+// safeFileNameChars is the character set cleanURLString promises to stay inside — no separator
+// and nothing else that would break os.Create.
+var safeFileNameChars = regexp.MustCompile(`^[a-z0-9._-]*$`)
+
+func TestPropertyCleanURLStringProducesASafeFileName(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		title := rapid.String().Draw(t, "title")
+
+		cleaned := (&ComposerPatches1{}).cleanURLString(title)
+
+		// The result is concatenated into a path and handed to os.Create. Any title at all —
+		// including one containing "../", a NUL byte or a full URL — has to come out as
+		// something that cannot leave the patch directory.
+		assert.Regexp(t, safeFileNameChars, cleaned, "cleaned %q", title)
+
+		// Stated on the name the caller actually builds rather than on the fragment. A run of
+		// dots survives cleaning, and that is fine: with no separator in the character set it
+		// cannot form a traversal, and the fragment is always embedded between an issue ID and
+		// the ".diff" suffix, so the name can never be "." or ".." either.
+		const patchDir = "patches/drupal"
+		name := fmt.Sprintf("%s-%s-%s.diff", "3456789", "0ff1ce", cleaned)
+		assert.Equal(t, name, filepath.Base(name), "%q is not a single path element", name)
+		assert.True(t, strings.HasPrefix(filepath.Clean(filepath.Join(patchDir, name)), patchDir+"/"),
+			"%q escapes %q", name, patchDir)
+	})
+}
+
+func TestPropertyCleanURLStringIsIdempotent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		title := rapid.String().Draw(t, "title")
+
+		cleaner := &ComposerPatches1{}
+		once := cleaner.cleanURLString(title)
+		assert.Equal(t, once, cleaner.cleanURLString(once))
+	})
+}
+
+func TestPropertyIsRemotePatchRejectsEveryFilesystemPath(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		segments := rapid.SliceOfN(rapid.StringMatching(`[a-zA-Z0-9_.-]{1,10}`), 1, 4).Draw(t, "segments")
+		absolute := rapid.Bool().Draw(t, "absolute")
+
+		path := strings.Join(segments, "/")
+		if absolute {
+			path = "/" + path
+		}
+
+		// A local patch has a file in the worktree that has to be removed when the patch is
+		// dropped. Classifying it as remote makes the removal a silent no-op, so the patch file
+		// stays behind and composer-patches keeps applying it.
+		assert.False(t, isRemotePatch(path), "for %q", path)
+	})
+}
+
+func TestPropertyIsRemotePatchAcceptsHTTPURLs(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		scheme := rapid.SampledFrom([]string{"http", "https"}).Draw(t, "scheme")
+		host := rapid.StringMatching(`[a-z][a-z0-9-]{0,10}(\.[a-z]{2,5}){1,2}`).Draw(t, "host")
+		path := rapid.StringMatching(`(/[a-zA-Z0-9_.-]{1,10}){0,3}`).Draw(t, "path")
+
+		url := scheme + "://" + host + path
+		assert.True(t, isRemotePatch(url), "for %q", url)
+	})
+}
+
+func TestPropertyDropPatchFileTouchesTheWorktreeOnlyForLocalPatches(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		patchPath := rapid.OneOf(
+			rapid.StringMatching(`(/)?([a-zA-Z0-9_.-]{1,10}/){0,3}[a-zA-Z0-9_.-]{1,10}\.(patch|diff)`),
+			rapid.StringMatching(`https?://[a-z]{1,8}\.example\.com/[a-z0-9-]{1,10}\.patch`),
+		).Draw(t, "patchPath")
+
+		worktree := NewMockWorktree(t)
+		if !isRemotePatch(patchPath) {
+			worktree.EXPECT().Remove(patchPath).Return(plumbing.Hash{}, nil).Once()
+		}
+
+		// A remote patch has no file in the repository, so handing its URL to worktree.Remove
+		// would fail and leave the caller believing the patch could not be dropped. The two
+		// have to agree for every reference, not just for the ones someone listed.
+		assert.NoError(t, (&ComposerPatches1{}).dropPatchFile(worktree, patchPath))
+	})
+}

--- a/internal/addon/deprecations_remover.go
+++ b/internal/addon/deprecations_remover.go
@@ -1,7 +1,8 @@
 package addon
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/rector"
@@ -135,11 +136,14 @@ func (dr *DeprecationsRemover) recordFixes(result rector.ReturnOutput) {
 
 	fixes := make([]DeprecationFix, 0, len(result.ChangedFiles))
 	for _, file := range result.ChangedFiles {
-		applied := rectorsByFile[file]
-		sort.Strings(applied)
+		// Cloned before sorting. Sorting in place would reorder the caller's own
+		// rector.ReturnOutput, and a file listed twice in ChangedFiles would hand two fixes the
+		// same backing array, so appending to one would show up in the other.
+		applied := slices.Clone(rectorsByFile[file])
+		slices.Sort(applied)
 		fixes = append(fixes, DeprecationFix{File: file, AppliedRectors: applied})
 	}
 	// Sorted so two runs over unchanged code produce byte-identical sections.
-	sort.Slice(fixes, func(i, j int) bool { return fixes[i].File < fixes[j].File })
+	slices.SortFunc(fixes, func(a, b DeprecationFix) int { return cmp.Compare(a.File, b.File) })
 	dr.fixes = fixes
 }

--- a/internal/addon/deprecations_remover_property_test.go
+++ b/internal/addon/deprecations_remover_property_test.go
@@ -1,0 +1,116 @@
+package addon
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/drupdater/drupdater/pkg/rector"
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+)
+
+// recordFixes turns rector's output into a report section, and the section is supposed to be
+// byte-identical for two runs over unchanged code. Rector's output order is not something this
+// code controls, so "the same input in a different order gives the same section" is exactly the
+// promise — and a permutation is what states it.
+
+func rectorOutputGen() *rapid.Generator[rector.ReturnOutput] {
+	fileGen := rapid.StringMatching(`(web|modules)/[a-z0-9_]{1,8}/[a-z0-9_]{1,8}\.php`)
+	ruleGen := rapid.StringMatching(`Rector\\[A-Za-z]{1,10}\\[A-Za-z]{1,10}Rector`)
+
+	return rapid.Custom(func(t *rapid.T) rector.ReturnOutput {
+		files := rapid.SliceOfNDistinct(fileGen, 0, 5, rapid.ID).Draw(t, "files")
+
+		diffs := make([]rector.ReturnOutputFillDiff, 0, len(files))
+		for _, file := range files {
+			// Not every changed file gets a diff entry, which is the case that decides whether
+			// AppliedRectors ends up nil or populated.
+			if !rapid.Bool().Draw(t, "hasDiff-"+file) {
+				continue
+			}
+			diffs = append(diffs, rector.ReturnOutputFillDiff{
+				File:           file,
+				Diff:           "@@ -1 +1 @@",
+				AppliedRectors: rapid.SliceOfNDistinct(ruleGen, 0, 4, rapid.ID).Draw(t, "rules-"+file),
+			})
+		}
+
+		return rector.ReturnOutput{ChangedFiles: files, FileDiffs: diffs}
+	})
+}
+
+func TestPropertyRecordFixesIgnoresRectorsOrdering(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		output := rectorOutputGen().Draw(t, "output")
+		shuffled := rector.ReturnOutput{
+			Totals:       output.Totals,
+			ChangedFiles: rapid.Permutation(output.ChangedFiles).Draw(t, "changedFiles"),
+			FileDiffs:    rapid.Permutation(output.FileDiffs).Draw(t, "fileDiffs"),
+		}
+
+		original := &DeprecationsRemover{}
+		original.recordFixes(output)
+
+		reordered := &DeprecationsRemover{}
+		reordered.recordFixes(shuffled)
+
+		assert.Equal(t, original.fixes, reordered.fixes)
+	})
+}
+
+func TestPropertyRecordFixesCoversEveryChangedFile(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		output := rectorOutputGen().Draw(t, "output")
+
+		remover := &DeprecationsRemover{}
+		remover.recordFixes(output)
+
+		// Every changed file is accounted for, each carries exactly the rules rector recorded
+		// for it, and both levels come out ordered — that ordering is the whole reason the
+		// section is stable across runs.
+		assert.Len(t, remover.fixes, len(output.ChangedFiles))
+		for i, fix := range remover.fixes {
+			assert.ElementsMatch(t, rulesFor(output, fix.File), fix.AppliedRectors, "rules for %q", fix.File)
+			if i > 0 {
+				assert.LessOrEqual(t, remover.fixes[i-1].File, fix.File, "files come out sorted")
+			}
+			if len(fix.AppliedRectors) > 1 {
+				assert.IsIncreasing(t, fix.AppliedRectors, "the rules of %q come out sorted", fix.File)
+			}
+		}
+	})
+}
+
+func TestPropertyRecordFixesLeavesRectorsOutputAlone(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		output := rectorOutputGen().Draw(t, "output")
+
+		// slices.Clone rather than append-onto-nil, which would turn an empty-but-not-nil
+		// slice into a nil one and make the snapshot differ from the input on its own.
+		before := make([][]string, len(output.FileDiffs))
+		for i, diff := range output.FileDiffs {
+			before[i] = slices.Clone(diff.AppliedRectors)
+		}
+
+		(&DeprecationsRemover{}).recordFixes(output)
+
+		// The caller still owns this value — the post-code-update handler passes rector's own
+		// output and goes on using it. Sorting a slice out of it in place reaches back into
+		// data this function was only given to read.
+		for i, diff := range output.FileDiffs {
+			assert.Equal(t, before[i], diff.AppliedRectors, "AppliedRectors of %q was rewritten", diff.File)
+		}
+	})
+}
+
+// rulesFor returns the rules the output records for file, unsorted, or nil when the file has no
+// diff entry. Deliberately not a second implementation of recordFixes: it only looks the entry
+// up, and the property compares the two as sets and checks the ordering separately.
+func rulesFor(output rector.ReturnOutput, file string) []string {
+	for _, diff := range output.FileDiffs {
+		if diff.File == file {
+			return diff.AppliedRectors
+		}
+	}
+	return nil
+}

--- a/internal/addon/deprecations_remover_test.go
+++ b/internal/addon/deprecations_remover_test.go
@@ -16,6 +16,27 @@ import (
 	"go.uber.org/zap"
 )
 
+// TestRecordFixes_DoesNotSortRectorsOutputInPlace pins that recordFixes only reads the value it
+// is handed. It sorts each file's rules, and doing that on the slice inside rector's own output
+// would reorder data the caller still owns — and hand two fixes for the same file one shared
+// backing array.
+func TestRecordFixes_DoesNotSortRectorsOutputInPlace(t *testing.T) {
+	output := rector.ReturnOutput{
+		ChangedFiles: []string{"web/modules/custom/a.php"},
+		FileDiffs: []rector.ReturnOutputFillDiff{
+			{File: "web/modules/custom/a.php", AppliedRectors: []string{"ZRector", "ARector"}},
+		},
+	}
+
+	dr := &DeprecationsRemover{}
+	dr.recordFixes(output)
+
+	assert.Equal(t, []string{"ZRector", "ARector"}, output.FileDiffs[0].AppliedRectors,
+		"rector's own output was reordered")
+	assert.Equal(t, []string{"ARector", "ZRector"}, dr.fixes[0].AppliedRectors,
+		"the report section is still sorted")
+}
+
 func TestDeprecationsRemover_SubscribedEvents(t *testing.T) {
 	dr := &DeprecationsRemover{}
 	events := dr.SubscribedEvents()

--- a/internal/codehosting/factory_property_test.go
+++ b/internal/codehosting/factory_property_test.go
@@ -1,0 +1,139 @@
+package codehosting
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// Repository URLs arrive from a CI variable or a flag, in whichever of the two shapes git
+// itself accepts. The example-based tests cover the shapes someone wrote down; these state what
+// has to hold for every URL of either shape, and that the parser is total — it is called on
+// unvalidated user input, so "never panics" is part of the contract.
+
+// hostGen generates a repository host: labels of the kind a real forge uses. No port — the SCP
+// form has no slot for one, since the colon after the host already introduces the path, so a
+// port belongs only to the URL form and is covered separately.
+func hostGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-z][a-z0-9-]{0,10}(\.[a-z][a-z0-9-]{0,10}){1,2}`)
+}
+
+// segmentGen generates one path segment of an "owner/repo" pair.
+func segmentGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-zA-Z0-9][a-zA-Z0-9._-]{0,15}`)
+}
+
+func TestPropertyParseGitURLRoundTripsBothURLShapes(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		host := hostGen().Draw(t, "host")
+		owner := segmentGen().Draw(t, "owner")
+		repo := segmentGen().Draw(t, "repo")
+		wantPath := owner + "/" + repo
+
+		// Both forms name the same repository, so both have to parse back to the same pair.
+		// The SCP form is the one url.ParseRequestURI rejects outright, which is why
+		// ValidateRepositoryURL exists.
+		for _, raw := range []string{
+			"https://" + host + "/" + wantPath + ".git",
+			"https://" + host + "/" + wantPath,
+			"git@" + host + ":" + wantPath + ".git",
+			"git@" + host + ":" + wantPath,
+		} {
+			gotHost, gotPath, err := parseGitURL(raw)
+			require.NoError(t, err, "parsing %q", raw)
+			assert.Equal(t, host, gotHost, "host from %q", raw)
+			assert.Equal(t, wantPath, gotPath, "path from %q", raw)
+		}
+	})
+}
+
+func TestPropertyParseGitURLKeepsThePort(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		host := hostGen().Draw(t, "host")
+		port := rapid.IntRange(1, 65535).Draw(t, "port")
+		owner := segmentGen().Draw(t, "owner")
+		repo := segmentGen().Draw(t, "repo")
+
+		// A self-hosted GitLab is routinely reached on a non-default port, and the port is part
+		// of the host the gitlab client is constructed with — dropping it would send every API
+		// call somewhere else.
+		hostPort := fmt.Sprintf("%s:%d", host, port)
+		gotHost, gotPath, err := parseGitURL("https://" + hostPort + "/" + owner + "/" + repo + ".git")
+		require.NoError(t, err)
+		assert.Equal(t, hostPort, gotHost)
+		assert.Equal(t, owner+"/"+repo, gotPath)
+	})
+}
+
+func TestPropertyParseGitURLNormalisesItsOutput(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		raw := rapid.String().Draw(t, "raw")
+
+		// Total function: parseGitURL runs on whatever the operator passed in, so every input
+		// either parses or returns an error, and none of them panics.
+		host, path, err := parseGitURL(raw)
+		if err != nil {
+			assert.Empty(t, host)
+			assert.Empty(t, path)
+			return
+		}
+
+		assert.NotEmpty(t, host, "a URL that parsed must have a host")
+		assert.False(t, strings.HasSuffix(path, ".git"), "path %q kept its .git suffix", path)
+		assert.False(t, strings.HasPrefix(path, "/"), "path %q kept a leading slash", path)
+		assert.False(t, strings.HasSuffix(path, "/"), "path %q kept a trailing slash", path)
+	})
+}
+
+func TestPropertyValidateRepositoryURLAgreesWithParseGitURL(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		raw := rapid.String().Draw(t, "raw")
+
+		// The whole point of ValidateRepositoryURL is that a preflight check accepts exactly
+		// what a run will later accept. If the two ever diverged, a check would pass and the
+		// run would then fail on the same URL.
+		_, _, parseErr := parseGitURL(raw)
+		assert.Equal(t, parseErr == nil, ValidateRepositoryURL(raw) == nil, "for %q", raw)
+	})
+}
+
+func TestPropertyProviderFromHostIgnoresCase(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		host := rapid.StringMatching(`[a-zA-Z0-9.-]{0,30}`).Draw(t, "host")
+		upper := rapid.SliceOfN(rapid.Bool(), len(host), len(host)).Draw(t, "upper")
+
+		// Hostnames are case-insensitive, and a CI variable may well carry one in mixed case.
+		// Which client a repository is routed to must not depend on that.
+		var flipped strings.Builder
+		for i, r := range []byte(host) {
+			if upper[i] {
+				flipped.WriteString(strings.ToUpper(string(r)))
+				continue
+			}
+			flipped.WriteString(strings.ToLower(string(r)))
+		}
+
+		assert.Equal(t, providerFromHost(host), providerFromHost(flipped.String()))
+	})
+}
+
+func TestPropertyProviderFromHostPrefersGitlab(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := rapid.StringMatching(`[a-z.-]{0,8}`).Draw(t, "prefix")
+		middle := rapid.StringMatching(`[a-z.-]{0,8}`).Draw(t, "middle")
+		suffix := rapid.StringMatching(`[a-z.-]{0,8}`).Draw(t, "suffix")
+
+		// A host naming both is ambiguous and the precedence is load-bearing: gitlab wins,
+		// whichever order the two appear in. Create falls through to gitlab for "" as well, so
+		// the only host that reaches the github client is one that says github and not gitlab.
+		gitlabFirst := prefix + "gitlab" + middle + "github" + suffix
+		githubFirst := prefix + "github" + middle + "gitlab" + suffix
+
+		assert.Equal(t, "gitlab", providerFromHost(gitlabFirst))
+		assert.Equal(t, "gitlab", providerFromHost(githubFirst))
+	})
+}

--- a/internal/configfile_property_test.go
+++ b/internal/configfile_property_test.go
@@ -1,0 +1,234 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"pgregory.net/rapid"
+)
+
+// .drupdater.yaml is written by hand, in a repository this tool has no other contact with, and
+// it is decoded strictly — so every key present has to land where the documentation says, and
+// every key absent has to fall back to the documented default. Those two claims are about all
+// files, not about the fixtures someone happened to write.
+
+// fileConfigGen generates a config with every key set, so a round-trip covers each of them
+// rather than the ones an example filled in.
+func fileConfigGen() *rapid.Generator[fileConfig] {
+	addonsGen := rapid.SliceOfNDistinct(rapid.SampledFrom(defaultNormalAddons), 0, len(defaultNormalAddons), rapid.ID)
+
+	return rapid.Custom(func(t *rapid.T) fileConfig {
+		return fileConfig{
+			Sites:   rapid.SliceOfNDistinct(rapid.StringMatching(`[a-z][a-z0-9_]{0,10}`), 1, 4, rapid.ID).Draw(t, "sites"),
+			Timeout: flexTimeout(rapid.SampledFrom([]string{"0", "45s", "30m", "2h", "1h30m"}).Draw(t, "timeout")),
+			RunTypes: RunTypesConfig{
+				Normal: RunTypeConfig{
+					Addons:    addonsGen.Draw(t, "normalAddons"),
+					AutoMerge: rapid.Bool().Draw(t, "normalAutoMerge"),
+				},
+				Security: RunTypeConfig{
+					Addons:    addonsGen.Draw(t, "securityAddons"),
+					AutoMerge: rapid.Bool().Draw(t, "securityAutoMerge"),
+				},
+			},
+		}
+	})
+}
+
+// writePropertyConfig writes body to a .drupdater.yaml in dir and returns its path. Separate
+// from writeConfig in configfile_test.go because that one takes a *testing.T and makes its own
+// temporary directory per call, and a property makes hundreds of calls under a *rapid.T.
+func writePropertyConfig(t require.TestingT, dir string, body string) string {
+	path := filepath.Join(dir, ".drupdater.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func TestPropertyLoadConfigFileRoundTripsEveryKey(t *testing.T) {
+	dir := t.TempDir()
+
+	rapid.Check(t, func(t *rapid.T) {
+		want := fileConfigGen().Draw(t, "config")
+
+		body, err := yaml.Marshal(want)
+		require.NoError(t, err)
+
+		var got Config
+		found, err := LoadConfigFile(writePropertyConfig(t, dir, string(body)), &got)
+		require.NoError(t, err)
+		assert.True(t, found)
+
+		// Strict decoding means this also proves the struct tags match what the file emits: a
+		// renamed key would fail the decode rather than silently fall back to a default.
+		assert.Equal(t, want.Sites, got.Sites)
+		assert.Equal(t, want.RunTypes, got.RunTypes)
+
+		wantTimeout, err := time.ParseDuration(string(want.Timeout))
+		require.NoError(t, err)
+		assert.Equal(t, wantTimeout, got.Timeout)
+	})
+}
+
+func TestPropertyLoadConfigFileFillsInEveryAbsentKey(t *testing.T) {
+	dir := t.TempDir()
+	defaults := defaultFileConfig()
+
+	rapid.Check(t, func(t *rapid.T) {
+		full := fileConfigGen().Draw(t, "config")
+		withSites := rapid.Bool().Draw(t, "withSites")
+		withTimeout := rapid.Bool().Draw(t, "withTimeout")
+		withRunTypes := rapid.Bool().Draw(t, "withRunTypes")
+
+		// A partial file is the normal case — most projects set `sites` and nothing else — and
+		// it has to resolve to a complete config, with the keys it does not mention taking the
+		// documented default rather than a zero value.
+		var body strings.Builder
+		if withSites {
+			fmt.Fprintf(&body, "sites: [%s]\n", strings.Join(full.Sites, ", "))
+		}
+		if withTimeout {
+			fmt.Fprintf(&body, "timeout: %q\n", string(full.Timeout))
+		}
+		if withRunTypes {
+			fmt.Fprintf(&body, "run_types:\n  normal:\n    auto_merge: %t\n  security:\n    auto_merge: %t\n",
+				full.RunTypes.Normal.AutoMerge, full.RunTypes.Security.AutoMerge)
+		}
+
+		var got Config
+		_, err := LoadConfigFile(writePropertyConfig(t, dir, body.String()), &got)
+		require.NoError(t, err)
+
+		if withSites {
+			assert.Equal(t, full.Sites, got.Sites)
+		} else {
+			assert.Equal(t, defaults.Sites, got.Sites)
+		}
+
+		wantTimeout := string(defaults.Timeout)
+		if withTimeout {
+			wantTimeout = string(full.Timeout)
+		}
+		parsed, err := time.ParseDuration(wantTimeout)
+		require.NoError(t, err)
+		assert.Equal(t, parsed, got.Timeout)
+
+		// Layering is per-key all the way down, not per-block: the generated run_types names
+		// only auto_merge, so the addon lists inside the same block still come from the
+		// defaults. A project that turns auto-merge on does not thereby switch every addon off.
+		if withRunTypes {
+			assert.Equal(t, full.RunTypes.Normal.AutoMerge, got.RunTypes.Normal.AutoMerge)
+			assert.Equal(t, full.RunTypes.Security.AutoMerge, got.RunTypes.Security.AutoMerge)
+			assert.Equal(t, defaults.RunTypes.Normal.Addons, got.RunTypes.Normal.Addons)
+			assert.Equal(t, defaults.RunTypes.Security.Addons, got.RunTypes.Security.Addons)
+		} else {
+			assert.Equal(t, defaults.RunTypes, got.RunTypes)
+		}
+	})
+}
+
+func TestPropertyLoadConfigFileTreatsAnEmptyDocumentAsAbsent(t *testing.T) {
+	dir := t.TempDir()
+
+	rapid.Check(t, func(t *rapid.T) {
+		// Spaces only: a tab is not whitespace as far as YAML is concerned, it is a character
+		// that cannot start a token, so a tab-only document is malformed rather than empty.
+		blanks := rapid.SliceOfN(rapid.SampledFrom([]string{"", " ", "   ", "# a comment", "#"}), 0, 6).Draw(t, "lines")
+		body := strings.Join(blanks, "\n")
+
+		var fromFile Config
+		_, err := LoadConfigFile(writePropertyConfig(t, dir, body), &fromFile)
+		require.NoError(t, err, "body %q", body)
+
+		var fromNothing Config
+		_, err = LoadConfigFile(filepath.Join(dir, "does-not-exist.yaml"), &fromNothing)
+		require.NoError(t, err)
+
+		// A file that sets no keys and no file at all are the same statement, so they must
+		// produce the same config — including the defaults, not a zero value.
+		assert.Equal(t, fromNothing, fromFile, "body %q", body)
+	})
+}
+
+func TestPropertyFlexTimeoutAcceptsAnyGoDuration(t *testing.T) {
+	dir := t.TempDir()
+
+	rapid.Check(t, func(t *rapid.T) {
+		hours := rapid.IntRange(0, 24).Draw(t, "hours")
+		minutes := rapid.IntRange(0, 59).Draw(t, "minutes")
+		seconds := rapid.IntRange(0, 59).Draw(t, "seconds")
+		raw := fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds)
+
+		// Quoted and bare have to mean the same thing. flexTimeout exists because `timeout: 0`,
+		// the documented way to disable the timeout, decodes as an int and would not fit a
+		// string field.
+		var quoted, bare Config
+		_, err := LoadConfigFile(writePropertyConfig(t, dir, fmt.Sprintf("sites: [default]\ntimeout: %q\n", raw)), &quoted)
+		require.NoError(t, err)
+		_, err = LoadConfigFile(writePropertyConfig(t, dir, fmt.Sprintf("sites: [default]\ntimeout: %s\n", raw)), &bare)
+		require.NoError(t, err)
+
+		want, err := time.ParseDuration(raw)
+		require.NoError(t, err)
+		assert.Equal(t, want, quoted.Timeout)
+		assert.Equal(t, want, bare.Timeout)
+	})
+}
+
+func TestPropertyLoadConfigFileRejectsAnEmptySiteList(t *testing.T) {
+	dir := t.TempDir()
+
+	rapid.Check(t, func(t *rapid.T) {
+		empty := rapid.SampledFrom([]string{"sites: []", "sites:", "sites: ~", "sites: null"}).Draw(t, "sites")
+		timeout := rapid.SampledFrom([]string{"", "\ntimeout: 30m", "\ntimeout: 0"}).Draw(t, "timeout")
+
+		// Every per-site phase iterates this list, so an empty one would skip installing the
+		// database, running update hooks and exporting configuration, and still open a merge
+		// request for an update nothing validated.
+		var got Config
+		_, err := LoadConfigFile(writePropertyConfig(t, dir, empty+timeout+"\n"), &got)
+		require.Error(t, err, "for %q", empty+timeout)
+		assert.Contains(t, err.Error(), "no sites configured")
+	})
+}
+
+func TestPropertyCheckLegacyLayoutFlagsOnlyTheOldShape(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		config := fileConfigGen().Draw(t, "config")
+		body, err := yaml.Marshal(config)
+		require.NoError(t, err)
+
+		// No false positives: a file already written in the current layout must pass, or every
+		// correctly migrated project would be told to migrate again.
+		assert.NoError(t, checkLegacyLayout(body))
+
+		legacy := rapid.SampledFrom([]string{
+			"addons:\n  normal: [code_beautifier]\n",
+			"auto_merge:\n  security: true\n",
+			"addons:\n  normal: []\nauto_merge:\n  normal: false\n",
+		}).Draw(t, "legacy")
+		assert.Error(t, checkLegacyLayout([]byte(legacy)), "the pre-run_types layout has to be named")
+	})
+}
+
+func TestPropertyCheckLegacyLayoutStaysOutOfTheWayOfMalformedYAML(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		body := rapid.SampledFrom([]string{
+			"sites: [unclosed\n",
+			"\tsites: default\n",
+			"a:\n b: c\n  d: e\n",
+			"{{{\n",
+		}).Draw(t, "body")
+
+		// A document that does not parse is the strict decode's business, which reports it with
+		// the file name and the parser's own message. Guessing at a legacy layout here would
+		// replace that with advice about a key the file may not even contain.
+		assert.NoError(t, checkLegacyLayout([]byte(body)))
+	})
+}

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -36,8 +36,13 @@ func NewRedactor() *Redactor {
 
 // Register adds values that must be redacted from all subsequent log output. Empty strings are
 // ignored, since redacting "" would replace every character in every log line. Each value's
-// URL-percent-encoded form is registered alongside it: a token embedded in a URL (e.g. a
+// URL-percent-encoded forms are registered alongside it: a token embedded in a URL (e.g. a
 // Composer repository URL) may appear encoded rather than literal.
+//
+// Both encodings are registered because Go — like the tools whose output this filters — escapes
+// a value differently depending on where in the URL it lands. A space becomes '+' in a query
+// component and "%20" in a path segment, so registering only one form leaves the value readable
+// in the other. Duplicates are collapsed by the map, so a value the two agree on costs nothing.
 func (r *Redactor) Register(values ...string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -55,6 +60,7 @@ func (r *Redactor) Register(values ...string) {
 	for _, v := range values {
 		add(v)
 		add(url.QueryEscape(v))
+		add(url.PathEscape(v))
 	}
 	if changed {
 		r.replacer = nil // rebuilt lazily by redact on next use

--- a/internal/logging/redact_property_test.go
+++ b/internal/logging/redact_property_test.go
@@ -1,0 +1,181 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"pgregory.net/rapid"
+)
+
+// The example-based tests in redact_test.go pin the cases someone thought of. The redactor is
+// the one component where a case nobody thought of means a credential in a log, so its promises
+// are stated here as properties over generated input instead.
+
+// secretGen generates a plausible credential value: the alphabet is the one real tokens are
+// drawn from, plus the separators that show up around them in basic-auth URLs and query
+// strings, so the generated values actually exercise the URL-encoded registration.
+//
+// '*' is deliberately excluded. The placeholder is "***", so a secret consisting only of
+// asterisks is a substring of the very thing that replaces it and would reappear in the output
+// by construction. A credential of one to three asterisks is not a credential; stating the
+// no-leak property for secrets distinguishable from the placeholder is the useful reading.
+func secretGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-zA-Z0-9_.:/+= @-]{1,20}`)
+}
+
+// secretsGen generates a small set of distinct secrets, the way a run registers a token, a
+// Composer password and a git credential.
+func secretsGen() *rapid.Generator[[]string] {
+	return rapid.SliceOfNDistinct(secretGen(), 1, 4, rapid.ID)
+}
+
+// logLineGen builds a line out of the given secrets and arbitrary filler. Drawing a wholly
+// random string instead would exercise redaction only by accident: a generated secret would
+// almost never appear in it, and the property would pass without ever replacing anything.
+func logLineGen(secrets []string) *rapid.Generator[string] {
+	parts := make([]*rapid.Generator[string], 0, len(secrets)+1)
+	parts = append(parts, rapid.String())
+	for _, secret := range secrets {
+		parts = append(parts, rapid.Just(secret))
+	}
+	part := rapid.OneOf(parts...)
+
+	return rapid.Custom(func(t *rapid.T) string {
+		var line strings.Builder
+		for range rapid.IntRange(0, 8).Draw(t, "parts") {
+			line.WriteString(part.Draw(t, "part"))
+		}
+		return line.String()
+	})
+}
+
+func TestPropertyRedactNeverLeaksASecret(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		secrets := secretsGen().Draw(t, "secrets")
+		line := logLineGen(secrets).Draw(t, "line")
+
+		redactor := NewRedactor()
+		redactor.Register(secrets...)
+
+		out := redactor.Redact(line)
+		for _, secret := range secrets {
+			assert.NotContains(t, out, secret)
+		}
+	})
+}
+
+func TestPropertyRedactIsIdempotent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		secrets := secretsGen().Draw(t, "secrets")
+		line := logLineGen(secrets).Draw(t, "line")
+
+		redactor := NewRedactor()
+		redactor.Register(secrets...)
+
+		once := redactor.Redact(line)
+		assert.Equal(t, once, redactor.Redact(once))
+	})
+}
+
+func TestPropertyRedactCoversURLEncodedForms(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		secret := secretGen().Draw(t, "secret")
+
+		redactor := NewRedactor()
+		redactor.Register(secret)
+
+		// A subprocess that echoes a token inside a URL emits it percent-encoded, and which
+		// encoding it is depends on where in the URL it landed: the query escaping turns a
+		// space into '+', the path escaping into "%20". Both have to be registered, or the
+		// value survives in the log in the form that is still perfectly usable.
+		assert.Equal(t, placeholder, redactor.Redact(secret))
+		assert.Equal(t, placeholder, redactor.Redact(url.QueryEscape(secret)))
+		assert.Equal(t, placeholder, redactor.Redact(url.PathEscape(secret)))
+	})
+}
+
+func TestPropertyRedactLeavesSecretFreeTextAlone(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Disjoint alphabets: the filler is drawn from characters no secret can contain, so
+		// "this text holds no secret" holds by construction rather than by luck. Neither
+		// URL-encoded form can bridge the two either, since encoding a lower-case secret
+		// introduces only '%' and hex digits.
+		secrets := rapid.SliceOfNDistinct(rapid.StringMatching(`[a-z0-9]{1,12}`), 1, 4, rapid.ID).Draw(t, "secrets")
+		text := rapid.StringMatching(`[ ,.!?()\[\]]{0,40}`).Draw(t, "text")
+
+		redactor := NewRedactor()
+		redactor.Register(secrets...)
+
+		assert.Equal(t, text, redactor.Redact(text))
+	})
+}
+
+func TestPropertyRegisterIsOrderIndependent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		secrets := secretsGen().Draw(t, "secrets")
+		shuffled := rapid.Permutation(secrets).Draw(t, "shuffled")
+		line := logLineGen(secrets).Draw(t, "line")
+
+		together := NewRedactor()
+		together.Register(secrets...)
+
+		separately := NewRedactor()
+		for _, secret := range shuffled {
+			separately.Register(secret)
+		}
+
+		// Registration order is not something a caller controls — cmd/root.go registers as the
+		// values become known — so it must not change what a log line turns into.
+		assert.Equal(t, together.Redact(line), separately.Redact(line))
+	})
+}
+
+func TestPropertyRedactReplacesTheLongestSecret(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		outer := rapid.StringMatching(`[a-z0-9]{2,20}`).Draw(t, "outer")
+		start := rapid.IntRange(0, len(outer)-1).Draw(t, "start")
+		end := rapid.IntRange(start+1, len(outer)).Draw(t, "end")
+		inner := outer[start:end]
+
+		redactor := NewRedactor()
+		redactor.Register(outer, inner)
+
+		// A short secret that happens to be part of a longer one must not consume it piecemeal
+		// and leave the rest of the longer value readable.
+		assert.Equal(t, placeholder, redactor.Redact(outer))
+	})
+}
+
+func TestPropertyWrappedLoggerNeverWritesASecret(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		secrets := secretsGen().Draw(t, "secrets")
+		message := logLineGen(secrets).Draw(t, "message")
+		field := logLineGen(secrets).Draw(t, "field")
+
+		var buf bytes.Buffer
+		redactor := NewRedactor()
+		redactor.Register(secrets...)
+		newTestLogger(&buf, redactor).Info(message, zap.String("detail", field))
+
+		// Asserted on the decoded entry rather than on the raw line, because the raw line also
+		// carries zap's own envelope. A one-character secret like "8" occurs in the timestamp
+		// of roughly every entry, and no redactor can or should do anything about that — the
+		// promise is about what the call site passed in.
+		var entry struct {
+			Message string `json:"msg"`
+			Detail  string `json:"detail"`
+		}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+
+		for _, secret := range secrets {
+			assert.NotContains(t, entry.Message, secret)
+			assert.NotContains(t, entry.Detail, secret)
+		}
+	})
+}

--- a/internal/logging/redact_test.go
+++ b/internal/logging/redact_test.go
@@ -54,6 +54,29 @@ func TestRedactorRedactsPercentEncodedForm(t *testing.T) {
 	assert.NotContains(t, out, encoded)
 }
 
+// TestRedactorRedactsPathEncodedForm covers the other escaping. Which one a tool emits depends
+// on where the value sat in the URL, not on the value: the same token is "a+b" after a query
+// component is escaped and "a%20b" after a path segment is. Registering only the query form
+// left the path form — still a perfectly usable credential — readable in the log.
+func TestRedactorRedactsPathEncodedForm(t *testing.T) {
+	const token = "a b c"
+
+	var buf bytes.Buffer
+	redactor := NewRedactor()
+	redactor.Register(token)
+	logger := newTestLogger(&buf, redactor)
+
+	pathEncoded := url.PathEscape(token)
+	require.NotEqual(t, url.QueryEscape(token), pathEncoded)
+
+	logger.Info("clone failed for https://example.com/" + pathEncoded + "/repo.git")
+
+	out := buf.String()
+	assert.NotContains(t, out, token)
+	assert.NotContains(t, out, pathEncoded)
+	assert.Contains(t, out, "https://example.com/***/repo.git")
+}
+
 func TestRedactorRedactsStringFields(t *testing.T) {
 	const token = "field-secret"
 

--- a/internal/logging/testdata/rapid/TestPropertyRedactCoversURLEncodedForms/TestPropertyRedactCoversURLEncodedForms-20260801210044-6470.fail
+++ b/internal/logging/testdata/rapid/TestPropertyRedactCoversURLEncodedForms/TestPropertyRedactCoversURLEncodedForms-20260801210044-6470.fail
@@ -1,0 +1,64 @@
+# 2026/08/01 21:00:44.537462 [TestPropertyRedactCoversURLEncodedForms] [rapid] draw secret: "-vuzR2 +z+"
+# 2026/08/01 21:00:44.537552 [TestPropertyRedactCoversURLEncodedForms] 
+# 	Error Trace:	/home/user/drupdater/internal/logging/redact_property_test.go:97
+# 	            				/root/go/pkg/mod/pgregory.net/rapid@v1.3.0/engine.go:458
+# 	            				/root/go/pkg/mod/pgregory.net/rapid@v1.3.0/engine.go:467
+# 	            				/root/go/pkg/mod/pgregory.net/rapid@v1.3.0/engine.go:292
+# 	            				/root/go/pkg/mod/pgregory.net/rapid@v1.3.0/engine.go:207
+# 	            				/home/user/drupdater/internal/logging/redact_property_test.go:85
+# 	            				/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.linux-amd64/src/runtime/asm_amd64.s:1771
+# 	Error:      	Not equal: 
+# 	            	expected: "***"
+# 	            	actual  : "-vuzR2%20+z+"
+# 	            	
+# 	            	Diff:
+# 	            	--- Expected
+# 	            	+++ Actual
+# 	            	@@ -1 +1 @@
+# 	            	-***
+# 	            	+-vuzR2%20+z+
+# 	Test:       	TestPropertyRedactCoversURLEncodedForms
+# 
+v0.4.8#11040429362938902097
+0x7eb1b38811a95
+0x0
+0x6b9ab789a6db0
+0x2
+0x5de8d9b91e5d2
+0x0
+0x1ed019d51b111d
+0x42
+0x106097dafe2e97
+0x0
+0x114d00d7fc86ad
+0x41
+0xa7dc0e3078a01
+0x0
+0x1f807ebb129134
+0xffffffffffffffff
+0x1c90c2ef95f31d
+0x0
+0x141491d8b6591a
+0x67
+0x23
+0x1897b9299f58ab
+0x0
+0x82fde68c3d686
+0x7
+0x181f8906d27fed
+0x0
+0x4b0b5548a26c
+0x0
+0x15999106b39007
+0x0
+0x7f84770c301a2
+0x1
+0x1b708d6181e0c5
+0x0
+0x1fb044ac19d9d2
+0xffffffffffffffff
+0x16226356212423
+0x0
+0x1dfd63bae75b8
+0x1
+0x49871db5b9c35

--- a/internal/report/report_property_test.go
+++ b/internal/report/report_property_test.go
@@ -1,0 +1,234 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drupdater/drupdater/internal/logging"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// This file is the report's published schema, so the promises worth stating over the whole input
+// space are the ones a consumer relies on: what is written parses back, no credential reaches
+// the file whichever field carried it, and a reader polling the path never sees a partial write.
+
+// secretGen generates a credential of the kind a repository URL or an error message can carry.
+func secretGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-zA-Z0-9_-]{8,24}`)
+}
+
+func TestPropertySanitizeURLDropsEveryCredential(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		user := secretGen().Draw(t, "user")
+		password := secretGen().Draw(t, "password")
+		host := rapid.StringMatching(`[a-z]{1,8}\.example\.com`).Draw(t, "host")
+		path := rapid.StringMatching(`(/[a-z0-9_-]{1,10}){1,3}\.git`).Draw(t, "path")
+
+		raw := fmt.Sprintf("https://%s:%s@%s%s", user, password, host, path)
+		sanitized := SanitizeURL(raw)
+
+		assert.NotContains(t, sanitized, user)
+		assert.NotContains(t, sanitized, password)
+		assert.Contains(t, sanitized, host, "the URL is still meant to identify the repository")
+		assert.Contains(t, sanitized, path)
+	})
+}
+
+func TestPropertySanitizeURLIsIdempotent(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		raw := rapid.String().Draw(t, "raw")
+
+		once := SanitizeURL(raw)
+		assert.Equal(t, once, SanitizeURL(once))
+	})
+}
+
+func TestPropertySanitizeURLLeavesCredentialFreeURLsAlone(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		raw := rapid.StringMatching(`https://[a-z]{1,8}\.example\.com(:[0-9]{2,4})?(/[a-z0-9_-]{1,8}){0,3}(\?[a-z]{1,5}=[a-z0-9]{1,5})?(#[a-z]{1,5})?`).Draw(t, "raw")
+
+		// A URL with nothing to remove has to come back byte-identical. Re-serialising it
+		// through net/url would normalise escaping and case, and the report is compared across
+		// runs by consumers who would read that as a change.
+		assert.Equal(t, raw, SanitizeURL(raw))
+	})
+}
+
+func TestPropertySanitizeURLKeepsEverythingButTheUserinfo(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		user := secretGen().Draw(t, "user")
+		base := rapid.StringMatching(`https://[a-z]{1,8}\.example\.com(:[0-9]{2,4})?(/[a-z0-9_-]{1,8}){0,3}(\?[a-z]{1,5}=[a-z0-9]{1,5})?(#[a-z]{1,5})?`).Draw(t, "base")
+
+		withUser := strings.Replace(base, "https://", "https://"+user+"@", 1)
+
+		want, err := url.Parse(base)
+		require.NoError(t, err)
+		got, err := url.Parse(SanitizeURL(withUser))
+		require.NoError(t, err)
+
+		// Only the userinfo goes. Host, path, query and fragment are what make the URL useful
+		// in the report at all.
+		assert.Nil(t, got.User)
+		assert.Equal(t, want.Host, got.Host)
+		assert.Equal(t, want.Path, got.Path)
+		assert.Equal(t, want.RawQuery, got.RawQuery)
+		assert.Equal(t, want.Fragment, got.Fragment)
+	})
+}
+
+func TestPropertyNewCheckIsOKOnlyWhenEveryResultIs(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		results := rapid.SliceOfN(rapid.Custom(func(t *rapid.T) CheckResult {
+			return CheckResult{
+				Name:   rapid.StringMatching(`[a-z-]{1,20}`).Draw(t, "name"),
+				OK:     rapid.Bool().Draw(t, "ok"),
+				Detail: rapid.StringMatching(`[a-z ]{0,20}`).Draw(t, "detail"),
+			}
+		}), 0, 8).Draw(t, "results")
+
+		check := NewCheck("1.2.3", results)
+
+		// The document's OK mirrors the command's exit status, so a single failing check has to
+		// pull it down no matter where in the list it sits.
+		wantOK := true
+		for _, result := range results {
+			wantOK = wantOK && result.OK
+		}
+		assert.Equal(t, wantOK, check.OK)
+		assert.Equal(t, results, check.Results, "the results are passed through untouched")
+		assert.Equal(t, SchemaVersion, check.SchemaVersion)
+	})
+}
+
+func TestPropertyNewCheckIgnoresResultOrder(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		results := rapid.SliceOfN(rapid.Custom(func(t *rapid.T) CheckResult {
+			return CheckResult{
+				Name: rapid.StringMatching(`[a-z-]{1,20}`).Draw(t, "name"),
+				OK:   rapid.Bool().Draw(t, "ok"),
+			}
+		}), 0, 8).Draw(t, "results")
+		shuffled := rapid.Permutation(results).Draw(t, "shuffled")
+
+		assert.Equal(t, NewCheck("1.2.3", results).OK, NewCheck("1.2.3", shuffled).OK)
+	})
+}
+
+// reportGen generates a whole report document, including the optional parts that a hand-written
+// example tends to leave zero.
+func reportGen(secret string) *rapid.Generator[Report] {
+	text := rapid.StringMatching(`[a-z ]{0,20}`)
+	return rapid.Custom(func(t *rapid.T) Report {
+		rep := Report{
+			SchemaVersion:    SchemaVersion,
+			DrupdaterVersion: rapid.StringMatching(`(dev|[0-9]\.[0-9]\.[0-9])`).Draw(t, "version"),
+			StartedAt:        time.Unix(rapid.Int64Range(0, 1<<31).Draw(t, "startedAt"), 0).UTC(),
+			FinishedAt:       time.Unix(rapid.Int64Range(0, 1<<31).Draw(t, "finishedAt"), 0).UTC(),
+			DurationSeconds:  float64(rapid.IntRange(0, 10000).Draw(t, "duration")),
+			Status:           rapid.SampledFrom([]Status{StatusSuccess, StatusFailed, StatusNoChanges}).Draw(t, "status"),
+			Mode:             rapid.SampledFrom([]Mode{ModeNormal, ModeSecurity}).Draw(t, "mode"),
+			DryRun:           rapid.Bool().Draw(t, "dryRun"),
+			BaseBranch:       rapid.StringMatching(`[a-z0-9/_-]{1,15}`).Draw(t, "baseBranch"),
+			Sites:            rapid.SliceOfN(rapid.StringMatching(`[a-z0-9_]{1,10}`), 1, 3).Draw(t, "sites"),
+			Packages: rapid.SliceOfN(rapid.Custom(func(t *rapid.T) PackageChange {
+				return PackageChange{
+					Action:  rapid.SampledFrom([]string{"Install", "Upgrade", "Downgrade", "Remove"}).Draw(t, "action"),
+					Package: rapid.StringMatching(`[a-z0-9_-]{1,10}/[a-z0-9_-]{1,10}`).Draw(t, "package"),
+					From:    rapid.StringMatching(`([0-9]\.[0-9]\.[0-9])?`).Draw(t, "from"),
+					To:      rapid.StringMatching(`([0-9]\.[0-9]\.[0-9])?`).Draw(t, "to"),
+				}
+			}), 0, 4).Draw(t, "packages"),
+			Phases: rapid.SliceOfN(rapid.Custom(func(t *rapid.T) Phase {
+				return Phase{
+					Name:            rapid.StringMatching(`[a-z-]{1,15}`).Draw(t, "phaseName"),
+					StartedAt:       time.Unix(rapid.Int64Range(0, 1<<31).Draw(t, "phaseStartedAt"), 0).UTC(),
+					DurationSeconds: float64(rapid.IntRange(0, 600).Draw(t, "phaseDuration")),
+					OK:              rapid.Bool().Draw(t, "phaseOK"),
+					Error:           rapid.StringMatching(`([a-z ]{1,15})?`).Draw(t, "phaseError"),
+				}
+			}), 0, 4).Draw(t, "phases"),
+		}
+
+		// The secret is planted in whichever field this draw picks. Which one does not matter
+		// to the promise — that is the point of redacting the finished document rather than
+		// naming the fields that might carry a credential.
+		switch rapid.SampledFrom([]string{"repository", "error", "branch", "mr", "addons"}).Draw(t, "carrier") {
+		case "repository":
+			rep.Repository = "https://" + secret + "@example.com/org/repo.git"
+		case "error":
+			rep.FailedPhase = "composer-update"
+			rep.Error = "failed to authenticate with token " + secret
+		case "branch":
+			rep.UpdateBranch = "update-" + secret
+		case "mr":
+			rep.MergeRequest = &MergeRequest{URL: "https://example.com/org/repo/-/merge_requests/" + secret}
+		case "addons":
+			rep.Addons = map[string]any{"composer_audit": map[string]any{"note": text.Draw(t, "note") + secret}}
+		}
+
+		return rep
+	})
+}
+
+func TestPropertyWriteRoundTripsTheDocument(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		rep := reportGen("").Draw(t, "report")
+		path := "/out/" + strings.Join(rapid.SliceOfN(rapid.StringMatching(`[a-z]{1,6}`), 1, 3).Draw(t, "dir"), "/") + "/report.json"
+
+		fs := afero.NewMemMapFs()
+		require.NoError(t, Write(fs, path, rep, nil))
+
+		raw, err := afero.ReadFile(fs, path)
+		require.NoError(t, err)
+
+		// The published schema has to survive the trip: what a consumer parses back is what the
+		// run recorded, for every field, not only the ones an example filled in.
+		var got Report
+		require.NoError(t, json.Unmarshal(raw, &got))
+		assert.Equal(t, rep, got)
+	})
+}
+
+func TestPropertyWriteRedactsWhicheverFieldCarriedTheSecret(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		secret := secretGen().Draw(t, "secret")
+		rep := reportGen(secret).Draw(t, "report")
+
+		redactor := logging.NewRedactor()
+		redactor.Register(secret)
+
+		fs := afero.NewMemMapFs()
+		require.NoError(t, Write(fs, "/out/report.json", rep, redactor.Redact))
+
+		raw, err := afero.ReadFile(fs, "/out/report.json")
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), secret)
+	})
+}
+
+func TestPropertyWriteLeavesNoTemporaryFileBehind(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		rep := reportGen("").Draw(t, "report")
+		dir := "/out/" + strings.Join(rapid.SliceOfN(rapid.StringMatching(`[a-z]{1,6}`), 1, 3).Draw(t, "dir"), "/")
+
+		fs := afero.NewMemMapFs()
+		require.NoError(t, Write(fs, filepath.Join(dir, "report.json"), rep, nil))
+
+		// The write is atomic so a consumer polling the path never reads half a document. That
+		// only holds if the temporary file is renamed rather than left next to the real one,
+		// where a glob would pick it up.
+		entries, err := afero.ReadDir(fs, dir)
+		require.NoError(t, err)
+		for _, entry := range entries {
+			assert.NotContains(t, entry.Name(), ".drupdater-report-", "temporary file left in %s", dir)
+		}
+	})
+}

--- a/internal/services/workflow_base_property_test.go
+++ b/internal/services/workflow_base_property_test.go
@@ -1,0 +1,55 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/drupdater/drupdater/internal/report"
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+)
+
+// report.PackageChange deliberately mirrors composer.PackageChange instead of reusing it, so
+// that a refactor in the composer package cannot rename a field every consumer of the published
+// report depends on. That decoupling only pays off if something notices when the two drift, and
+// a hand-written example only covers the fields whoever wrote it filled in. Generating the whole
+// struct is what makes a dropped field fail.
+
+func packageChangeGen() *rapid.Generator[composer.PackageChange] {
+	return rapid.Custom(func(t *rapid.T) composer.PackageChange {
+		return composer.PackageChange{
+			Action:  rapid.SampledFrom([]string{"Install", "Upgrade", "Downgrade", "Remove"}).Draw(t, "action"),
+			Package: rapid.StringMatching(`[a-z0-9_-]{1,10}/[a-z0-9_-]{1,10}`).Draw(t, "package"),
+			From:    rapid.StringMatching(`([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2})?`).Draw(t, "from"),
+			To:      rapid.StringMatching(`([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2})?`).Draw(t, "to"),
+		}
+	})
+}
+
+func TestPropertyToReportPackagesCarriesEveryField(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		changes := rapid.SliceOfN(packageChangeGen(), 1, 8).Draw(t, "changes")
+
+		out := toReportPackages(changes)
+
+		assert.Len(t, out, len(changes))
+		for i, change := range changes {
+			assert.Equal(t, report.PackageChange{
+				Action:  change.Action,
+				Package: change.Package,
+				From:    change.From,
+				To:      change.To,
+			}, out[i], "package change %d", i)
+		}
+	})
+}
+
+func TestPropertyToReportPackagesReturnsNilForNothing(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		empty := rapid.SampledFrom([][]composer.PackageChange{nil, {}}).Draw(t, "empty")
+
+		// Nil rather than an empty slice: the report's field is `omitempty`, so an empty slice
+		// would publish "packages": [] where the schema says the key is absent.
+		assert.Nil(t, toReportPackages(empty))
+	})
+}

--- a/pkg/composer/composer_property_test.go
+++ b/pkg/composer/composer_property_test.go
@@ -1,0 +1,259 @@
+package composer
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// The helpers below all read output or configuration produced by Composer, which is to say by
+// something outside this repository's control. Each has a doc comment naming a concrete bug it
+// exists to prevent; these properties state that promise over the whole input space instead of
+// over the one example that prompted the comment.
+
+// jsonKeyGen generates an object key of the shape composer.json uses for a repository entry.
+func jsonKeyGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-z][a-z0-9_.-]{0,10}`)
+}
+
+func TestPropertyOrderedObjectValuesKeepsDeclarationOrder(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		keys := rapid.SliceOfN(jsonKeyGen(), 0, 6).Draw(t, "keys")
+
+		// Values are made distinguishable by index so that a reordering is visible; sorting the
+		// keys, which this function once did, would shuffle the caller's repositories into a
+		// priority order the project never declared.
+		pairs := make([]string, 0, len(keys))
+		want := make([]json.RawMessage, 0, len(keys))
+		for i, key := range keys {
+			value := fmt.Sprintf(`{"pos":%d}`, i)
+			pairs = append(pairs, fmt.Sprintf("%q:%s", key, value))
+			want = append(want, json.RawMessage(value))
+		}
+
+		got, ok := orderedObjectValues(json.RawMessage("{" + strings.Join(pairs, ",") + "}"))
+		require.True(t, ok)
+		assert.Len(t, got, len(keys), "duplicate keys count too — the object is not a map here")
+		for i := range want {
+			assert.JSONEq(t, string(want[i]), string(got[i]), "value %d", i)
+		}
+	})
+}
+
+func TestPropertyOrderedObjectValuesRejectsEverythingButObjects(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		raw := rapid.OneOf(
+			rapid.String(),
+			rapid.StringMatching(`\[(1(,1)*)?\]`),
+			rapid.StringMatching(`(-?[0-9]{1,4}|true|false|null|"[a-z]{0,5}")`),
+		).Filter(func(s string) bool {
+			// An object is the one input this property is not about, and a random string can
+			// happen to open one.
+			return !strings.HasPrefix(strings.TrimSpace(s), "{")
+		}).Draw(t, "raw")
+
+		// composer.json is user-supplied, so a "repositories" key holding an array or a scalar
+		// has to be reported as not-an-object rather than crash the run.
+		values, ok := orderedObjectValues(json.RawMessage(raw))
+		assert.False(t, ok, "for %q", raw)
+		assert.Nil(t, values)
+	})
+}
+
+func TestPropertyNormalizeRepositoryDropsOnlyTheDisableForm(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		name := jsonKeyGen().Draw(t, "name")
+		disabled := rapid.Bool().Draw(t, "disabled")
+
+		// The disable form is one repository name mapped to a bool, and nothing else. It is
+		// matched on that exact shape because a real entry may carry a bool of its own —
+		// {"type":"composer","url":"...","canonical":false} is how a mirror is declared, and
+		// dropping that would silently change which packages resolve.
+		_, keep := normalizeRepository(json.RawMessage(fmt.Sprintf(`{%q:%t}`, name, disabled)), "/project")
+		assert.False(t, keep, "a single name mapped to a bool is a disable entry")
+
+		mirror := json.RawMessage(fmt.Sprintf(`{"type":"composer","url":"https://example.com","canonical":%t}`, disabled))
+		got, keep := normalizeRepository(mirror, "/project")
+		assert.True(t, keep, "an entry with more than one key is a repository, bool or not")
+		assert.JSONEq(t, string(mirror), string(got))
+	})
+}
+
+func TestPropertyNormalizeRepositoryResolvesRelativePathsOnce(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		projectDir := "/" + strings.Join(rapid.SliceOfN(jsonKeyGen(), 1, 3).Draw(t, "projectDir"), "/")
+		relative := strings.Join(rapid.SliceOfN(jsonKeyGen(), 1, 3).Draw(t, "relative"), "/")
+
+		entry := json.RawMessage(fmt.Sprintf(`{"type":"path","url":%q}`, relative))
+		normalized, keep := normalizeRepository(entry, projectDir)
+		require.True(t, keep)
+
+		var got struct {
+			URL string `json:"url"`
+		}
+		require.NoError(t, json.Unmarshal(normalized, &got))
+		assert.Equal(t, filepath.Join(projectDir, relative), got.URL)
+
+		// Idempotent: the resolved URL is absolute, so normalising again must not join it onto
+		// the project directory a second time. The scratch project is rebuilt per check, and a
+		// doubled prefix would point at a directory that does not exist.
+		again, keep := normalizeRepository(normalized, projectDir)
+		require.True(t, keep)
+		assert.JSONEq(t, string(normalized), string(again))
+	})
+}
+
+func TestPropertyNormalizeRepositoryPassesNonPathEntriesThrough(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		repoType := rapid.SampledFrom([]string{"composer", "vcs", "git", "artifact", "package"}).Draw(t, "type")
+		url := rapid.StringMatching(`https://[a-z]{1,8}\.example\.com/[a-z]{0,8}`).Draw(t, "url")
+
+		// Only "path" repositories carry a filesystem location that the scratch project has to
+		// have rewritten. Everything else must arrive byte-identical, since re-marshalling it
+		// would reorder keys and could drop a field this struct does not know about.
+		entry := json.RawMessage(fmt.Sprintf(`{"type":%q,"url":%q}`, repoType, url))
+		got, keep := normalizeRepository(entry, "/project")
+		assert.True(t, keep)
+		assert.Equal(t, string(entry), string(got))
+	})
+}
+
+func TestPropertyUnresolvableReasonLetsPatchRejectionWin(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		rejection := rapid.SampledFrom([]string{"could not apply patch", "cannot apply patch"}).Draw(t, "rejection")
+		markers := rapid.SliceOfN(rapid.SampledFrom([]string{
+			"could not find package",
+			"could not find a matching version",
+			"could not be found",
+			"invalid credentials",
+			"authentication required",
+			"could not be downloaded",
+		}), 0, 4).Draw(t, "markers")
+		noise := rapid.StringMatching(`[a-z .:/'"-]{0,40}`).Draw(t, "noise")
+
+		// Composer's dist-to-source fallback prints "could not be downloaded" and then carries
+		// on, so an unresolvable marker can sit in output that describes a genuine patch
+		// rejection. Classifying that as "could not obtain the package" would leave the package
+		// unpinned and ship a patch that does not apply — the worse of the two failures, so the
+		// rejection wins no matter how many markers accompany it.
+		out := noise + rejection + noise + strings.Join(markers, noise)
+		reason, unresolvable := unresolvableReason(out)
+		assert.False(t, unresolvable)
+		assert.Empty(t, reason)
+	})
+}
+
+func TestPropertyUnresolvableReasonIgnoresCase(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		out := rapid.SampledFrom([]string{
+			"Could not find package foo/bar in any version",
+			"The \"https://example.com/x.zip\" file could not be downloaded",
+			"Invalid credentials for https://repo.example.com",
+			"Authentication required (repo.example.com)",
+			"Could not apply patch! Skipping.",
+			"nothing interesting happened here",
+		}).Draw(t, "out")
+		upper := rapid.SliceOfN(rapid.Bool(), len(out), len(out)).Draw(t, "upper")
+
+		var flipped strings.Builder
+		for i, c := range []byte(out) {
+			if upper[i] {
+				flipped.WriteString(strings.ToUpper(string(c)))
+				continue
+			}
+			flipped.WriteString(strings.ToLower(string(c)))
+		}
+
+		// Composer's capitalisation varies with the message and its version; the classification
+		// must not.
+		wantReason, wantUnresolvable := unresolvableReason(out)
+		gotReason, gotUnresolvable := unresolvableReason(flipped.String())
+		assert.Equal(t, wantUnresolvable, gotUnresolvable)
+		assert.Equal(t, wantReason, gotReason)
+	})
+}
+
+func TestPropertyUnresolvableReasonIsNotUndoneByTrailingOutput(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		marker := rapid.SampledFrom([]string{
+			"could not find package",
+			"could not find a matching version",
+			"could not be found",
+			"invalid credentials",
+			"authentication required",
+			"could not be downloaded",
+		}).Draw(t, "marker")
+		// Free of both the patch-rejection wording and any other marker, so appending it cannot
+		// legitimately change the answer.
+		extra := rapid.StringMatching(`[a-z0-9 .:/-]{0,30}`).
+			Filter(func(s string) bool { return !strings.Contains(s, "could") && !strings.Contains(s, "cannot") }).
+			Draw(t, "extra")
+
+		reason, unresolvable := unresolvableReason(extra + marker + extra)
+		assert.True(t, unresolvable)
+		assert.NotEmpty(t, reason, "an unresolvable package has to come with a reason for the report")
+	})
+}
+
+func TestPropertyAuditUnmarshalFlattensEveryShape(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		packages := rapid.SliceOfNDistinct(jsonKeyGen(), 0, 4, rapid.ID).Draw(t, "packages")
+
+		// Composer emits the advisories of a package either as a list or as a keyed map,
+		// depending on the package. Both have to flatten into the same one list, or an advisory
+		// silently disappears from a security report.
+		entries := make([]string, 0, len(packages))
+		want := make([]string, 0)
+		for _, pkg := range packages {
+			ids := rapid.SliceOfNDistinct(jsonKeyGen(), 0, 3, rapid.ID).Draw(t, "ids-"+pkg)
+			advisories := make([]string, 0, len(ids))
+			for _, id := range ids {
+				advisories = append(advisories, fmt.Sprintf(`{"advisoryId":%q}`, id))
+				want = append(want, id)
+			}
+
+			if rapid.Bool().Draw(t, "asMap-"+pkg) {
+				keyed := make([]string, 0, len(advisories))
+				for i, advisory := range advisories {
+					keyed = append(keyed, fmt.Sprintf("%q:%s", fmt.Sprintf("k%d", i), advisory))
+				}
+				entries = append(entries, fmt.Sprintf("%q:{%s}", pkg, strings.Join(keyed, ",")))
+				continue
+			}
+			entries = append(entries, fmt.Sprintf("%q:[%s]", pkg, strings.Join(advisories, ",")))
+		}
+
+		var audit Audit
+		require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(`{"advisories":{%s}}`, strings.Join(entries, ","))), &audit))
+
+		// Compared as a set: the map iteration inside UnmarshalJSON has no defined order.
+		got := make([]string, 0, len(audit.Advisories))
+		for _, advisory := range audit.Advisories {
+			got = append(got, advisory.AdvisoryID)
+		}
+		assert.ElementsMatch(t, want, got)
+	})
+}
+
+func TestPropertyAuditUnmarshalToleratesAMissingAdvisoriesKey(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		keys := rapid.SliceOfNDistinct(jsonKeyGen().Filter(func(s string) bool { return s != "advisories" }), 0, 4, rapid.ID).Draw(t, "keys")
+
+		pairs := make([]string, 0, len(keys))
+		for _, key := range keys {
+			pairs = append(pairs, fmt.Sprintf(`%q:1`, key))
+		}
+
+		// `composer audit` reports no advisories by omitting the key, which is the common case
+		// and must not read as a failure to parse.
+		var audit Audit
+		require.NoError(t, json.Unmarshal([]byte("{"+strings.Join(pairs, ",")+"}"), &audit))
+		assert.Empty(t, audit.Advisories)
+	})
+}

--- a/pkg/drupalorg/drupalorg_property_test.go
+++ b/pkg/drupalorg/drupalorg_property_test.go
@@ -1,0 +1,72 @@
+package drupalorg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+)
+
+// FindIssueNumber pulls an issue ID out of free-form text — a patch URL, a patch description, a
+// branch name — so the wrong answer silently attributes a patch to somebody else's issue. The
+// properties below pin what it extracts from arbitrary surroundings, including the cases that
+// are deliberate rather than accidental.
+
+// nonDigitGen generates filler that cannot contribute digits of its own, so a generated issue
+// number stays exactly the number the property put there.
+func nonDigitGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-zA-Z_./ +:?&=-]{0,20}`)
+}
+
+// issueNumberGen generates a number long enough to be recognised as an issue ID.
+func issueNumberGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[1-9][0-9]{5,9}`)
+}
+
+func TestPropertyFindIssueNumberExtractsTheNumberFromAnySurroundings(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		before := nonDigitGen().Draw(t, "before")
+		number := issueNumberGen().Draw(t, "number")
+		after := nonDigitGen().Draw(t, "after")
+
+		got, found := (&HTTPClient{}).FindIssueNumber(before + number + after)
+		assert.True(t, found)
+		assert.Equal(t, number, got, "the whole run of digits is the issue ID, not a prefix of it")
+	})
+}
+
+func TestPropertyFindIssueNumberTakesTheFirstMatch(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		first := issueNumberGen().Draw(t, "first")
+		second := issueNumberGen().Draw(t, "second")
+		between := nonDigitGen().Filter(func(s string) bool { return s != "" }).Draw(t, "between")
+
+		// A patch file name routinely carries both the issue and the comment number
+		// ("1234567-89-fix.patch"); the issue comes first, and that is the one meant.
+		got, found := (&HTTPClient{}).FindIssueNumber(first + between + second)
+		assert.True(t, found)
+		assert.Equal(t, first, got)
+	})
+}
+
+func TestPropertyFindIssueNumberIgnoresShortDigitRuns(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		parts := rapid.SliceOfN(rapid.StringMatching(`[0-9]{1,5}`), 0, 6).Draw(t, "runs")
+		separators := rapid.SliceOfN(nonDigitGen().Filter(func(s string) bool {
+			return s != "" && !strings.ContainsAny(s, "0123456789")
+		}), len(parts), len(parts)).Draw(t, "separators")
+
+		// Version numbers, comment counts and dates all produce short digit runs. None of them
+		// is an issue ID, and treating one as such would point a patch at a random issue.
+		var text strings.Builder
+		for i, part := range parts {
+			text.WriteString(part)
+			text.WriteString(separators[i])
+		}
+
+		got, found := (&HTTPClient{}).FindIssueNumber(text.String())
+		assert.False(t, found)
+		assert.Empty(t, got)
+	})
+}

--- a/pkg/repo/repo_property_test.go
+++ b/pkg/repo/repo_property_test.go
@@ -1,0 +1,95 @@
+package repo
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+)
+
+// pathWithin decides whether a changed file counts as a change to a configured directory. Its
+// doc comment names the bug a substring test would have; these properties state the containment
+// laws that rule that class of bug out for every path rather than for the one example.
+
+// segmentGen generates one segment of a slash-separated repository path. Segments start with an
+// alphanumeric so the generator cannot produce "." or ".."; git status paths are already
+// relative to the worktree root and never contain either, and path.Join would silently collapse
+// them into a shape the function is not being asked about.
+func segmentGen() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-z0-9][a-z0-9_.-]{0,7}`)
+}
+
+// segmentsGen generates between one and maxLen segments of a slash-separated repository path.
+func segmentsGen(maxLen int) *rapid.Generator[[]string] {
+	return rapid.SliceOfN(segmentGen(), 1, maxLen)
+}
+
+func TestPropertyPathWithinAcceptsEveryDescendant(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir := path.Join(segmentsGen(3).Draw(t, "dir")...)
+		below := path.Join(segmentsGen(3).Draw(t, "below")...)
+
+		assert.True(t, pathWithin(path.Join(dir, below), dir))
+	})
+}
+
+func TestPropertyPathWithinRejectsPrefixSiblings(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir := path.Join(segmentsGen(3).Draw(t, "dir")...)
+		// A non-empty suffix that does not start with a separator turns the last segment into a
+		// different directory name — "translations" against "translations-backup". A substring
+		// test would report every file in it as a change to dir.
+		suffix := segmentGen().Draw(t, "suffix")
+		file := segmentGen().Draw(t, "file")
+
+		assert.False(t, pathWithin(path.Join(dir+suffix, file), dir))
+	})
+}
+
+func TestPropertyPathWithinIsReflexive(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir := path.Join(segmentsGen(3).Draw(t, "dir")...)
+
+		// A configured directory that is itself staged — a deleted directory, say — counts as
+		// within itself, or the change would be invisible to the addon that asked about it.
+		assert.True(t, pathWithin(dir, dir))
+	})
+}
+
+func TestPropertyPathWithinIsTransitive(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		outer := path.Join(segmentsGen(2).Draw(t, "outer")...)
+		middle := path.Join(outer, path.Join(segmentsGen(2).Draw(t, "middle")...))
+		inner := path.Join(middle, path.Join(segmentsGen(2).Draw(t, "inner")...))
+
+		assert.True(t, pathWithin(inner, middle))
+		assert.True(t, pathWithin(middle, outer))
+		assert.True(t, pathWithin(inner, outer), "containment has to compose")
+	})
+}
+
+func TestPropertyPathWithinIgnoresSurroundingSlashes(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		dir := path.Join(segmentsGen(3).Draw(t, "dir")...)
+		file := path.Join(dir, path.Join(segmentsGen(2).Draw(t, "file")...))
+		lead := strings.Repeat("/", rapid.IntRange(0, 2).Draw(t, "lead"))
+		trail := strings.Repeat("/", rapid.IntRange(0, 2).Draw(t, "trail"))
+
+		// Callers pass a directory straight from configuration, where writing it as
+		// "/translations/" is a matter of taste. Git status paths never carry them, so the
+		// two forms have to mean the same thing.
+		assert.Equal(t, pathWithin(file, dir), pathWithin(file, lead+dir+trail))
+	})
+}
+
+func TestPropertyPathWithinTreatsAnEmptyDirAsNoFilter(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		file := rapid.String().Draw(t, "file")
+
+		// "no path filter" is expressed as the empty directory, so it has to match everything —
+		// including paths that are themselves empty or nothing but separators.
+		assert.True(t, pathWithin(file, ""))
+	})
+}


### PR DESCRIPTION
The suite is example-based throughout: every test checks the inputs someone
thought of. Coverage proves a line ran, mutation testing proves a test watches
it, and neither says whether a function's promise holds across its whole input
space. For the parts of this tool where it matters most -- secret redaction,
URL sanitising, path containment, classifying composer's output -- that is the
interesting question.

Adds pgregory.net/rapid and 45 properties across ten packages, in
<subject>_property_test.go files named TestProperty... so `make test-property`
can select them. Each states a law -- idempotent, order-independent,
round-trips, leaks nothing -- rather than a second implementation of the
function under test.

Three defects the properties found, each fixed with an ordinary test naming the
counterexample so the mutation gate does not depend on the random seed:

- logging: Register only registered a value's query escaping. A space is '+'
  in a query component and "%20" in a path segment, so a token a subprocess
  echoed back from a URL path reached the log intact. Registers both forms.
- addon: recordFixes sorted rector's own AppliedRectors slice in place,
  reordering data the caller still owns and aliasing two fixes for a file
  listed twice onto one array. Clones before sorting.
- addon: advisoryKey's package+title fallback joined on '|'. Advisory titles
  are free text, so two distinct advisories could share a key -- reporting one
  as fixed while it is still open, in a security update. Quotes both halves.

Mutation score on the changed lines is 100% (7/7). Two operational notes are
documented and baked into the Makefile: mutation runs need RAPID_NOFAILFILE=1
or every killed mutant leaves a counterexample file behind, and RAPID_CHECKS
must be used instead of -rapid.checks across ./... because rapid registers its
flags only in binaries that import it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EPZ2gHv4v82auRAm5Dj8rp