### PR TITLE
test: verify what a drupdater run actually produced

### DIFF
--- a/.github/assert-lock-matches-report.jq
+++ b/.github/assert-lock-matches-report.jq
@@ -1,0 +1,84 @@
+# Verifies a drupdater run report's package list against the composer.lock it produced.
+#
+#   jq -n -e -r --slurpfile before old-composer.lock \
+#                --slurpfile after  composer.lock \
+#                --slurpfile report report.json \
+#                -f .github/assert-lock-matches-report.jq
+#
+# The report's "packages" field is parsed out of composer's console output, not
+# read back from the lock, so everything downstream of it -- the dependency
+# table in the merge request, a fleet-wide view of what moved, this repository's
+# own integration assertions -- trusts a regular expression over human-readable
+# text. That regex has to keep up with composer's output, and nothing in the
+# unit tests would notice if it stopped doing so: they feed it the output it was
+# written against.
+#
+# Diffing the two lock files is the independent second opinion. It is derived
+# from the artefact the run actually committed, so a report that says a package
+# moved when the lock disagrees -- or stays silent about one that did -- fails
+# here rather than being believed.
+
+# name -> version, across both sections. require-dev packages are updated by the
+# same composer update and are as much a part of the diff as the rest.
+def packages_map:
+  (((.packages // []) + (."packages-dev" // []))
+   | map({key: .name, value: (.version // "")})
+   | from_entries);
+
+# The report's action vocabulary, reduced to what a lock diff can actually
+# distinguish. Upgrade and Downgrade are one case here: telling them apart needs
+# a semantic version comparison, which jq has no business doing -- the direction
+# is composer's own statement and there is nothing in the lock to check it
+# against.
+def category: if . == "Upgrade" or . == "Downgrade" then "change" else ascii_downcase end;
+
+($before[0] | packages_map) as $was
+| ($after[0] | packages_map) as $now
+| ($report[0].packages // []) as $reported
+| ($reported | map({key: .package, value: .}) | from_entries) as $by_name
+| ( [ ($now | keys_unsorted[] | . as $name
+       | select(($was | has($name)) | not)
+       | {package: $name, category: "install", to: $now[$name]}),
+      ($was | keys_unsorted[] | . as $name
+       | select(($now | has($name)) | not)
+       | {package: $name, category: "remove", from: $was[$name]}),
+      ($now | keys_unsorted[] | . as $name
+       | select(($was | has($name)) and ($was[$name] != $now[$name]))
+       | {package: $name, category: "change", from: $was[$name], to: $now[$name]})
+    ] ) as $expected
+| ( $expected | map({key: .package, value: .}) | from_entries ) as $expected_by_name
+| [
+  # Every lock change has to appear in the report, with the same shape.
+  ( $expected[]
+    | . as $want
+    | ($by_name[$want.package] // null) as $got
+    | if $got == null
+      then "composer.lock changed \($want.package) (\($want.category)) but the report does not mention it"
+      elif ($got.action | category) != $want.category
+      then "\($want.package): composer.lock shows a \($want.category), the report says \($got.action)"
+      elif ($want.from != null) and (($got.from // "") != $want.from)
+      then "\($want.package): composer.lock has it going from \($want.from), the report says \($got.from // "")"
+      elif ($want.to != null) and (($got.to // "") != $want.to)
+      then "\($want.package): composer.lock has it going to \($want.to), the report says \($got.to // "")"
+      else empty end ),
+
+  # ... and nothing may be reported that the lock does not show. A report
+  # claiming an update that never landed is the more dangerous direction: it is
+  # the one a reviewer would act on.
+  ( $reported[]
+    | . as $got
+    | select(($expected_by_name | has($got.package)) | not)
+    | "\($got.package): the report claims a \($got.action) that composer.lock does not show" ),
+
+  # A run that updated nothing has no business reporting packages, and one that
+  # changed the lock has no business reporting none.
+  ( if ($expected | length) == 0 and ($reported | length) > 0
+    then "composer.lock is unchanged, but the report lists \($reported | length) package changes"
+    elif ($expected | length) > 0 and ($reported | length) == 0
+    then "composer.lock changed \($expected | length) packages, but the report lists none"
+    else empty end )
+]
+| if length == 0
+  then "composer.lock matches the report (\($expected | length) package changes)"
+  else "composer.lock does not match the report:\n  - " + join("\n  - ") | halt_error(1)
+  end

--- a/.github/assert-report.jq
+++ b/.github/assert-report.jq
@@ -9,15 +9,68 @@
 # addons a fixture is built to exercise actually appear in the report is what
 # turns this job from "it did not crash" into "it did what it is for".
 #
+# The checks come in two kinds. The $expect fields are per fixture: only the
+# fixture knows what it was built to produce. Everything after them holds for
+# *any* report -- they are the report's own internal consistency, need no
+# fixture knowledge, and are therefore always on.
+#
 # $expect fields, all optional except status:
-#   status        list of acceptable .status values
-#   min_packages  minimum number of package changes
-#   phases        phase names that must be present AND ok
-#   addons        keys that must appear under .addons
+#   status          list of acceptable .status values
+#   min_packages    minimum number of package changes
+#   phases          phase names that must be present AND ok
+#   addons          keys that must appear under .addons
+#   packages_match  regexes, each of which some package name must match
+#   forbid_actions  package actions that must not appear at all
+#   audit_fixed_min minimum number of advisories composer_audit closed
+#
+# Secrets are read from the DRUPDATER_ASSERT_SECRETS environment variable,
+# newline separated, and asserted to appear nowhere in the document. Unset means
+# the check is skipped.
+
+# The phases in the order the workflow runs them. Used to check that the phases
+# a run recorded are ordered and unique -- a report whose phases are shuffled or
+# repeated describes a run nobody can reason about, whatever .status says.
+def phase_order: [
+  "acquire working copy",
+  "preflight",
+  "composer install",
+  "baseline site install",
+  "update shared code",
+  "site update",
+  "render merge request",
+  "publish"
+];
+
+# Addons that both report structured data and render a section into the merge
+# request description, with the heading that section starts with.
+#
+# The two have to agree: an addon that told the report it did something while
+# leaving the description silent about it produces a merge request whose
+# reviewer is never told what changed. Only addons that render a section belong
+# here -- code_beautifier, deprecations_remover and translations_updater report
+# without contributing one, and are deliberately absent.
+def addon_sections: {
+  "composer_audit":      "## 🛡️ Security Report",
+  "composer_patches":    "## 🩹 Patch updates",
+  "unsupported_modules": "## ⚠️ Unsupported modules",
+  "update_hooks":        "## 📄 Job Logs"
+};
+
+# An advisory's identity, for comparing the fixed and remaining lists. Mirrors
+# the key composer_audit itself uses: CVE first, then the advisory id, then the
+# package and title for an advisory carrying neither.
+def advisory_key: "\(.cve // "")|\(.advisoryId // "")|\(.packageName // "")|\(.title // "")";
+
+def secrets: (env.DRUPDATER_ASSERT_SECRETS // "") | split("\n") | map(select(length > 0));
 
 . as $r
 | ($r.addons // {}) as $addons
+| ($r.phases // []) as $phases
+| ($r.packages // []) as $packages
+| ($r.merge_request_description // "") as $description
 | [
+  # ---------------------------------------------------------------- $expect
+
   ( if ($expect.status | index($r.status)) == null
     then "status: got \"\($r.status)\", want one of \($expect.status | join(", "))"
        + (if $r.failed_phase
@@ -25,13 +78,13 @@
           else "" end)
     else empty end ),
 
-  ( if ($r.packages | length) < ($expect.min_packages // 0)
-    then "packages: got \($r.packages | length), want at least \($expect.min_packages)"
+  ( if ($packages | length) < ($expect.min_packages // 0)
+    then "packages: got \($packages | length), want at least \($expect.min_packages)"
     else empty end ),
 
   ( ($expect.phases // [])[]
     | . as $name
-    | ($r.phases | map(select(.name == $name))) as $found
+    | ($phases | map(select(.name == $name))) as $found
     | if ($found | length) == 0 then "phase missing: \($name)"
       elif ($found | map(select(.ok)) | length) == 0
       then "phase not ok: \($name) (\($found[0].error // "no error recorded"))"
@@ -45,9 +98,187 @@
             | if $k == "" then "(none)" else $k end)
       end ),
 
+  # A fixture built around a particular package -- core held a minor behind,
+  # say -- only exercises what it is for if that package actually moved. A
+  # count alone is satisfied by any unrelated transitive bump.
+  ( ($expect.packages_match // [])[]
+    | . as $pattern
+    | if ($packages | map(select(.package | test($pattern))) | length) == 0
+      then "packages: nothing matching /\($pattern)/ was updated"
+      else empty end ),
+
+  ( ($expect.forbid_actions // [])[]
+    | . as $action
+    | ($packages | map(select(.action == $action)) | map(.package)) as $found
+    | if ($found | length) > 0
+      then "packages: \($action) is not expected here: \($found | join(", "))"
+      else empty end ),
+
+  # "composer_audit reported something" is satisfied by a run that closed no
+  # advisory at all and only listed the ones still open -- the one outcome a
+  # security run must not produce quietly.
+  ( (($addons.composer_audit.fixed) // []) as $fixed
+    | if $expect.audit_fixed_min and ($fixed | length) < $expect.audit_fixed_min
+      then "composer_audit: fixed \($fixed | length) advisories, want at least \($expect.audit_fixed_min)"
+      else empty end ),
+
+  # ------------------------------------------------------------ invariants
+
   ( if $r.schema_version != 1
     then "schema_version: got \($r.schema_version), want 1 -- the report contract changed"
-    else empty end )
+    else empty end ),
+
+  # Package changes: shape first, because a malformed entry makes every other
+  # statement about .packages meaningless.
+  ( $packages[]
+    | . as $p
+    | select((["Install", "Upgrade", "Downgrade", "Remove"] | index($p.action)) == null)
+    | "packages: \($p.package // "(unnamed)") has unknown action \"\($p.action // "")\"" ),
+
+  ( $packages[]
+    | select(.action == "Upgrade" or .action == "Downgrade")
+    | select(((.from // "") | length) == 0 or ((.to // "") | length) == 0)
+    | "packages: \(.package) is a \(.action) without both from and to" ),
+
+  ( $packages[]
+    | select(.action == "Install")
+    | select(((.to // "") | length) == 0)
+    | "packages: \(.package) was installed without a version" ),
+
+  ( $packages[]
+    | select(.action == "Remove")
+    | select(((.from // "") | length) == 0)
+    | "packages: \(.package) was removed without a version" ),
+
+  # One composer update produces at most one operation per package, so a
+  # duplicate means the operations were parsed out of composer's output wrong.
+  ( $packages
+    | group_by(.package)
+    | map(select(length > 1))[]
+    | "packages: \(.[0].package) appears \(length) times" ),
+
+  # Phases are recorded in the order they ran, once each.
+  ( $phases
+    | group_by(.name)
+    | map(select(length > 1))[]
+    | "phases: \(.[0].name) recorded \(length) times" ),
+
+  ( $phases[]
+    | . as $phase
+    | select((phase_order | index($phase.name)) == null)
+    | "phases: unknown phase \"\($phase.name)\" -- phase_order in this script is out of date" ),
+
+  ( ($phases | map(. as $phase | phase_order | index($phase.name)) | map(select(. != null))) as $positions
+    | if ($positions | length) > 1 and ($positions != ($positions | sort))
+      then "phases: recorded out of order: \($phases | map(.name) | join(" -> "))"
+      else empty end ),
+
+  ( $phases[]
+    | select((.duration_seconds // 0) < 0)
+    | "phases: \(.name) has a negative duration" ),
+
+  # A run cannot be shorter than the phases it is made of. One second of slack
+  # absorbs the rounding of eight independently measured durations.
+  ( ($phases | map(.duration_seconds // 0) | add // 0) as $sum
+    | if $sum > (($r.duration_seconds // 0) + 1)
+      then "duration: phases add up to \($sum)s but the run lasted \($r.duration_seconds)s"
+      else empty end ),
+
+  # Status has to agree with the phases it summarises, in both directions.
+  ( if $r.status == "success"
+    then ( ($phases | map(select(.ok | not)) | map(.name)) as $failed
+           | if ($failed | length) > 0
+             then "status: success, but these phases are not ok: \($failed | join(", "))"
+             else empty end ),
+         ( if (($r.failed_phase // "") | length) > 0 or (($r.error // "") | length) > 0
+           then "status: success, but failed_phase=\($r.failed_phase // "") error=\($r.error // "")"
+           else empty end )
+    else empty end ),
+
+  ( if $r.status == "failed"
+    then ( if (($r.failed_phase // "") | length) == 0
+           then "status: failed, but no failed_phase is named"
+           else ( ($phases | map(select(.name == $r.failed_phase and (.ok | not)))) as $found
+                  | if ($found | length) == 0
+                    then "status: failed_phase=\($r.failed_phase) is not recorded as a failed phase"
+                    else empty end )
+           end )
+    else empty end ),
+
+  ( if $r.status == "no_changes" and ($r.merge_request != null)
+    then "status: no_changes, but a merge request was created (\($r.merge_request.url // ""))"
+    else empty end ),
+
+  # A --dry-run does everything except publish. That it published anyway is the
+  # single worst thing this report could be hiding.
+  ( if $r.dry_run == true and ($r.merge_request != null)
+    then "dry_run: a merge request was created anyway (\($r.merge_request.url // ""))"
+    else empty end ),
+
+  ( if $r.merge_request != null and (($r.merge_request.url // "") | length) == 0
+    then "merge_request: recorded without a url"
+    else empty end ),
+
+  # The branch is named as soon as the code update succeeds -- including under
+  # --dry-run, where it is the only handle on what the run produced.
+  ( if ($phases | map(select(.name == "update shared code" and .ok)) | length) > 0
+      and (($r.update_branch // "") | length) == 0
+    then "update_branch: empty although the code update succeeded"
+    else empty end ),
+
+  # Same for the merge request's title and description: rendering them is a
+  # phase of its own so that a dry run assembles them too.
+  ( if ($phases | map(select(.name == "render merge request" and .ok)) | length) > 0
+    then ( if (($r.merge_request_title // "") | length) == 0
+           then "merge_request_title: empty although the merge request was rendered"
+           else empty end ),
+         ( if ($description | length) == 0
+           then "merge_request_description: empty although the merge request was rendered"
+           else empty end )
+    else empty end ),
+
+  # What an addon reported and what the reviewer is told must be the same story.
+  ( addon_sections
+    | to_entries[]
+    | . as $section
+    | select(($addons | has($section.key)) and ($description | length) > 0)
+    | select(($description | contains($section.value)) | not)
+    | "merge_request_description: \($section.key) reported data but rendered no \"\($section.value)\" section" ),
+
+  # Site-keyed addon sections can only be about sites the run was configured for.
+  ( ["update_hooks", "translations_updater"][]
+    | . as $key
+    | ($addons[$key] // {})
+    | if type == "object"
+      then keys[]
+           | . as $site
+           | select((($r.sites // []) | index($site)) == null)
+           | "\($key): reports site \"\($site)\", which is not in .sites"
+      else empty end ),
+
+  ( ($addons.unsupported_modules // [])[]
+    | select(((.name // "") | length) == 0)
+    | "unsupported_modules: an entry has no name" ),
+
+  # An advisory cannot be both closed by this update and still open after it.
+  ( (($addons.composer_audit.fixed // []) | map(advisory_key)) as $fixed
+    | (($addons.composer_audit.remaining // []) | map(advisory_key)) as $remaining
+    | ($fixed - ($fixed - $remaining))[]
+    | "composer_audit: advisory \(.) is reported as both fixed and remaining" ),
+
+  # translations_updater exists to make "ran and found nothing" distinguishable
+  # from "bailed out early", so every site it reports has to say which it was.
+  ( ($addons.translations_updater // {})
+    | to_entries[]
+    | select((.value.updated != true) and (((.value.skipped // "") | length) == 0))
+    | "translations_updater: site \(.key) neither updated nor gave a skip reason" ),
+
+  # The report is archived and attached to tickets. A credential reaching it is
+  # a finding regardless of what else the run did right.
+  ( ($r | tojson) as $document
+    | secrets[]
+    | select(. as $secret | $document | contains($secret))
+    | "credential: a secret from the environment appears in the report" )
 ]
 | if length == 0 then "report assertions passed"
   else "report assertions failed:\n  - " + join("\n  - ") | halt_error(1)

--- a/.github/integration-fixtures.json
+++ b/.github/integration-fixtures.json
@@ -10,13 +10,20 @@
           "success"
         ],
         "min_packages": 1,
+        "packages_match": [
+          "^drupal/core"
+        ],
+        "forbid_actions": [
+          "Downgrade"
+        ],
         "phases": [
           "acquire working copy",
           "preflight",
           "composer install",
           "baseline site install",
           "update shared code",
-          "site update"
+          "site update",
+          "render merge request"
         ],
         "addons": [
           "update_hooks",
@@ -31,13 +38,18 @@
           "success"
         ],
         "min_packages": 1,
+        "audit_fixed_min": 1,
+        "forbid_actions": [
+          "Downgrade"
+        ],
         "phases": [
           "acquire working copy",
           "preflight",
           "composer install",
           "baseline site install",
           "update shared code",
-          "site update"
+          "site update",
+          "render merge request"
         ],
         "addons": [
           "composer_audit",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ on:
       # changes the published site even though it is not under docs/.
       - "internal/addon/testdata/**"
       - ".github/assert-report.jq"
+      - ".github/assert-lock-matches-report.jq"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -175,7 +175,10 @@ jobs:
     needs: [plan, build]
     name: ${{ matrix.fixture }} / ${{ matrix.mode }}
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    # Generous because the normal-mode legs run drupdater a second time to check
+    # the update is idempotent, and that second run installs the site again
+    # before it gets as far as composer update.
+    timeout-minutes: 120
     strategy:
       # One fixture or mode failing must not hide the state of the others.
       fail-fast: false
@@ -185,11 +188,13 @@ jobs:
       TARGET_URL: ${{ matrix.repository_url }}
       TARGET_BRANCH: ${{ matrix.branch }}
     steps:
-      # Just the assertion script -- the job otherwise has no use for the source.
-      - name: Checkout assertion script
+      # Just the assertion scripts -- the job otherwise has no use for the source.
+      - name: Checkout assertion scripts
         uses: actions/checkout@v7
         with:
-          sparse-checkout: .github/assert-report.jq
+          sparse-checkout: |
+            .github/assert-report.jq
+            .github/assert-lock-matches-report.jq
           sparse-checkout-cone-mode: false
 
       - name: Download image
@@ -258,9 +263,17 @@ jobs:
       # The report is written on every exit path, so this runs even when the
       # container failed -- a failed run's report is the one worth reading.
       - name: Summarise and verify run report
+        id: report
         if: always()
         env:
           EXPECT: ${{ matrix.expect }}
+          # Asserted to appear nowhere in the report. Redaction is a documented
+          # promise about a file that gets archived and attached to tickets, and
+          # this is the only place it is checked against a real run's errors and
+          # URLs rather than against strings a unit test made up.
+          DRUPDATER_ASSERT_SECRETS: |
+            ${{ secrets.DRUPDATER_TEST_TOKEN }}
+            ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
         run: |
           # The container runs as root and the report is written 0600, so both jq
           # and upload-artifact get EACCES until the runner owns it back.
@@ -280,14 +293,153 @@ jobs:
           # exists") and a run reports success even when an addon logged and
           # swallowed its own failure, so neither exit status nor .status alone is
           # a verdict. Assert what this fixture is actually meant to produce.
+          # Hand the outcome to the steps below: everything that inspects the
+          # working copy only makes sense for a run that produced one.
+          {
+            echo "status=$(jq -r '.status' ./run/report.json)"
+            echo "update_branch=$(jq -r '.update_branch // ""' ./run/report.json)"
+          } >> "$GITHUB_OUTPUT"
           jq -e -r --argjson expect "$EXPECT" -f .github/assert-report.jq \
             ./run/report.json | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Everything above reads the report, which is drupdater's own account of
+      # the run. The steps below read the repository it left behind, which is
+      # what a reviewer would actually get -- the two disagreeing is the failure
+      # mode a report cannot catch on its own.
+      - name: Verify the working copy
+        if: always() && steps.report.outputs.status == 'success'
+        env:
+          UPDATE_BRANCH: ${{ steps.report.outputs.update_branch }}
+        run: |
+          set -euo pipefail
+          cd ./run/project
+          echo "### Working copy" >> "$GITHUB_STEP_SUMMARY"
+
+          # The run ends on the branch it created, and the report names it. A
+          # mismatch means the report is describing a branch that is not there.
+          current="$(git rev-parse --abbrev-ref HEAD)"
+          if [ "$current" != "$UPDATE_BRANCH" ]; then
+            echo "::error::checkout is on $current, report says $UPDATE_BRANCH"
+            exit 1
+          fi
+
+          # The update has to be additive: the base branch is left where it was,
+          # and the update branch descends from it.
+          if ! git merge-base --is-ancestor "origin/$TARGET_BRANCH" HEAD; then
+            echo "::error::$UPDATE_BRANCH does not descend from origin/$TARGET_BRANCH"
+            exit 1
+          fi
+          if [ "$(git rev-parse "$TARGET_BRANCH")" != "$(git rev-parse "origin/$TARGET_BRANCH")" ]; then
+            echo "::error::the local $TARGET_BRANCH branch was moved"
+            exit 1
+          fi
+
+          commits="$(git rev-list --count "origin/$TARGET_BRANCH..HEAD")"
+          if [ "$commits" -lt 1 ]; then
+            echo "::error::a successful run left no commits on $UPDATE_BRANCH"
+            exit 1
+          fi
+          echo "$commits commits on \`$UPDATE_BRANCH\`:" >> "$GITHUB_STEP_SUMMARY"
+          git log --oneline "origin/$TARGET_BRANCH..HEAD" >> "$GITHUB_STEP_SUMMARY"
+
+          # Addons commit as they go, so a finished run leaves nothing behind:
+          # an uncommitted change is work that would never reach the merge
+          # request. settings.php is the one exception -- ConfigureDatabase
+          # appends the test database to it on purpose, and it is gitignored in
+          # most projects anyway -- so it is excluded rather than tolerated
+          # wholesale. Untracked files are out of scope: vendor/ and the site's
+          # generated files legitimately sit in the checkout.
+          dirty="$(git status --porcelain --untracked-files=no \
+                   | grep -v 'sites/[^/]*/settings\.php$' || true)"
+          if [ -n "$dirty" ]; then
+            echo "::error::uncommitted changes left behind"
+            echo "$dirty"
+            exit 1
+          fi
+
+      - name: Verify the report against composer.lock
+        if: always() && steps.report.outputs.status == 'success'
+        run: |
+          set -euo pipefail
+          # The report's package list is parsed out of composer's console
+          # output. Diffing the lock the run committed against the one it
+          # started from is the independent check on that parsing -- and on
+          # everything built from it, the merge request's dependency table
+          # included.
+          git -C ./run/project show "origin/$TARGET_BRANCH:composer.lock" > /tmp/base-composer.lock
+          jq -n -e -r \
+            --slurpfile before /tmp/base-composer.lock \
+            --slurpfile after ./run/project/composer.lock \
+            --slurpfile report ./run/report.json \
+            -f .github/assert-lock-matches-report.jq | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify composer.json and composer.lock are usable
+        if: always() && steps.report.outputs.status == 'success'
+        run: |
+          set -euo pipefail
+          # A lock that does not match composer.json, or one that cannot be
+          # resolved for the target platform, makes the merge request useless
+          # however good the changelog looks. composer is in the image, so this
+          # runs against exactly the version the update itself used.
+          #
+          # --no-check-publish drops the rules about publishable packages
+          # (name, description, license); a site is not a library. The lock
+          # check is deliberately kept.
+          docker run --rm -v "$(pwd)/run:/workspace" -w /workspace/project \
+            --entrypoint composer drupdater:test \
+            validate --no-check-publish --no-interaction | tee -a "$GITHUB_STEP_SUMMARY"
+          docker run --rm -v "$(pwd)/run:/workspace" -w /workspace/project \
+            --entrypoint composer drupdater:test \
+            install --dry-run --no-scripts --no-interaction \
+            | tail -20 | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Running drupdater on its own output must find nothing left to do. It is
+      # the one assertion that covers the addons that only ever write files:
+      # a normaliser, PHPCBF or Rector rule that rewrites the same code
+      # differently on every pass produces an endless stream of merge requests,
+      # and no single run can tell that it did.
+      #
+      # Only the normal-mode leg: the second run exercises the same code path in
+      # either mode, and it is not cheap -- it installs the site again before it
+      # can get as far as composer update.
+      - name: Re-run to prove the update is idempotent
+        if: steps.report.outputs.status == 'success' && matrix.mode == 'normal'
+        env:
+          REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
+          DRUPALCODE_ACCESS_TOKEN: ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
+          UPDATE_BRANCH: ${{ steps.report.outputs.update_branch }}
+          VERBOSE: ${{ needs.plan.outputs.verbose }}
+        run: |
+          set -euo pipefail
+          # Move the base branch onto the update, the way merging the request
+          # would, and run against that. Re-running on the update branch itself
+          # would abort with "branch already exists" and prove nothing.
+          git -C ./run/project checkout "$TARGET_BRANCH"
+          git -C ./run/project merge --ff-only "$UPDATE_BRANCH"
+
+          args=(--working-dir /workspace/project --report /workspace/report-second.json --dry-run)
+          [ "$VERBOSE" = "true" ] && args+=(--verbose)
+          docker run --rm \
+            -e DRUPALCODE_ACCESS_TOKEN \
+            -v "$(pwd)/run:/workspace" \
+            drupdater:test "$REPO_TOKEN" "${args[@]}"
+
+          sudo chown -R "$(id -u):$(id -g)" ./run || true
+          echo "### Second run (idempotency)" >> "$GITHUB_STEP_SUMMARY"
+          # Anything other than no_changes means the first run left work behind:
+          # read .packages in the second report to see what moved the second
+          # time round.
+          jq -e -r --argjson expect '{"status": ["no_changes"]}' \
+            -f .github/assert-report.jq ./run/report-second.json \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload run report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: drupdater-report-${{ matrix.fixture }}-${{ matrix.mode }}
-          path: ./run/report.json
+          # report-second.json only exists for the legs that run the idempotency
+          # check, so the pattern is a glob rather than two named files.
+          path: ./run/report*.json
           if-no-files-found: error
           retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Verify with `make docs-build` (runs `mkdocs build --strict`, which fails on brok
 Some pages embed files from the repo via `pymdownx.snippets`, so they cannot drift:
 
 - `internal/addon/testdata/*.md` → the "pull request section" examples on addon pages
-- `.github/assert-report.jq` → `docs/how-to/consume-the-run-report.md`
+- `.github/assert-report.jq`, `.github/assert-lock-matches-report.jq` → `docs/how-to/consume-the-run-report.md`
 
 Changing a golden file changes the published example. `internal/addon/testdata/composer_diff.md` is a `Dummy Table` placeholder and is deliberately *not* embedded — that page hand-writes its example.
 
@@ -90,7 +90,7 @@ Where things live. For *how they work*, read `docs/explanation/` rather than dup
 |---|---|
 | `main.go` → `cmd/root.go` | Cobra commands, flag parsing, service construction, `addonRegistry`, `mandatoryAddons` |
 | `cmd/check.go` | The `check` command and its cheap/full check tiers |
-| `internal/services/workflow_base.go` | `StartUpdate` and the seven phases |
+| `internal/services/workflow_base.go` | `StartUpdate` and the eight phases |
 | `internal/services/event.go` | The six workflow events and `AbortError` |
 | `internal/services/preflight.go` | Checks shared between `check` and the run's own `preflight` phase |
 | `internal/addon/` | The ten addons |

--- a/docs/explanation/addon-architecture.md
+++ b/docs/explanation/addon-architecture.md
@@ -26,7 +26,7 @@ other one is disabled" — because none of them ever depended on another being t
 | `post-code-update` | After `composer.json`/`.lock` are committed | — |
 | `pre-site-update` | Before each site's update hooks | — (carries the site name) |
 | `post-site-update` | After each site's hooks, before config export | — (carries the site name) |
-| `pre-merge-request-create` | Before the request is opened | `Title` |
+| `pre-merge-request-create` | While the request is rendered — under `--dry-run` too | `Title` |
 
 All but the last carry the run context, the working directory path and the git worktree,
 so an addon can read files and stage changes without being handed a service.

--- a/docs/explanation/how-a-run-works.md
+++ b/docs/explanation/how-a-run-works.md
@@ -12,7 +12,7 @@ flowchart LR
     D --> E[Open PR / MR<br/>with changelog]
 ```
 
-## The seven phases
+## The eight phases
 
 Phases run linearly. Their names are exactly the strings that appear in the [run
 report](../reference/run-report.md)'s `phases` list.
@@ -81,12 +81,22 @@ The commit step is serialised across sites even though the rest is concurrent. A
 share one worktree and one git index, and `drush config:export` shells out to git itself —
 so concurrent commits would race on the index.
 
-### 7. `publish`
+### 7. `render merge request`
+
+Fire **`pre-merge-request-create`** (where a security run retitles the request) and
+assemble the description from every addon's template.
+
+This is a phase of its own, ahead of `publish`, so that it happens under `--dry-run` too.
+The description is the run's only human-readable account of itself, and both title and
+description are recorded in the [run report](../reference/run-report.md#merge-request-content)
+whether or not a request is opened — so a dry run can be reviewed, and a broken template
+fails there instead of surfacing on a real run that has already pushed.
+
+### 8. `publish`
 
 **Skipped entirely under `--dry-run`.**
 
-Push the branch, generate the description from every addon's template, fire
-**`pre-merge-request-create`** (where a security run retitles the request), and create it.
+Push the branch and create the request with the title and description rendered in phase 7.
 
 If creating the request fails after the push succeeded, the just-pushed remote branch is
 deleted on a best-effort basis — otherwise a failed run would leave an orphan branch that

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -10,7 +10,7 @@ the behaviour makes sense rather than looking arbitrary.
 
     ---
 
-    The seven phases, what each one produces, and why "nothing to update" is a success
+    The eight phases, what each one produces, and why "nothing to update" is a success
     rather than a failure.
 
 -   **[The addon architecture](addon-architecture.md)**

--- a/docs/how-to/consume-the-run-report.md
+++ b/docs/how-to/consume-the-run-report.md
@@ -38,6 +38,9 @@ jq -r 'select(.status == "failed") | "\(.failed_phase): \(.error)"' report.json
 # Which addons reported anything?
 jq -r '.addons | keys[]' report.json
 
+# What would the merge request say? (works on a --dry-run, which opens none)
+jq -r '.merge_request_description' report.json
+
 # Which security advisories are still open?
 jq -r '.addons.composer_audit.remaining[]? | "\(.cve // .advisoryId) \(.packageName)"' report.json
 
@@ -69,9 +72,14 @@ esac
 ## Assert on a run in CI
 
 Drupdater's own integration tests use a jq script for this, and it is directly reusable.
-It asserts on status, a minimum package count, that named phases are present **and
-succeeded**, that named addons reported something, and that the schema version is the one
-you wrote your consumer against:
+
+It checks two different things. The `$expect` fields are what *your* project expects —
+status, a minimum package count, named phases present **and** succeeded, named addons that
+reported something, packages that had to move, actions that must not appear. Everything
+after them is the report's own internal consistency and is always on: package changes have
+a shape, phases are ordered and unique, a `success` has no failed phase, a `--dry-run` has
+no merge request, an advisory is not both fixed and remaining, and an addon that reported
+data also rendered its section into the description.
 
 ```jq title=".github/assert-report.jq"
 --8<-- ".github/assert-report.jq"
@@ -83,11 +91,22 @@ Use it like this:
 EXPECT='{
   "status": ["success", "no_changes"],
   "phases": ["composer install", "baseline site install", "update shared code"],
-  "addons": ["update_hooks", "code_beautifier"]
+  "addons": ["update_hooks", "code_beautifier"],
+  "packages_match": ["^drupal/core"],
+  "forbid_actions": ["Downgrade"],
+  "audit_fixed_min": 1
 }'
+
+# Optional: assert no credential reached the document
+export DRUPDATER_ASSERT_SECRETS="$DRUPDATER_TOKEN"
 
 jq -e --argjson expect "$EXPECT" -f .github/assert-report.jq report.json
 ```
+
+`packages_match` and `audit_fixed_min` are the two worth adding early. A package count
+alone is satisfied by any unrelated transitive bump, and "`composer_audit` reported
+something" is satisfied by a security run that closed no advisory at all and only listed
+the ones still open.
 
 On failure it prints every problem at once and exits non-zero:
 
@@ -111,6 +130,29 @@ security run produce different sets. Drupdater's own fixtures split them:
 Note that [`composer_diff`](../reference/addons/composer-diff.md) and
 [`composer_normalizer`](../reference/addons/composer-normalizer.md) never appear in the
 report at all — do not assert on them.
+
+### Cross-check the report against `composer.lock`
+
+`packages` is parsed out of composer's console output, not read back from the lock. If you
+want a second opinion that does not share that assumption, diff the lock the run committed
+against the one it started from and compare:
+
+```bash
+git show "origin/main:composer.lock" > /tmp/base-composer.lock
+
+jq -n -e -r \
+  --slurpfile before /tmp/base-composer.lock \
+  --slurpfile after composer.lock \
+  --slurpfile report report.json \
+  -f .github/assert-lock-matches-report.jq
+```
+
+It fails in both directions: a lock change the report does not mention, and a reported
+change the lock does not show — the second being the one a reviewer would act on.
+
+```jq title=".github/assert-lock-matches-report.jq"
+--8<-- ".github/assert-lock-matches-report.jq"
+```
 
 ## Collect the report as a CI artifact
 

--- a/docs/reference/run-report.md
+++ b/docs/reference/run-report.md
@@ -31,6 +31,8 @@ drupdater --dry-run --report ./drupdater-report.json
     "url": "https://github.com/org/site/pull/42",
     "auto_merge": { "enabled": true }
   },
+  "merge_request_title": "July 2026: Drupal Security Updates",
+  "merge_request_description": "This automated merge request by Drupdater …",
   "sites": ["default"],
   "packages": [
     { "action": "Upgrade", "package": "drupal/core", "from": "10.1.8", "to": "10.2.0" }
@@ -64,6 +66,8 @@ drupdater --dry-run --report ./drupdater-report.json
 | `base_branch` | string | The branch the request targets |
 | `update_branch` | string | The branch created, omitted if the run never got that far |
 | `merge_request` | object or `null` | `null` when none was created — a dry run, or a failure |
+| `merge_request_title` | string | The rendered title, present even when no request was opened |
+| `merge_request_description` | string | The rendered description, likewise — see [merge request content](#merge-request-content) |
 | `sites` | list of strings | The configured sites |
 | `packages` | list of objects | Every dependency change |
 | `phases` | list of objects | Every phase with its duration and outcome |
@@ -99,6 +103,21 @@ with an `error` while the run itself still reports `success` — which is exactl
 field exists rather than only a log line. See [Enable
 auto-merge](../how-to/enable-auto-merge.md).
 
+### Merge request content
+
+`merge_request_title` and `merge_request_description` hold the title and body assembled
+from the addons. They are recorded **independently of `merge_request`**: a `--dry-run`
+renders both and opens nothing, so they are the only readable account that run leaves
+behind.
+
+```bash
+# Preview what the merge request would say, without opening one
+drupdater "$TOKEN" --dry-run --report ./report.json
+jq -r '.merge_request_description' ./report.json
+```
+
+Both are absent from a run that failed before the `render merge request` phase.
+
 ### `packages`
 
 ```json
@@ -124,6 +143,7 @@ Adds `error` when `ok` is `false`. The phase names, in order:
 | `baseline site install` | Installing each site at the old code |
 | `update shared code` | `composer update`, addon events, commits, branch creation |
 | `site update` | Update hooks and configuration export per site |
+| `render merge request` | Assembling the title and description from the addons — runs under `--dry-run` too |
 | `publish` | Push and open the request — absent under `--dry-run` |
 
 Recording durations here makes the cost of a run measurable without separate

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -210,7 +210,7 @@
   color: var(--md-accent-fg-color);
 }
 
-/* The seven phases, as a numbered strip. */
+/* The run phases, as a numbered strip. */
 .md-typeset ol.dr-steps {
   display: grid;
   gap: 0.7rem;

--- a/docs/tutorials/first-run.md
+++ b/docs/tutorials/first-run.md
@@ -86,7 +86,7 @@ INFO  exporting configuration {"site": "default"}
 INFO  update finished
 ```
 
-The log does not announce the seven phases — those are recorded in the report, with their
+The log does not announce the eight phases — those are recorded in the report, with their
 durations, which you will read in the next step.
 
 Nothing is pushed and no request is created: that is the `publish` phase, and `--dry-run`
@@ -164,6 +164,13 @@ jq '.addons.update_hooks' drupdater-report.json
 Those are the database update hooks that would run on deploy — exactly the information a
 reviewer needs.
 
+The same report also holds the pull request this run *would* have opened, description and
+all, even though `--dry-run` opened nothing:
+
+```bash
+jq -r '.merge_request_title, .merge_request_description' drupdater-report.json
+```
+
 !!! note "`no_changes` is not a failure"
 
     If `status` is `no_changes`, the run worked and found nothing to update. It exits `0`
@@ -209,7 +216,7 @@ already gone — checkout-mode runs remove them.
 - `drupdater check` validates a project in about a second, and `--full` proves the site
   installs.
 - A checkout-mode `--dry-run` is completely safe and needs no credentials.
-- The run works through seven phases, and the report records each with its duration.
+- The run works through eight phases, and the report records each with its duration.
 - The report distinguishes `success`, `no_changes` and `failed`.
 - Update branches are content-addressed, so identical updates cannot duplicate.
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -78,6 +78,14 @@ type Report struct {
 	// or because it failed before publishing.
 	MergeRequest *MergeRequest `json:"merge_request"`
 
+	// MergeRequestTitle and MergeRequestDescription are the title and body the run assembled
+	// from its addons, recorded whether or not a merge request was opened with them. A
+	// --dry-run has no MergeRequest at all, and these two are then the only account of what the
+	// run would have said about itself -- which is both what a preview is for and the only way
+	// a dry run can tell a broken description template from a working one.
+	MergeRequestTitle       string `json:"merge_request_title,omitempty"`
+	MergeRequestDescription string `json:"merge_request_description,omitempty"`
+
 	Sites []string `json:"sites"`
 
 	// Packages lists every dependency change composer made. Empty for a run that failed before
@@ -245,6 +253,16 @@ func (r *Recorder) SetMergeRequest(url string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.report.MergeRequest = &MergeRequest{URL: SanitizeURL(url)}
+}
+
+// SetMergeRequestContent records the title and description assembled for the merge request. It
+// is deliberately independent of SetMergeRequest: the content exists as soon as it is rendered,
+// which happens before -- and, under --dry-run, without -- a merge request being created.
+func (r *Recorder) SetMergeRequestContent(title, description string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.report.MergeRequestTitle = title
+	r.report.MergeRequestDescription = description
 }
 
 // SetAutoMerge records the outcome of the auto-merge request. err is nil when the platform

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -110,6 +110,34 @@ func TestRecorderMergeRequestIsNilWhenNoneWasCreated(t *testing.T) {
 	assert.Nil(t, rep.MergeRequest)
 }
 
+// The rendered title and description are recorded on their own, without a merge request: a
+// --dry-run renders both and opens nothing, and they are then the run's only readable summary.
+func TestRecorderMergeRequestContentIsIndependentOfTheMergeRequest(t *testing.T) {
+	rec := newTestRecorder()
+	rec.SetMergeRequestContent("July 2026: Drupal Maintenance Updates", "## Dependency updates\n")
+
+	rep := rec.Finish()
+	assert.Equal(t, "July 2026: Drupal Maintenance Updates", rep.MergeRequestTitle)
+	assert.Equal(t, "## Dependency updates\n", rep.MergeRequestDescription)
+	assert.Nil(t, rep.MergeRequest, "content is recorded even though nothing was opened")
+}
+
+// Both keys are omitted when nothing was rendered -- a run that failed before the description
+// was assembled must not claim an empty one.
+func TestMergeRequestContentOmittedFromJSONWhenNotRendered(t *testing.T) {
+	encoded, err := json.Marshal(newTestRecorder().Finish())
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "merge_request_title")
+	assert.NotContains(t, string(encoded), "merge_request_description")
+
+	rec := newTestRecorder()
+	rec.SetMergeRequestContent("a title", "a description")
+	encoded, err = json.Marshal(rec.Finish())
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"merge_request_title":"a title"`)
+	assert.Contains(t, string(encoded), `"merge_request_description":"a description"`)
+}
+
 func TestRecorderAutoMergeOutcome(t *testing.T) {
 	t.Run("absent until requested", func(t *testing.T) {
 		rec := newTestRecorder()

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -245,12 +245,47 @@ func (ws *WorkflowBaseService) runPhases(
 		return err
 	}
 
+	// Assemble the merge request's title and description. This is a phase of its own, ahead of
+	// publish, because it has to happen under --dry-run as well: the description is assembled
+	// from every addon's RenderTemplate and is the run's only human-readable account of itself.
+	// Rendered only when publishing, a broken template would be invisible to every dry run and
+	// would surface in a real run only after the branch had already been pushed.
+	var mrTitle, mrDescription string
+	if err := rec.Run("render merge request", func() error {
+		var renderErr error
+		mrTitle, mrDescription, renderErr = ws.renderMergeRequest(addons)
+		return renderErr
+	}); err != nil {
+		return err
+	}
+	rec.SetMergeRequestContent(mrTitle, mrDescription)
+
 	if !ws.config.DryRun {
 		return rec.Run("publish", func() error {
-			return ws.publishWork(ctx, repository, updateBranchName, addons, rec)
+			return ws.publishWork(ctx, repository, updateBranchName, mrTitle, mrDescription, rec)
 		})
 	}
 	return nil
+}
+
+// renderMergeRequest produces the title and description for the run's merge request.
+//
+// The title starts as the maintenance-update default and is offered to the addons through
+// pre-merge-request-create, which is how a security run gets re-labelled by composer_audit. The
+// event fires here rather than in publishWork so that the title a dry run reports is the one a
+// real run would have used.
+func (ws *WorkflowBaseService) renderMergeRequest(addons []internal.Addon) (string, string, error) {
+	e := NewPreMergeRequestCreateEvent(fmt.Sprintf("%s: Drupal Maintenance Updates", ws.current.Format("January 2006")))
+	if err := ws.dispatcher.FireEvent(e); err != nil {
+		return "", "", fmt.Errorf("failed to fire event: %w", err)
+	}
+
+	description, err := ws.GenerateDescription(TemplateData{Addons: addons}, "dependency_update.go.tmpl")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate description: %w", err)
+	}
+
+	return e.Title, description, nil
 }
 
 // captureOriginalHead returns the checkout's current HEAD in checkout mode, or nil in clone mode
@@ -533,7 +568,7 @@ func toReportPackages(changes []composer.PackageChange) []report.PackageChange {
 	return out
 }
 
-func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRepository, updateBranchName string, addons []internal.Addon, rec *report.Recorder) error {
+func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRepository, updateBranchName, title, description string, rec *report.Recorder) error {
 	err := repository.Push(&git.PushOptions{
 		RemoteName: "origin",
 		RefSpecs: []gitConfig.RefSpec{
@@ -549,25 +584,7 @@ func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRe
 		return fmt.Errorf("failed to push changes: %w", err)
 	}
 
-	title := fmt.Sprintf("%s: Drupal Maintenance Updates", ws.current.Format("January 2006"))
-
-	data := TemplateData{
-		Addons: addons,
-	}
-
-	// Generate description and create MR
-	description, err := ws.GenerateDescription(data, "dependency_update.go.tmpl")
-	if err != nil {
-		return fmt.Errorf("failed to generate description: %w", err)
-	}
-
-	e := NewPreMergeRequestCreateEvent(title)
-	err = ws.dispatcher.FireEvent(e)
-	if err != nil {
-		return fmt.Errorf("failed to fire event: %w", err)
-	}
-
-	mr, err := ws.platform.CreateMergeRequest(ctx, e.Title, description, updateBranchName, ws.config.Branch)
+	mr, err := ws.platform.CreateMergeRequest(ctx, title, description, updateBranchName, ws.config.Branch)
 	if err != nil {
 		if deleteErr := ws.platform.DeleteBranch(ctx, updateBranchName); deleteErr != nil {
 			ws.logger.Warn("failed to delete remote branch after MR creation failure",

--- a/internal/services/workflow_report_test.go
+++ b/internal/services/workflow_report_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/codehosting"
@@ -28,6 +29,10 @@ type reportHarness struct {
 	composer    *MockComposer
 	drush       *MockDrush
 	worktree    *MockWorktree
+
+	// addons are handed to StartUpdate and registered with the run's event manager, the same
+	// way cmd/root.go wires the real ones up. Empty for the runs that do not care.
+	addons []internal.Addon
 
 	got *report.Report
 }
@@ -89,16 +94,27 @@ func (h *reportHarness) expectFullRun(t *testing.T) {
 		Return([]composer.PackageChange{{Action: "Upgrade", Package: "drupal/core", From: "9.0.0", To: "9.1.0"}}, nil).Maybe()
 }
 
+// withAddons registers addons with the run, so a test can stand in for the real ones where the
+// workflow reads back what an addon contributed.
+func (h *reportHarness) withAddons(addons ...internal.Addon) {
+	h.addons = addons
+}
+
 func (h *reportHarness) run(t *testing.T) error {
 	t.Helper()
 
+	dispatcher := event.NewManager("")
+	for _, addon := range h.addons {
+		dispatcher.AddSubscriber(addon)
+	}
+
 	svc := NewWorkflowBaseService(
 		zap.NewNop(), h.config, h.drush, h.vcsProvider, h.repoSvc, h.installer, h.composer,
-		event.NewManager(""),
+		dispatcher,
 		WithReportSink(func(rep report.Report) { h.got = &rep }),
 	)
 
-	return svc.StartUpdate(context.Background(), nil)
+	return svc.StartUpdate(context.Background(), h.addons)
 }
 
 func TestReportWrittenOnSuccessfulRun(t *testing.T) {
@@ -157,6 +173,9 @@ func TestReportWrittenOnDryRun(t *testing.T) {
 	assert.True(t, h.got.DryRun)
 	assert.Nil(t, h.got.MergeRequest)
 	assert.NotContains(t, phaseNames(h.got.Phases), "publish")
+	// With no addon renaming it, the title is the maintenance-update default, dated by month.
+	assert.Contains(t, h.got.MergeRequestTitle, ": Drupal Maintenance Updates")
+	assert.Contains(t, h.got.MergeRequestTitle, time.Now().Format("January 2006"))
 }
 
 // The most valuable case: a run that fails partway leaves a report naming the phase that failed.
@@ -228,6 +247,127 @@ func TestRunWithoutReportSinkIsUnaffected(t *testing.T) {
 
 	require.NoError(t, svc.StartUpdate(context.Background(), nil))
 	assert.Nil(t, h.got)
+}
+
+// mergeRequestAddon stands in for a real addon at the two points the merge request is assembled:
+// it renames the title through pre-merge-request-create, the way composer_audit re-labels a
+// security run, and contributes a section to the description.
+type mergeRequestAddon struct {
+	title   string
+	section string
+	// err makes the pre-merge-request-create handler fail, standing in for an addon that cannot
+	// produce its part of the merge request. renderErr does the same one step later, when the
+	// description template asks the addon for its section.
+	err       error
+	renderErr error
+}
+
+func (a *mergeRequestAddon) SubscribedEvents() map[string]any {
+	return map[string]any{
+		"pre-merge-request-create": event.ListenerItem{
+			Priority: event.Normal,
+			Listener: event.ListenerFunc(func(e event.Event) error {
+				if a.err != nil {
+					return a.err
+				}
+				e.(*PreMergeRequestCreateEvent).Title = a.title
+
+				return nil
+			}),
+		},
+	}
+}
+
+func (a *mergeRequestAddon) RenderTemplate() (string, error) { return a.section, a.renderErr }
+
+var _ internal.Addon = (*mergeRequestAddon)(nil)
+
+// A --dry-run opens no merge request, but it does assemble one. Recording the title and
+// description is what lets a dry run be reviewed at all -- and what makes a broken description
+// template visible before a real run has pushed anything.
+func TestReportRecordsMergeRequestContentOnDryRun(t *testing.T) {
+	h := newReportHarness(t, true)
+	h.expectFullRun(t)
+	h.withAddons(&mergeRequestAddon{
+		title:   "2026-07-25: Drupal Security Updates",
+		section: "## Security Report\n",
+	})
+
+	require.NoError(t, h.run(t))
+
+	require.NotNil(t, h.got)
+	assert.Equal(t, "2026-07-25: Drupal Security Updates", h.got.MergeRequestTitle,
+		"the title an addon set must be the one the dry run reports")
+	assert.Contains(t, h.got.MergeRequestDescription, "## Security Report")
+	assert.Contains(t, phaseNames(h.got.Phases), "render merge request")
+	assert.NotContains(t, phaseNames(h.got.Phases), "publish")
+	assert.Nil(t, h.got.MergeRequest)
+}
+
+// The reported content has to be the published content, not a second rendering of it: a report
+// that showed something other than what the reviewer sees on the merge request would be worse
+// than no report at all.
+func TestReportedMergeRequestContentIsWhatWasPublished(t *testing.T) {
+	h := newReportHarness(t, false)
+	h.expectFullRun(t)
+	h.withAddons(&mergeRequestAddon{title: "custom title", section: "## Section\n"})
+	h.repository.EXPECT().Push(mock.Anything).Return(nil)
+
+	var publishedTitle, publishedDescription string
+	h.vcsProvider.EXPECT().CreateMergeRequest(anyCtx, mock.Anything, mock.Anything, mock.Anything, "main").
+		RunAndReturn(func(_ context.Context, title, description, _, _ string) (codehosting.MergeRequest, error) {
+			publishedTitle, publishedDescription = title, description
+
+			return codehosting.MergeRequest{URL: "https://example.com/mr/1"}, nil
+		})
+
+	require.NoError(t, h.run(t))
+
+	require.NotNil(t, h.got)
+	assert.Equal(t, "custom title", publishedTitle)
+	assert.Contains(t, publishedDescription, "## Section")
+	assert.Equal(t, publishedTitle, h.got.MergeRequestTitle)
+	assert.Equal(t, publishedDescription, h.got.MergeRequestDescription)
+}
+
+// Assembling the merge request is a phase like any other, so a failure there is attributed
+// rather than surfacing as an unexplained error at the end of a run. Both halves can fail: the
+// event that settles the title, and the template that renders the description.
+func TestReportNamesTheRenderPhaseWhenAssemblyFails(t *testing.T) {
+	t.Run("the title event fails", func(t *testing.T) {
+		titleErr := errors.New("addon could not produce a title")
+		h := newReportHarness(t, true)
+		h.expectFullRun(t)
+		h.withAddons(&mergeRequestAddon{err: titleErr})
+
+		err := h.run(t)
+
+		// Wrapped, not replaced: a caller matching on its own sentinel error still can.
+		require.ErrorIs(t, err, titleErr)
+		require.NotNil(t, h.got)
+		assert.Equal(t, report.StatusFailed, h.got.Status)
+		assert.Equal(t, "render merge request", h.got.FailedPhase)
+		assert.Contains(t, h.got.Error, "failed to fire event")
+		assert.Contains(t, h.got.Error, "addon could not produce a title")
+		assert.Empty(t, h.got.MergeRequestTitle)
+		assert.Empty(t, h.got.MergeRequestDescription)
+	})
+
+	t.Run("an addon cannot render its section", func(t *testing.T) {
+		renderErr := errors.New("template exploded")
+		h := newReportHarness(t, true)
+		h.expectFullRun(t)
+		h.withAddons(&mergeRequestAddon{title: "a title", renderErr: renderErr})
+
+		err := h.run(t)
+
+		require.ErrorIs(t, err, renderErr)
+		require.NotNil(t, h.got)
+		assert.Equal(t, report.StatusFailed, h.got.Status)
+		assert.Equal(t, "render merge request", h.got.FailedPhase)
+		assert.Contains(t, h.got.Error, "failed to generate description")
+		assert.Empty(t, h.got.MergeRequestDescription)
+	})
 }
 
 func phaseNames(phases []report.Phase) []string {


### PR DESCRIPTION
The integration test's only verdict on a run was its report: status, a
package count, which phases ran, which addons said anything. That checks
drupdater's account of itself and nothing else -- the repository it left
behind was never looked at, and the report's own internal consistency was
taken on trust.

Two directions, both on the existing job.

Deeper assertions on the report. assert-report.jq gains fixture-level
expectations (packages_match, forbid_actions, audit_fixed_min -- a
package count is satisfied by any transitive bump, and "composer_audit
reported something" by a security run that closed nothing) and, more
importantly, invariants that hold for any report and are therefore always
on: package changes have a shape, phases are ordered and unique, a
success has no failed phase, a dry run has no merge request, an advisory
is not both fixed and remaining, site-keyed addon sections only mention
configured sites, and no credential appears anywhere in the document.

Assertions on the working copy. The job now checks the checkout is on the
branch the report names, that it descends from the base branch, that the
base branch did not move, and that nothing was left uncommitted; diffs
the committed composer.lock against the base one and compares it to the
report's package list (which is parsed out of composer's console output,
so nothing else verifies that parsing); runs composer validate and a
dry-run install against the result; and re-runs drupdater on the merged
outcome to prove a second run finds nothing to do.

Making the merge request description verifiable needed one behaviour
change: rendering it is now a phase of its own, ahead of publish, so a
--dry-run assembles it too, and the title and description are recorded in
the report whether or not a request is opened. A broken description
template was previously invisible until a real run had already pushed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ChnvejMy8vsCJhngy3D361