### PR TITLE
fix(composer): force the Composer settings drupdater depends on

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -70,8 +70,9 @@ go run . --working-dir /path/to/a/drupal/checkout --dry-run --verbose
 `make build`, `go run`, and a binary a CI job downloaded all invoke whatever `composer`,
 `php` and `git` are on `PATH`, against whatever Composer configuration your environment
 provides. That is supported: the two Composer settings the tool's own correctness depends
-on (`COMPOSER_PROCESS_TIMEOUT`, `COMPOSER_NO_AUDIT`) are forced in `pkg/composer` on every
-invocation rather than inherited from the image. The image's remaining Composer variables
+on (`COMPOSER_PROCESS_TIMEOUT`, `COMPOSER_NO_AUDIT`) are forced by `composer.Env` on every
+invocation rather than inherited from the image — including the `composer exec` calls that
+`pkg/drush`, `pkg/phpcs` and `pkg/rector` make. The image's remaining Composer variables
 are deployment policy and need no local equivalent — see [environment
 variables](../reference/environment-variables.md#set-by-drupdater).
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -65,6 +65,20 @@ no token needed:
 go run . --working-dir /path/to/a/drupal/checkout --dry-run --verbose
 ```
 
+### Running outside the image
+
+`make build`, `go run`, and a binary a CI job downloaded all invoke whatever `composer`,
+`php` and `git` are on `PATH`, against whatever Composer configuration your environment
+provides. That is supported: the two Composer settings the tool's own correctness depends
+on (`COMPOSER_PROCESS_TIMEOUT`, `COMPOSER_NO_AUDIT`) are forced in `pkg/composer` on every
+invocation rather than inherited from the image. The image's remaining Composer variables
+are deployment policy and need no local equivalent — see [environment
+variables](../reference/environment-variables.md#set-by-drupdater).
+
+What the image does give you is a known-good PHP with the required extensions and the
+helper plugins installed globally. If a run fails locally in a way it does not in CI,
+check that first.
+
 ## Enforced on commit
 
 A pre-commit hook runs two gates. Read its output rather than assuming it passed.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment variables
 
-Drupdater reads seven environment variables and sets one for its subprocesses. None of
+Drupdater reads seven environment variables and sets three for its subprocesses. None of
 them are bound to CLI flags — each is read directly where it is used.
 
 ## Read by Drupdater
@@ -88,18 +88,42 @@ This is the hook a multi-site project uses to resolve which site Drush is operat
 Your `web/sites/sites.php` reads it to map the current request onto a site directory. See
 [Update multiple sites](../how-to/update-multiple-sites.md) for the snippet.
 
+### `COMPOSER_PROCESS_TIMEOUT` and `COMPOSER_NO_AUDIT`
+
+Set on **every** Composer invocation, to `0` and `1` respectively. A value inherited from
+the surrounding environment is replaced; everything else in the environment — including
+`COMPOSER_AUTH` — is passed through untouched.
+
+| Variable | Forced value | Why Drupdater requires it |
+|---|---|---|
+| `COMPOSER_PROCESS_TIMEOUT` | `0` | Composer's default caps every process it spawns at 300s. A `drupal/core` clone or a large `composer install` on a slow network exceeds that, and the run dies mid-phase with a message about a killed subprocess and no visible connection to a timeout nobody configured. |
+| `COMPOSER_NO_AUDIT` | `1` | Suppresses the implicit audit Composer runs after `update`, whose extra output the update parsing is not written against. Auditing is the [`composer_audit`](addons/composer-audit.md) addon's job, on its own schedule; the explicit `composer audit` that addon runs is unaffected. |
+
+These are forced in code rather than left to the image, so they hold however Drupdater was
+installed — the published image, `make build`, or a binary a CI job downloaded. The
+Dockerfile still sets both, and the values agree.
+
+**Setting either of these yourself has no effect on a Drupdater run.** Drupdater's
+correctness depends on them, so no configuration overrides them.
+
 ## Set inside the Docker image
 
 The published images bake in a Composer environment tuned for unattended runs. These are
-image defaults, not something Drupdater reads:
+image defaults, not something Drupdater reads or requires:
 
 | Variable | Value | Why |
 |---|---|---|
 | `COMPOSER_HOME` | `/usr/local/composer` | Shared global install of the helper plugins |
 | `COMPOSER_CACHE_DIR` | `/tmp/composer/cache` | Writable regardless of the user the container runs as |
 | `COMPOSER_ALLOW_SUPERUSER` | `1` | Containers commonly run as root |
-| `COMPOSER_NO_AUDIT` | `1` | Auditing is the [`composer_audit`](addons/composer-audit.md) addon's job, on its own schedule |
 | `COMPOSER_FUND` | `0` | Suppresses funding notices in log output |
-| `COMPOSER_PROCESS_TIMEOUT` | `0` | A large `composer update` can legitimately exceed the default 300s |
+
+Unlike the two variables above, these are deployment policy: they are right for a
+container and wrong to impose on a developer machine, and Drupdater behaves correctly
+whatever they are set to. Running the binary outside the image leaves them to Composer's
+own defaults, which is fine.
+
+The image also sets `COMPOSER_NO_AUDIT=1` and `COMPOSER_PROCESS_TIMEOUT=0`. Those two are
+now belt-and-braces — Drupdater sets them itself on every invocation.
 
 See [Docker images](docker-images.md).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -94,9 +94,14 @@ Set on **every** Composer invocation, to `0` and `1` respectively. A value inher
 the surrounding environment is replaced; everything else in the environment — including
 `COMPOSER_AUTH` — is passed through untouched.
 
+That covers the tools Drupdater runs *through* Composer as well: Drush, PHPCS/PHPCBF and
+Rector are all invoked as `composer exec -- <tool>`, which makes them subprocesses of
+Composer and so subject to the same process timeout. A `drush updatedb` on a large site
+is exactly the kind of call that outlasts the default.
+
 | Variable | Forced value | Why Drupdater requires it |
 |---|---|---|
-| `COMPOSER_PROCESS_TIMEOUT` | `0` | Composer's default caps every process it spawns at 300s. A `drupal/core` clone or a large `composer install` on a slow network exceeds that, and the run dies mid-phase with a message about a killed subprocess and no visible connection to a timeout nobody configured. |
+| `COMPOSER_PROCESS_TIMEOUT` | `0` | Composer's default caps every process it spawns at 300s. A `drupal/core` clone, a large `composer install` on a slow network, or a `drush site:install` exceeds that, and the run dies mid-phase with a message about a killed subprocess and no visible connection to a timeout nobody configured. |
 | `COMPOSER_NO_AUDIT` | `1` | Suppresses the implicit audit Composer runs after `update`, whose extra output the update parsing is not written against. Auditing is the [`composer_audit`](addons/composer-audit.md) addon's job, on its own schedule; the explicit `composer audit` that addon runs is unaffected. |
 
 These are forced in code rather than left to the image, so they hold however Drupdater was

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -35,9 +35,61 @@ func NewCLI(logger *zap.Logger) *CLI {
 	}
 }
 
+// requiredComposerEnv is the Composer configuration drupdater's own correctness depends on, as
+// KEY=VALUE entries. It is forced on every Composer invocation (see composerEnv) rather than
+// left to the Dockerfile, which sets the same values but only for runs that happen to use the
+// published image — `make build` and an installed binary get neither.
+//
+//   - COMPOSER_PROCESS_TIMEOUT: Composer's documented default of 300s applies to the processes
+//     it spawns, and a drupal/core clone or a large install on a slow network exceeds it. The
+//     run then dies mid-phase with a message about a killed subprocess and no connection to a
+//     timeout nobody configured. No plausible user intent is served by a five-minute cap on a
+//     dependency update, which is why this is forced rather than merely defaulted.
+//   - COMPOSER_NO_AUDIT: suppresses the implicit audit Composer runs after update/require, whose
+//     output Update()'s parsing was not written against. Auditing is the composer_audit addon's
+//     job, on its own schedule; this does not affect the explicit `composer audit` it runs.
+//
+// The image's other Composer variables (COMPOSER_HOME, COMPOSER_CACHE_DIR,
+// COMPOSER_ALLOW_SUPERUSER, COMPOSER_FUND) are deliberately absent: those are deployment policy
+// — right for a container, wrong to impose on a developer running the binary directly — and
+// drupdater behaves correctly whatever they are set to.
+var requiredComposerEnv = []string{
+	"COMPOSER_PROCESS_TIMEOUT=0",
+	"COMPOSER_NO_AUDIT=1",
+}
+
+// composerEnv returns env with requiredComposerEnv applied: every other entry is passed through
+// unchanged and in order — notably COMPOSER_AUTH, which carries private registry credentials —
+// and any inherited assignment to a required variable is dropped in favour of the value
+// drupdater needs.
+//
+// Dropping rather than appending matters: os/exec resolves duplicate keys itself, so leaving the
+// inherited entry in place would make the outcome depend on that behaviour instead of on this
+// function, and would leave the losing value visible in the command's Env.
+func composerEnv(env []string) []string {
+	result := make([]string, 0, len(env)+len(requiredComposerEnv))
+	for _, entry := range env {
+		key, _, isAssignment := strings.Cut(entry, "=")
+		// An entry that is not an assignment cannot be overriding anything, so it is carried
+		// over rather than dropped.
+		if isAssignment && slices.ContainsFunc(requiredComposerEnv, func(required string) bool {
+			requiredKey, _, _ := strings.Cut(required, "=")
+			return requiredKey == key
+		}) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, requiredComposerEnv...)
+}
+
 func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (string, error) {
 	command := execCommand(ctx, "composer", args...)
 	command.Dir = dir
+	// Environ() resolves to os.Environ() when the caller set no explicit environment, so this
+	// forces drupdater's requirements on top of whatever the deployment provides instead of
+	// replacing it.
+	command.Env = composerEnv(command.Environ())
 
 	out, err := command.CombinedOutput()
 	output := strings.TrimSuffix(string(out), "\n")
@@ -53,6 +105,7 @@ func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (str
 func (s *CLI) execComposerJSON(ctx context.Context, dir string, args ...string) (string, error) {
 	command := execCommand(ctx, "composer", args...)
 	command.Dir = dir
+	command.Env = composerEnv(command.Environ())
 
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -36,9 +36,9 @@ func NewCLI(logger *zap.Logger) *CLI {
 }
 
 // requiredComposerEnv is the Composer configuration drupdater's own correctness depends on, as
-// KEY=VALUE entries. It is forced on every Composer invocation (see composerEnv) rather than
-// left to the Dockerfile, which sets the same values but only for runs that happen to use the
-// published image — `make build` and an installed binary get neither.
+// KEY=VALUE entries. It is forced on every Composer invocation (see Env) rather than left to
+// the Dockerfile, which sets the same values but only for runs that happen to use the published
+// image — `make build` and an installed binary get neither.
 //
 //   - COMPOSER_PROCESS_TIMEOUT: Composer's documented default of 300s applies to the processes
 //     it spawns, and a drupal/core clone or a large install on a slow network exceeds it. The
@@ -58,7 +58,7 @@ var requiredComposerEnv = []string{
 	"COMPOSER_NO_AUDIT=1",
 }
 
-// composerEnv returns env with requiredComposerEnv applied: every other entry is passed through
+// Env returns env with requiredComposerEnv applied: every other entry is passed through
 // unchanged and in order — notably COMPOSER_AUTH, which carries private registry credentials —
 // and any inherited assignment to a required variable is dropped in favour of the value
 // drupdater needs.
@@ -66,7 +66,14 @@ var requiredComposerEnv = []string{
 // Dropping rather than appending matters: os/exec resolves duplicate keys itself, so leaving the
 // inherited entry in place would make the outcome depend on that behaviour instead of on this
 // function, and would leave the losing value visible in the command's Env.
-func composerEnv(env []string) []string {
+//
+// It is exported because this package is not the only one that runs composer: drush, phpcs and
+// rector are all invoked through `composer exec`, which makes them subprocesses of composer and
+// so subject to the same process timeout. Every package that builds a composer *exec.Cmd should
+// set its Env from this:
+//
+//	command.Env = composer.Env(command.Environ())
+func Env(env []string) []string {
 	result := make([]string, 0, len(env)+len(requiredComposerEnv))
 	for _, entry := range env {
 		key, _, isAssignment := strings.Cut(entry, "=")
@@ -89,7 +96,7 @@ func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (str
 	// Environ() resolves to os.Environ() when the caller set no explicit environment, so this
 	// forces drupdater's requirements on top of whatever the deployment provides instead of
 	// replacing it.
-	command.Env = composerEnv(command.Environ())
+	command.Env = Env(command.Environ())
 
 	out, err := command.CombinedOutput()
 	output := strings.TrimSuffix(string(out), "\n")
@@ -105,7 +112,7 @@ func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (str
 func (s *CLI) execComposerJSON(ctx context.Context, dir string, args ...string) (string, error) {
 	command := execCommand(ctx, "composer", args...)
 	command.Dir = dir
-	command.Env = composerEnv(command.Environ())
+	command.Env = Env(command.Environ())
 
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout

--- a/pkg/composer/composer_env_test.go
+++ b/pkg/composer/composer_env_test.go
@@ -1,0 +1,194 @@
+package composer
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// helperEnv builds the environment of the fake composer subprocess. Anything passed in is seen
+// by the helper process on top of the control variables it needs to run at all.
+func helperEnv(extra ...string) []string {
+	return append([]string{"GO_WANT_HELPER_PROCESS=1", "GOCOVERDIR=/tmp"}, extra...)
+}
+
+// fakeComposer replaces execCommand with the helper process for the duration of the test and
+// gives it the supplied environment.
+func fakeComposer(t *testing.T, env []string) {
+	t.Helper()
+	execCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+		cs := append([]string{"-test.run=TestHelperProcess", "--", name}, arg...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...) //nolint:gosec // test helper process
+		cmd.Env = env
+		return cmd
+	}
+	t.Cleanup(func() { execCommand = exec.CommandContext })
+}
+
+func TestComposerEnv(t *testing.T) {
+	t.Run("forces the settings drupdater depends on when they are absent", func(t *testing.T) {
+		got := composerEnv([]string{"PATH=/usr/bin"})
+
+		assert.Contains(t, got, "PATH=/usr/bin", "unrelated entries must survive")
+		assert.Contains(t, got, "COMPOSER_PROCESS_TIMEOUT=0")
+		assert.Contains(t, got, "COMPOSER_NO_AUDIT=1")
+	})
+
+	t.Run("overrides an inherited value, leaving exactly one entry per variable", func(t *testing.T) {
+		got := composerEnv([]string{
+			"COMPOSER_PROCESS_TIMEOUT=300",
+			"COMPOSER_NO_AUDIT=0",
+			"COMPOSER_AUTH={}",
+		})
+
+		// Not merely "the forced value is present": an inherited entry left in place would make
+		// the result depend on os/exec's de-duplication order rather than on this function.
+		assert.Equal(t, 1, countKey(got, "COMPOSER_PROCESS_TIMEOUT"))
+		assert.Equal(t, 1, countKey(got, "COMPOSER_NO_AUDIT"))
+		assert.Contains(t, got, "COMPOSER_PROCESS_TIMEOUT=0")
+		assert.Contains(t, got, "COMPOSER_NO_AUDIT=1")
+		assert.NotContains(t, got, "COMPOSER_PROCESS_TIMEOUT=300")
+		assert.NotContains(t, got, "COMPOSER_NO_AUDIT=0")
+		assert.Contains(t, got, "COMPOSER_AUTH={}", "COMPOSER_AUTH must be passed through untouched")
+	})
+
+	t.Run("leaves the image's policy variables to the environment", func(t *testing.T) {
+		// These are deployment policy, not correctness: forcing them would override a developer
+		// running the binary outside the image with a composer home of their own choosing.
+		got := composerEnv([]string{
+			"COMPOSER_HOME=/home/dev/.composer",
+			"COMPOSER_CACHE_DIR=/home/dev/.cache/composer",
+			"COMPOSER_ALLOW_SUPERUSER=0",
+			"COMPOSER_FUND=1",
+		})
+
+		assert.Contains(t, got, "COMPOSER_HOME=/home/dev/.composer")
+		assert.Contains(t, got, "COMPOSER_CACHE_DIR=/home/dev/.cache/composer")
+		assert.Contains(t, got, "COMPOSER_ALLOW_SUPERUSER=0")
+		assert.Contains(t, got, "COMPOSER_FUND=1")
+	})
+
+	t.Run("keeps entries that are not KEY=VALUE", func(t *testing.T) {
+		// Including one that is a bare forced variable name: os.Environ() promises nothing about
+		// its entries containing "=", and a name on its own assigns nothing and so overrides
+		// nothing.
+		got := composerEnv([]string{"NOT_AN_ASSIGNMENT", "COMPOSER_PROCESS_TIMEOUT"})
+
+		assert.Contains(t, got, "NOT_AN_ASSIGNMENT")
+		assert.Contains(t, got, "COMPOSER_PROCESS_TIMEOUT")
+	})
+
+	t.Run("preserves the order of the entries it keeps", func(t *testing.T) {
+		got := composerEnv([]string{"A=1", "COMPOSER_NO_AUDIT=0", "B=2", "C=3"})
+
+		assert.Equal(t, []string{"A=1", "B=2", "C=3"}, kept(got),
+			"removing a forced entry must not reorder the rest")
+	})
+}
+
+// countKey returns how many entries of env assign key.
+func countKey(env []string, key string) int {
+	count := 0
+	for _, entry := range env {
+		if len(entry) > len(key) && entry[:len(key)+1] == key+"=" {
+			count++
+		}
+	}
+	return count
+}
+
+// kept returns the entries of env that composerEnv did not append itself.
+func kept(env []string) []string {
+	var result []string
+	for _, entry := range env {
+		if !slices.Contains(requiredComposerEnv, entry) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+func TestExecComposerEnvironmentReachesTheSubprocess(t *testing.T) {
+	service := &CLI{logger: zap.NewNop()}
+
+	t.Run("execComposer forces the process timeout over an inherited one", func(t *testing.T) {
+		// The whole point of the issue: a 300s cap that nobody configured kills a long
+		// `composer update` mid-phase. Assert on what the subprocess actually sees, not on the
+		// slice drupdater built, so a value that never survives into the child is caught.
+		fakeComposer(t, helperEnv(
+			"GO_HELPER_PROCESS_PRINT_ENV=COMPOSER_PROCESS_TIMEOUT",
+			"COMPOSER_PROCESS_TIMEOUT=300",
+		))
+
+		out, err := service.execComposer(t.Context(), "/tmp", "update")
+		require.NoError(t, err)
+		assert.Equal(t, "0", out)
+	})
+
+	t.Run("execComposer disables the implicit audit", func(t *testing.T) {
+		fakeComposer(t, helperEnv("GO_HELPER_PROCESS_PRINT_ENV=COMPOSER_NO_AUDIT"))
+
+		out, err := service.execComposer(t.Context(), "/tmp", "update")
+		require.NoError(t, err)
+		assert.Equal(t, "1", out)
+	})
+
+	t.Run("execComposer passes the rest of the environment through", func(t *testing.T) {
+		fakeComposer(t, helperEnv(
+			"GO_HELPER_PROCESS_PRINT_ENV=COMPOSER_AUTH",
+			`COMPOSER_AUTH={"http-basic":{}}`,
+		))
+
+		out, err := service.execComposer(t.Context(), "/tmp", "update")
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"http-basic":{}}`, out, "private registry credentials must still reach composer")
+	})
+
+	t.Run("execComposerJSON forces the same settings", func(t *testing.T) {
+		fakeComposer(t, helperEnv(
+			"GO_HELPER_PROCESS_PRINT_ENV=COMPOSER_PROCESS_TIMEOUT",
+			"COMPOSER_PROCESS_TIMEOUT=300",
+		))
+
+		out, err := service.execComposerJSON(t.Context(), "/tmp", "audit", "--format=json")
+		require.NoError(t, err)
+		assert.Equal(t, "0", out)
+	})
+
+	t.Run("execComposerJSON passes the rest of the environment through", func(t *testing.T) {
+		fakeComposer(t, helperEnv(
+			"GO_HELPER_PROCESS_PRINT_ENV=COMPOSER_AUTH",
+			`COMPOSER_AUTH={"http-basic":{}}`,
+		))
+
+		out, err := service.execComposerJSON(t.Context(), "/tmp", "audit", "--format=json")
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"http-basic":{}}`, out)
+	})
+
+	t.Run("inherits the process environment when the caller set none", func(t *testing.T) {
+		// exec.Cmd with a nil Env inherits os.Environ(); building the forced values on top of it
+		// must not drop that inheritance, or composer loses PATH and every other variable it
+		// needs.
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		t.Setenv("GOCOVERDIR", "/tmp")
+		t.Setenv("GO_HELPER_PROCESS_PRINT_ENV", "COMPOSER_AUTH")
+		t.Setenv("COMPOSER_AUTH", "inherited")
+
+		execCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+			cs := append([]string{"-test.run=TestHelperProcess", "--", name}, arg...)
+			return exec.CommandContext(ctx, os.Args[0], cs...) //nolint:gosec // test helper process
+		}
+		t.Cleanup(func() { execCommand = exec.CommandContext })
+
+		out, err := service.execComposer(t.Context(), "/tmp", "update")
+		require.NoError(t, err)
+		assert.Equal(t, "inherited", out)
+	})
+}

--- a/pkg/composer/composer_env_test.go
+++ b/pkg/composer/composer_env_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +32,7 @@ func fakeComposer(t *testing.T, env []string) {
 
 func TestComposerEnv(t *testing.T) {
 	t.Run("forces the settings drupdater depends on when they are absent", func(t *testing.T) {
-		got := composerEnv([]string{"PATH=/usr/bin"})
+		got := Env([]string{"PATH=/usr/bin"})
 
 		assert.Contains(t, got, "PATH=/usr/bin", "unrelated entries must survive")
 		assert.Contains(t, got, "COMPOSER_PROCESS_TIMEOUT=0")
@@ -41,7 +40,7 @@ func TestComposerEnv(t *testing.T) {
 	})
 
 	t.Run("overrides an inherited value, leaving exactly one entry per variable", func(t *testing.T) {
-		got := composerEnv([]string{
+		got := Env([]string{
 			"COMPOSER_PROCESS_TIMEOUT=300",
 			"COMPOSER_NO_AUDIT=0",
 			"COMPOSER_AUTH={}",
@@ -61,7 +60,7 @@ func TestComposerEnv(t *testing.T) {
 	t.Run("leaves the image's policy variables to the environment", func(t *testing.T) {
 		// These are deployment policy, not correctness: forcing them would override a developer
 		// running the binary outside the image with a composer home of their own choosing.
-		got := composerEnv([]string{
+		got := Env([]string{
 			"COMPOSER_HOME=/home/dev/.composer",
 			"COMPOSER_CACHE_DIR=/home/dev/.cache/composer",
 			"COMPOSER_ALLOW_SUPERUSER=0",
@@ -78,16 +77,16 @@ func TestComposerEnv(t *testing.T) {
 		// Including one that is a bare forced variable name: os.Environ() promises nothing about
 		// its entries containing "=", and a name on its own assigns nothing and so overrides
 		// nothing.
-		got := composerEnv([]string{"NOT_AN_ASSIGNMENT", "COMPOSER_PROCESS_TIMEOUT"})
+		got := Env([]string{"NOT_AN_ASSIGNMENT", "COMPOSER_PROCESS_TIMEOUT"})
 
 		assert.Contains(t, got, "NOT_AN_ASSIGNMENT")
 		assert.Contains(t, got, "COMPOSER_PROCESS_TIMEOUT")
 	})
 
 	t.Run("preserves the order of the entries it keeps", func(t *testing.T) {
-		got := composerEnv([]string{"A=1", "COMPOSER_NO_AUDIT=0", "B=2", "C=3"})
+		got := Env([]string{"A=1", "COMPOSER_NO_AUDIT=0", "B=2", "C=3"})
 
-		assert.Equal(t, []string{"A=1", "B=2", "C=3"}, kept(got),
+		assert.Equal(t, []string{"A=1", "B=2", "C=3"}, withoutRequired(got),
 			"removing a forced entry must not reorder the rest")
 	})
 }
@@ -101,17 +100,6 @@ func countKey(env []string, key string) int {
 		}
 	}
 	return count
-}
-
-// kept returns the entries of env that composerEnv did not append itself.
-func kept(env []string) []string {
-	var result []string
-	for _, entry := range env {
-		if !slices.Contains(requiredComposerEnv, entry) {
-			result = append(result, entry)
-		}
-	}
-	return result
 }
 
 func TestExecComposerEnvironmentReachesTheSubprocess(t *testing.T) {

--- a/pkg/composer/composer_property_test.go
+++ b/pkg/composer/composer_property_test.go
@@ -292,3 +292,83 @@ func TestPropertyAuditUnmarshalOrdersAbandonedByName(t *testing.T) {
 		assert.Equal(t, want, audit.Abandoned)
 	})
 }
+
+// TestPropertyComposerEnvLeavesEverythingElseAlone states the law composerEnv has to obey for
+// the Dockerfile's other variables, COMPOSER_AUTH, PATH and anything else a deployment sets: it
+// forces the entries drupdater's correctness depends on and passes every other entry through
+// unchanged and in order. Forcing an environment by rebuilding it is the kind of change that
+// silently drops a variable nobody thought to write a test for.
+func TestPropertyComposerEnvLeavesEverythingElseAlone(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		env := rapid.SliceOfN(envEntryGen(), 0, 8).Draw(t, "env")
+
+		got := composerEnv(env)
+
+		// Every entry that does not assign a forced variable survives, in its original order.
+		var want []string
+		for _, entry := range env {
+			if !assignsRequiredKey(entry) {
+				want = append(want, entry)
+			}
+		}
+		assert.Equal(t, want, withoutRequired(got))
+
+		// And each forced variable is assigned exactly once, to the value drupdater needs.
+		for _, required := range requiredComposerEnv {
+			key, value, _ := strings.Cut(required, "=")
+			assert.Equal(t, []string{value}, valuesOf(got, key))
+		}
+
+		// Applying it again changes nothing: the result is already a valid composer environment.
+		assert.Equal(t, got, composerEnv(got))
+	})
+}
+
+// envEntryGen generates an environment entry, drawing the key from the forced variables often
+// enough that the override path is exercised, and occasionally emitting an entry that is not an
+// assignment at all — os.Environ() makes no promise that every entry contains "=".
+func envEntryGen() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		key := rapid.SampledFrom([]string{
+			"COMPOSER_PROCESS_TIMEOUT", "COMPOSER_NO_AUDIT", "COMPOSER_AUTH",
+			"COMPOSER_HOME", "COMPOSER_CACHE_DIR", "PATH", "",
+		}).Draw(t, "key")
+		if key == "" {
+			return rapid.StringMatching(`[A-Z_]{1,8}`).Draw(t, "bare")
+		}
+		return key + "=" + rapid.StringMatching(`[a-z0-9/{}:_-]{0,10}`).Draw(t, "value")
+	})
+}
+
+func assignsRequiredKey(entry string) bool {
+	key, _, ok := strings.Cut(entry, "=")
+	if !ok {
+		return false
+	}
+	return slices.ContainsFunc(requiredComposerEnv, func(required string) bool {
+		requiredKey, _, _ := strings.Cut(required, "=")
+		return requiredKey == key
+	})
+}
+
+// withoutRequired drops the entries composerEnv appends, leaving what it carried over.
+func withoutRequired(env []string) []string {
+	var result []string
+	for _, entry := range env {
+		if !slices.Contains(requiredComposerEnv, entry) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+// valuesOf returns the values every entry of env assigns to key, in order.
+func valuesOf(env []string, key string) []string {
+	var values []string
+	for _, entry := range env {
+		if entryKey, value, ok := strings.Cut(entry, "="); ok && entryKey == key {
+			values = append(values, value)
+		}
+	}
+	return values
+}

--- a/pkg/composer/composer_property_test.go
+++ b/pkg/composer/composer_property_test.go
@@ -293,7 +293,7 @@ func TestPropertyAuditUnmarshalOrdersAbandonedByName(t *testing.T) {
 	})
 }
 
-// TestPropertyComposerEnvLeavesEverythingElseAlone states the law composerEnv has to obey for
+// TestPropertyComposerEnvLeavesEverythingElseAlone states the law Env has to obey for
 // the Dockerfile's other variables, COMPOSER_AUTH, PATH and anything else a deployment sets: it
 // forces the entries drupdater's correctness depends on and passes every other entry through
 // unchanged and in order. Forcing an environment by rebuilding it is the kind of change that
@@ -302,7 +302,7 @@ func TestPropertyComposerEnvLeavesEverythingElseAlone(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		env := rapid.SliceOfN(envEntryGen(), 0, 8).Draw(t, "env")
 
-		got := composerEnv(env)
+		got := Env(env)
 
 		// Every entry that does not assign a forced variable survives, in its original order.
 		var want []string
@@ -320,7 +320,7 @@ func TestPropertyComposerEnvLeavesEverythingElseAlone(t *testing.T) {
 		}
 
 		// Applying it again changes nothing: the result is already a valid composer environment.
-		assert.Equal(t, got, composerEnv(got))
+		assert.Equal(t, got, Env(got))
 	})
 }
 
@@ -351,7 +351,8 @@ func assignsRequiredKey(entry string) bool {
 	})
 }
 
-// withoutRequired drops the entries composerEnv appends, leaving what it carried over.
+// withoutRequired drops the entries Env appends, leaving what it carried over. Shared with the
+// example-based tests in composer_env_test.go.
 func withoutRequired(env []string) []string {
 	var result []string
 	for _, entry := range env {

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -972,6 +972,13 @@ func TestHelperProcess(*testing.T) {
 		os.Exit(1)
 	}
 
+	// Lets a test assert on what the subprocess actually received, rather than on the Env slice
+	// the caller assembled for it.
+	if name := os.Getenv("GO_HELPER_PROCESS_PRINT_ENV"); name != "" {
+		fmt.Fprintln(os.Stdout, os.Getenv(name))
+		os.Exit(0)
+	}
+
 	fmt.Fprintf(os.Stdout, "%v\n", os.Args[3])
 	os.Exit(0)
 }

--- a/pkg/drush/drush.go
+++ b/pkg/drush/drush.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/maypok86/otter"
 	"go.uber.org/zap"
+
+	"github.com/drupdater/drupdater/pkg/composer"
 )
 
 var execCommand = exec.CommandContext
@@ -31,9 +32,11 @@ func NewCLI(logger *zap.Logger, cache otter.Cache[string, string]) *CLI {
 func (e *CLI) execDrush(ctx context.Context, dir string, site string, args ...string) (string, error) {
 	command := execCommand(ctx, "composer", append([]string{"exec", "--", "drush"}, args...)...)
 	command.Dir = dir
-	// System env first, then our override so SITE_NAME always wins even if
-	// the parent process has SITE_NAME set in its environment.
-	command.Env = append(os.Environ(), "SITE_NAME="+site)
+	// The composer environment first — drush runs through `composer exec`, which makes it a
+	// subprocess of composer and so subject to composer's process timeout, and `site:install`
+	// and `updatedb` both outlast its 300s default — then our override so SITE_NAME always wins
+	// even if the parent process has SITE_NAME set in its environment.
+	command.Env = append(composer.Env(command.Environ()), "SITE_NAME="+site)
 
 	out, err := command.CombinedOutput()
 	output := strings.TrimSuffix(string(out), "\n")
@@ -49,7 +52,7 @@ func (e *CLI) execDrush(ctx context.Context, dir string, site string, args ...st
 func (e *CLI) execDrushStreams(ctx context.Context, dir string, site string, args ...string) (stdout string, stderr string, err error) {
 	command := execCommand(ctx, "composer", append([]string{"exec", "--", "drush"}, args...)...)
 	command.Dir = dir
-	command.Env = append(os.Environ(), "SITE_NAME="+site)
+	command.Env = append(composer.Env(command.Environ()), "SITE_NAME="+site)
 
 	var so, se bytes.Buffer
 	command.Stdout = &so

--- a/pkg/drush/drush_env_test.go
+++ b/pkg/drush/drush_env_test.go
@@ -1,0 +1,67 @@
+package drush
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/maypok86/otter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestComposerEnvironment covers what drush shares with every other package that shells out to
+// composer: `composer exec -- drush` runs drush as a subprocess of composer, so composer's
+// default 300s process timeout applies to it. `site:install` and `updatedb` on a real site
+// exceed that comfortably, and the run then dies with a killed subprocess rather than an
+// updated site — a failure that has nothing to do with the project being updated.
+func TestComposerEnvironment(t *testing.T) {
+	cache, _ := otter.MustBuilder[string, string](100).Build()
+	executor := NewCLI(zap.NewNop(), cache)
+
+	// captureCmd runs the helper process and hands back the command that actually ran, so the
+	// assertions are about the environment the subprocess was given rather than about the
+	// helper that builds it.
+	captureCmd := func(t *testing.T) **exec.Cmd {
+		t.Helper()
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		t.Setenv("GOCOVERDIR", "/tmp")
+
+		cmd := new(*exec.Cmd)
+		execCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+			cs := append([]string{"-test.run=TestHelperProcess", "--", name}, arg...)
+			c := exec.CommandContext(ctx, os.Args[0], cs...) //nolint:gosec // test helper process
+			*cmd = c
+			return c
+		}
+		t.Cleanup(func() { execCommand = exec.CommandContext })
+		return cmd
+	}
+
+	assertComposerEnvironment := func(t *testing.T, env []string) {
+		t.Helper()
+		assert.Contains(t, env, "COMPOSER_PROCESS_TIMEOUT=0", "composer must not cap the drush process it spawns")
+		assert.Contains(t, env, "COMPOSER_NO_AUDIT=1")
+		assert.Contains(t, env, "SITE_NAME=example_site", "the site must still be passed through")
+	}
+
+	t.Run("execDrush", func(t *testing.T) {
+		cmd := captureCmd(t)
+
+		_, err := executor.execDrush(t.Context(), "/tmp", "example_site", "status")
+		require.NoError(t, err)
+
+		assertComposerEnvironment(t, (*cmd).Env)
+	})
+
+	t.Run("execDrushStreams", func(t *testing.T) {
+		cmd := captureCmd(t)
+
+		_, _, err := executor.execDrushStreams(t.Context(), "/tmp", "example_site", "updatedb-status", "--format=json")
+		require.NoError(t, err)
+
+		assertComposerEnvironment(t, (*cmd).Env)
+	})
+}

--- a/pkg/phpcs/phpcs.go
+++ b/pkg/phpcs/phpcs.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+
+	"github.com/drupdater/drupdater/pkg/composer"
 )
 
 var execCommand = exec.CommandContext
@@ -25,6 +27,9 @@ func NewCLI(logger *zap.Logger) *CLI {
 func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (string, error) {
 	command := execCommand(ctx, "composer", args...)
 	command.Dir = dir
+	// phpcs runs through `composer exec`, which makes it a subprocess of composer and so
+	// subject to composer's process timeout.
+	command.Env = composer.Env(command.Environ())
 
 	out, err := command.CombinedOutput()
 	output := strings.TrimSuffix(string(out), "\n")
@@ -39,6 +44,7 @@ func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (str
 func (s *CLI) execComposerJSON(ctx context.Context, dir string, args ...string) (string, error) {
 	command := execCommand(ctx, "composer", args...)
 	command.Dir = dir
+	command.Env = composer.Env(command.Environ())
 
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout

--- a/pkg/phpcs/phpcs_env_test.go
+++ b/pkg/phpcs/phpcs_env_test.go
@@ -1,0 +1,42 @@
+package phpcs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComposerEnvironment covers what phpcs shares with every other package that shells out to
+// composer: `composer exec -- phpcs` runs phpcs as a subprocess of composer, so composer's
+// default 300s process timeout applies to it. A phpcbf pass over a large custom-code tree
+// exceeds that, and the run then fails with a killed subprocess rather than a report.
+func TestComposerEnvironment(t *testing.T) {
+	t.Run("Run", func(t *testing.T) {
+		cli, _ := newTestCLI(t)
+		_, _, cmd := stubExec(t, `{"files":{},"totals":{"errors":0,"warnings":0,"fixable":0}}`, false)
+
+		_, err := cli.Run(t.Context(), "/tmp")
+		require.NoError(t, err)
+
+		assertComposerEnvironment(t, (*cmd).Env)
+	})
+
+	t.Run("RunCBF", func(t *testing.T) {
+		cli, _ := newTestCLI(t)
+		_, _, cmd := stubExec(t, "", false)
+
+		require.NoError(t, cli.RunCBF(t.Context(), "/tmp"))
+
+		assertComposerEnvironment(t, (*cmd).Env)
+	})
+}
+
+// assertComposerEnvironment states the requirement on the environment the composer subprocess
+// was actually given, rather than on the helper that builds it.
+func assertComposerEnvironment(t *testing.T, env []string) {
+	t.Helper()
+	assert.Contains(t, env, "COMPOSER_PROCESS_TIMEOUT=0", "composer must not cap the process it spawns")
+	assert.Contains(t, env, "COMPOSER_NO_AUDIT=1")
+	assert.Contains(t, env, "GO_WANT_HELPER_PROCESS=1", "the inherited environment must survive")
+}

--- a/pkg/rector/rector.go
+++ b/pkg/rector/rector.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+
+	"github.com/drupdater/drupdater/pkg/composer"
 )
 
 var execCommand = exec.CommandContext
@@ -29,6 +31,9 @@ func NewCLI(logger *zap.Logger) *CLI {
 func (s *CLI) execComposerJSON(ctx context.Context, dir string, args ...string) (string, error) {
 	command := execCommand(ctx, "composer", args...)
 	command.Dir = dir
+	// rector runs through `composer exec`, which makes it a subprocess of composer and so
+	// subject to composer's process timeout.
+	command.Env = composer.Env(command.Environ())
 
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout

--- a/pkg/rector/rector_env_test.go
+++ b/pkg/rector/rector_env_test.go
@@ -1,0 +1,27 @@
+package rector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComposerEnvironment covers what rector shares with every other package that shells out to
+// composer: `composer exec -- rector process` runs rector as a subprocess of composer, so
+// composer's default 300s process timeout applies to it. A rector pass over a large custom-code
+// tree exceeds that, and the run then fails with a killed subprocess rather than a report.
+func TestComposerEnvironment(t *testing.T) {
+	cli, _ := newTestCLI(t)
+	_, _, cmd := stubExec(t, `{"totals":{"changed_files":0},"file_diffs":[]}`, false)
+
+	_, err := cli.Run(t.Context(), "/tmp", []string{"web/modules/custom"})
+	require.NoError(t, err)
+
+	// Asserted on the environment the composer subprocess was actually given, rather than on
+	// the helper that builds it.
+	env := (*cmd).Env
+	assert.Contains(t, env, "COMPOSER_PROCESS_TIMEOUT=0", "composer must not cap the process it spawns")
+	assert.Contains(t, env, "COMPOSER_NO_AUDIT=1")
+	assert.Contains(t, env, "GO_WANT_HELPER_PROCESS=1", "the inherited environment must survive")
+}


### PR DESCRIPTION
COMPOSER_PROCESS_TIMEOUT and COMPOSER_NO_AUDIT were set only by the Dockerfile,
so a binary from `make build` or one a CI job installed ran without them.
Composer's default 300s process timeout then applies to everything it spawns: a
drupal/core clone or a large install on a slow network dies mid-phase with a
message about a killed subprocess and no visible connection to a timeout nobody
configured. Without COMPOSER_NO_AUDIT, `update` also runs an implicit audit whose
output Update()'s parsing was not written against.

execComposer and execComposerJSON now build cmd.Env from the process environment
and force those two values on top of it, dropping any inherited assignment to
them. Everything else — notably COMPOSER_AUTH — is passed through unchanged and
in order.

The image's other Composer variables (COMPOSER_HOME, COMPOSER_CACHE_DIR,
COMPOSER_ALLOW_SUPERUSER, COMPOSER_FUND) are deliberately left alone: they are
deployment policy, right for a container and wrong to impose on a developer
machine, and drupdater behaves correctly whatever they are set to. No preflight
check is added for them for the same reason — unset is a legitimate state.

Docs: environment-variables.md now states what drupdater requires of Composer's
environment, and development.md says running the binary outside the image is
supported.

Closes #189

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FNmKUXtx9we3KDnNK23E7A