### PR TITLE
refactor(composer): share the composer subprocess runner

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -306,12 +306,7 @@ func runFullChecks(ctx context.Context, logger *zap.Logger, cfg internal.Config,
 func cleanupFullCheckArtifacts(path string, sites []string) {
 	defer os.RemoveAll(path)
 
-	parent := filepath.Dir(path)
-	for _, site := range sites {
-		os.Remove(filepath.Join(parent, site+".sqlite"))
-		os.RemoveAll(filepath.Join(parent, "private", site))
-	}
-	os.Remove(filepath.Join(parent, "private"))
+	services.CleanupSiteArtifacts(filepath.Dir(path), sites)
 }
 
 // printCheckResults writes results to w, redacting each detail first: a failed check's Detail

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/drupdater/drupdater/internal"
@@ -158,18 +159,18 @@ func checkToken(args []string) string {
 // It also fills cfg.Sites (and the rest of the file config) for the checks that follow.
 func checkConfigAndAddons(path string, cfg *internal.Config) []services.CheckResult {
 	if _, err := internal.LoadConfigFile(path, cfg); err != nil {
-		return []services.CheckResult{{Name: ".drupdater.yaml valid", OK: false, Detail: err.Error()}}
+		return []services.CheckResult{services.CheckFailed(".drupdater.yaml valid", err.Error())}
 	}
 
-	results := []services.CheckResult{{
-		Name: fmt.Sprintf(".drupdater.yaml valid (sites: %s)", strings.Join(cfg.Sites, ", ")),
-		OK:   true,
-	}}
+	results := []services.CheckResult{
+		services.CheckOK(fmt.Sprintf(".drupdater.yaml valid (sites: %s)", strings.Join(cfg.Sites, ", "))),
+	}
 
+	const addonsName = "addon names resolve"
 	if err := validateAddons(*cfg); err != nil {
-		return append(results, services.CheckResult{Name: "addon names resolve", OK: false, Detail: err.Error()})
+		return append(results, services.CheckFailed(addonsName, err.Error()))
 	}
-	return append(results, services.CheckResult{Name: "addon names resolve", OK: true})
+	return append(results, services.CheckOK(addonsName))
 }
 
 // newVcsProvider resolves a repository URL and token to a VCS platform. A variable so the token
@@ -189,13 +190,13 @@ func checkVCS(ctx context.Context, logger *zap.Logger, repositoryURL string, tok
 		if resolveErr != nil {
 			detail = resolveErr.Error()
 		}
-		return []services.CheckResult{{Name: name, OK: false, Detail: detail}}
+		return []services.CheckResult{services.CheckFailed(name, detail)}
 	}
 	if err := codehosting.ValidateRepositoryURL(repositoryURL); err != nil {
-		return []services.CheckResult{{Name: name, OK: false, Detail: err.Error()}}
+		return []services.CheckResult{services.CheckFailed(name, err.Error())}
 	}
 
-	results := []services.CheckResult{{Name: name, OK: true}}
+	results := []services.CheckResult{services.CheckOK(name)}
 	if token == "" {
 		return results
 	}
@@ -203,13 +204,13 @@ func checkVCS(ctx context.Context, logger *zap.Logger, repositoryURL string, tok
 	const tokenCheckName = "token authenticates"
 	platform, err := newVcsProvider(repositoryURL, token, logger)
 	if err != nil {
-		return append(results, services.CheckResult{Name: tokenCheckName, OK: false, Detail: err.Error()})
+		return append(results, services.CheckFailed(tokenCheckName, err.Error()))
 	}
 	userName, email := platform.GetUser(ctx)
 	if userName == "" && email == "" {
-		return append(results, services.CheckResult{Name: tokenCheckName, OK: false, Detail: "did not authenticate, or lacks API access"})
+		return append(results, services.CheckFailed(tokenCheckName, "did not authenticate, or lacks API access"))
 	}
-	return append(results, services.CheckResult{Name: tokenCheckName, OK: true})
+	return append(results, services.CheckOK(tokenCheckName))
 }
 
 // fullCheckComposer is what the --full tier needs from composer: the install it performs, the
@@ -259,12 +260,9 @@ var newFullCheckDeps = func(logger *zap.Logger) fullCheckDeps {
 // copy, and proves each configured site installs from its exported configuration.
 func runFullChecks(ctx context.Context, logger *zap.Logger, cfg internal.Config, token string) []services.CheckResult {
 	if cfg.RepositoryURL == "" {
-		return []services.CheckResult{{
-			Name: "sites install from configuration",
-			OK:   false,
-			Detail: "no repository URL to clone (pass --repository-url or run inside a checkout " +
-				"with an origin remote)",
-		}}
+		return []services.CheckResult{services.CheckFailed("sites install from configuration",
+			"no repository URL to clone (pass --repository-url or run inside a checkout "+
+				"with an origin remote)")}
 	}
 	branch := cfg.Branch
 	if branch == "" {
@@ -275,7 +273,7 @@ func runFullChecks(ctx context.Context, logger *zap.Logger, cfg internal.Config,
 
 	path, err := deps.clone(cfg.RepositoryURL, branch, token)
 	if err != nil {
-		return []services.CheckResult{{Name: "clone for full check", OK: false, Detail: err.Error()}}
+		return []services.CheckResult{services.CheckFailed("clone for full check", err.Error())}
 	}
 	defer cleanupFullCheckArtifacts(path, cfg.Sites)
 
@@ -283,22 +281,22 @@ func runFullChecks(ctx context.Context, logger *zap.Logger, cfg internal.Config,
 	defer composerCLI.Cleanup()
 
 	if err := composerCLI.Install(ctx, path); err != nil {
-		return []services.CheckResult{{Name: "composer install", OK: false, Detail: err.Error()}}
+		return []services.CheckResult{services.CheckFailed("composer install", err.Error())}
 	}
-	results := []services.CheckResult{{Name: "composer install", OK: true}}
+	results := []services.CheckResult{services.CheckOK("composer install")}
 
 	installer, err := deps.newInstaller(composerCLI)
 	if err != nil {
-		return append(results, services.CheckResult{Name: "drush site-install --existing-config", OK: false, Detail: err.Error()})
+		return append(results, services.CheckFailed("drush site-install --existing-config", err.Error()))
 	}
 
 	for _, site := range cfg.Sites {
 		name := fmt.Sprintf("site %q installs from configuration", site)
 		if err := installer.Install(ctx, path, site); err != nil {
-			results = append(results, services.CheckResult{Name: name, OK: false, Detail: err.Error()})
+			results = append(results, services.CheckFailed(name, err.Error()))
 			continue
 		}
-		results = append(results, services.CheckResult{Name: name, OK: true})
+		results = append(results, services.CheckOK(name))
 	}
 	return results
 }
@@ -334,12 +332,7 @@ func printCheckResults(w io.Writer, results []services.CheckResult, redactor *lo
 }
 
 func anyCheckFailed(results []services.CheckResult) bool {
-	for _, r := range results {
-		if !r.OK {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(results, func(r services.CheckResult) bool { return !r.OK })
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -469,18 +470,8 @@ func validateAddons(config internal.Config) error {
 // configurableAddons returns the sorted addon names settable in .drupdater.yaml: every
 // registered addon except the mandatory ones.
 func configurableAddons() []string {
-	excluded := make(map[string]bool, len(mandatoryAddons))
-	for _, n := range mandatoryAddons {
-		excluded[n] = true
-	}
-	names := make([]string, 0, len(addonRegistry))
-	for n := range addonRegistry {
-		if !excluded[n] {
-			names = append(names, n)
-		}
-	}
-	sort.Strings(names)
-	return names
+	names := slices.Sorted(maps.Keys(addonRegistry))
+	return slices.DeleteFunc(names, func(n string) bool { return slices.Contains(mandatoryAddons, n) })
 }
 
 // addonsCmd lists the addon names that can be set in .drupdater.yaml.

--- a/internal/addon.go
+++ b/internal/addon.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"strings"
+	"sync"
 	"text/template"
 
 	"github.com/gookit/event"
@@ -27,10 +28,16 @@ type Addon interface {
 type BasicAddon struct {
 }
 
-func (ba *BasicAddon) Render(name string, data any) (string, error) {
-	tmpl, err := template.New("").Funcs(template.FuncMap{
+// addonTemplates parses the embedded section templates once. The FS is compiled in, so the
+// result — success or failure — is the same on every call.
+var addonTemplates = sync.OnceValues(func() (*template.Template, error) {
+	return template.New("").Funcs(template.FuncMap{
 		"cell": cellReplacer.Replace,
 	}).ParseFS(templates, "addon/templates/*.go.tmpl")
+})
+
+func (ba *BasicAddon) Render(name string, data any) (string, error) {
+	tmpl, err := addonTemplates()
 	if err != nil {
 		return "", fmt.Errorf("failed to parse template: %w", err)
 	}

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -50,14 +50,23 @@ func (cb *CodeBeautifier) RenderTemplate() (string, error) {
 	return "", nil
 }
 
-// fileExists reports whether path has a phpcs.xml or phpcs.xml.dist.
-var fileExists = func(path string) bool {
-	if _, err := os.Stat(filepath.Join(path, "phpcs.xml")); os.IsNotExist(err) {
-		if _, err := os.Stat(filepath.Join(path, "phpcs.xml.dist")); os.IsNotExist(err) {
-			return false
+// phpcsConfigPath returns the project's phpcs config file. found is true when a candidate is
+// present — or when stat failed for a reason other than absence, which is not this function's
+// call to interpret: a config that exists but cannot be read must not read as "no config".
+func phpcsConfigPath(path string) (configPath string, found bool) {
+	for _, name := range []string{"phpcs.xml", "phpcs.xml.dist"} {
+		candidate := filepath.Join(path, name)
+		if _, err := os.Stat(candidate); !os.IsNotExist(err) {
+			return candidate, true
 		}
 	}
-	return true
+	return "", false
+}
+
+// fileExists reports whether path has a phpcs.xml or phpcs.xml.dist.
+var fileExists = func(path string) bool {
+	_, found := phpcsConfigPath(path)
+	return found
 }
 
 type phpcsRuleset struct {
@@ -67,12 +76,8 @@ type phpcsRuleset struct {
 
 // hasPHPCSPathDefinitions reports whether the config declares any <file> path.
 var hasPHPCSPathDefinitions = func(path string) (bool, error) {
-	var configPath string
-	if _, err := os.Stat(filepath.Join(path, "phpcs.xml")); err == nil {
-		configPath = filepath.Join(path, "phpcs.xml")
-	} else if _, err := os.Stat(filepath.Join(path, "phpcs.xml.dist")); err == nil {
-		configPath = filepath.Join(path, "phpcs.xml.dist")
-	} else {
+	configPath, found := phpcsConfigPath(path)
+	if !found {
 		return false, nil
 	}
 

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -170,7 +170,7 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error { //nolint:
 		return err
 	}
 
-	sort.Strings(addedFiles)
+	slices.Sort(addedFiles)
 	cb.fixedFiles = addedFiles
 	cb.fixable = codingStyleUpdateResult.Totals.Fixable
 	return nil

--- a/internal/addon/composer_audit.go
+++ b/internal/addon/composer_audit.go
@@ -107,11 +107,15 @@ func (ca *ComposerAudit) preComposerUpdateHandler(e event.Event) error {
 		return nil
 	}
 
+	// Deduplicated in first-seen order: several advisories often name one package, and the list
+	// becomes composer update's package arguments.
 	packagesToUpdate := make([]string, 0)
+	seen := make(map[string]bool, len(ca.beforeAudit.Advisories))
 	for _, advisory := range ca.beforeAudit.Advisories {
-		if slices.Contains(packagesToUpdate, advisory.PackageName) {
+		if seen[advisory.PackageName] {
 			continue
 		}
+		seen[advisory.PackageName] = true
 		packagesToUpdate = append(packagesToUpdate, advisory.PackageName)
 	}
 

--- a/internal/addon/composer_patches_1.go
+++ b/internal/addon/composer_patches_1.go
@@ -215,6 +215,30 @@ func isRemotePatch(patchPath string) bool {
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
 }
 
+// resolvePatchPath makes a patch reference absolute for the patch-test project, which runs from
+// a temp directory where a project-relative path points nowhere. A remote patch is already
+// absolute.
+//
+// Must go through isRemotePatch: url.ParseRequestURI accepts "/patches/x.diff", which would pass
+// through unprefixed, fail to resolve, and pin the package on a conflict that never happened.
+func resolvePatchPath(projectDir string, patchPath string) string {
+	if isRemotePatch(patchPath) {
+		return patchPath
+	}
+	return projectDir + "/" + patchPath
+}
+
+// conflict records a package held back at its current version because a patch no longer applies.
+func conflict(op composer.PackageChange, patchPath string, description string) ConflictPatch {
+	return ConflictPatch{
+		Package:          op.Package,
+		FixedVersion:     op.From,
+		NewVersion:       op.To,
+		PatchPath:        patchPath,
+		PatchDescription: description,
+	}
+}
+
 // dropPatchFile removes a patch's file from the worktree. A remote patch has no file, which is
 // not an error. Every removal goes through here so a URL never reaches worktree.Remove, which
 // would fail and read as "the patch could not be dropped".
@@ -338,13 +362,7 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 		patches[op.Package][description] = patchPath
 	}
 
-	absolutePath := patchPath
-	externalPatch := isRemotePatch(patchPath)
-	if !externalPatch {
-		absolutePath = path + "/" + patchPath
-	}
-
-	ok, err := h.composer.CheckIfPatchApplies(ctx, path, op.Package, op.To, absolutePath)
+	ok, err := h.composer.CheckIfPatchApplies(ctx, path, op.Package, op.To, resolvePatchPath(path, patchPath))
 	if err != nil {
 		// The check could not run at all, usually because the package was unobtainable. An
 		// unverifiable patch is not a stale one: pinning here would hold the package back on
@@ -362,7 +380,7 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 
 	if !issueNumberExists {
 		h.logger.Info("patch does not apply, keeping current package version", zap.String("package", op.Package), zap.String("version", op.From), zap.String("patch", patchPath))
-		updates.Conflicts = append(updates.Conflicts, ConflictPatch{Package: op.Package, FixedVersion: op.From, PatchPath: patchPath, NewVersion: op.To, PatchDescription: description})
+		updates.Conflicts = append(updates.Conflicts, conflict(op, patchPath, description))
 		return
 	}
 
@@ -370,7 +388,7 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 	// only configured when DRUPALCODE_ACCESS_TOKEN is set. Without it, keep the current version.
 	if h.gitlab == nil {
 		h.logger.Info("patch does not apply and no drupalcode client is configured, keeping current package version", zap.String("package", op.Package), zap.String("version", op.From), zap.String("patch", patchPath))
-		updates.Conflicts = append(updates.Conflicts, ConflictPatch{Package: op.Package, FixedVersion: op.From, PatchPath: patchPath, NewVersion: op.To, PatchDescription: description})
+		updates.Conflicts = append(updates.Conflicts, conflict(op, patchPath, description))
 		return
 	}
 
@@ -420,21 +438,14 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 		updates.Updated = append(updates.Updated, UpdatedPatch{Package: op.Package, PreviousPatchPath: patchPath, NewPatchPath: fullNewPath, PatchDescription: description})
 	} else {
 		h.logger.Info("merge request does not apply, keeping current package version", zap.String("package", op.Package), zap.String("version", op.To), zap.String("patch", path+"/"+newPatchDir))
-		updates.Conflicts = append(updates.Conflicts, ConflictPatch{Package: op.Package, FixedVersion: op.From, PatchPath: patchPath, NewVersion: op.To, PatchDescription: description})
+		updates.Conflicts = append(updates.Conflicts, conflict(op, patchPath, description))
 	}
 }
 
 func (h *ComposerPatches1) validateCombinedPatches(ctx context.Context, path string, op composer.PackageChange, patches map[string]map[string]string, updates *PatchUpdates) {
 	patchPaths := make([]string, 0, len(patches[op.Package]))
 	for _, patchPath := range patches[op.Package] {
-		// Resolve local paths against the project, as processSinglePatch does. Must use
-		// isRemotePatch: url.ParseRequestURI accepts "/patches/x.diff", which would pass
-		// through unprefixed, fail to resolve, and pin the package on a false conflict.
-		absolutePath := patchPath
-		if !isRemotePatch(patchPath) {
-			absolutePath = path + "/" + patchPath
-		}
-		patchPaths = append(patchPaths, absolutePath)
+		patchPaths = append(patchPaths, resolvePatchPath(path, patchPath))
 	}
 
 	ok, err := h.composer.CheckIfPatchesApply(ctx, path, op.Package, op.To, patchPaths)
@@ -446,12 +457,8 @@ func (h *ComposerPatches1) validateCombinedPatches(ctx context.Context, path str
 	if !ok {
 		h.logger.Info("patches do not apply together, keeping current package version",
 			zap.String("package", op.Package), zap.String("version", op.To))
-		updates.Conflicts = append(updates.Conflicts, ConflictPatch{
-			Package:          op.Package,
-			FixedVersion:     op.From,
-			NewVersion:       op.To,
-			PatchDescription: "Multiple patches do not apply together",
-		})
+		// No single patch to name: the package is held back because the set as a whole failed.
+		updates.Conflicts = append(updates.Conflicts, conflict(op, "", "Multiple patches do not apply together"))
 	} else {
 		h.logger.Debug("patches apply together", zap.String("package", op.Package), zap.String("version", op.To), zap.Any("patch", patchPaths))
 
@@ -481,13 +488,14 @@ func (h *ComposerPatches1) fetchForkMergeRequests(projectMachineName string, for
 	return mergeRequests, nil
 }
 
+var unsafeFileNameChars = regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
+
 // cleanURLString turns an issue title into a safe file name component: lower-cased, spaces to
 // underscores, everything outside [a-z0-9-_.] stripped, so it can hold no path separator.
 func (h *ComposerPatches1) cleanURLString(s string) string {
 	s = strings.ToLower(s)
 	s = strings.ReplaceAll(s, " ", "_")
-	re := regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
-	return re.ReplaceAllString(s, "")
+	return unsafeFileNameChars.ReplaceAllString(s, "")
 }
 
 func (h *ComposerPatches1) downloadFile(ctx context.Context, url, folder string, file string) error {

--- a/internal/addon/report.go
+++ b/internal/addon/report.go
@@ -1,7 +1,9 @@
 package addon
 
 import (
-	"sort"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/drupdater/drupdater/pkg/drush"
@@ -71,14 +73,11 @@ func (uh *UpdateHooks) ReportData() any {
 		return nil
 	}
 
-	// Copy: the caller has no way to know this map is mutex-guarded state.
+	// Copy: the caller has no way to know this map is mutex-guarded state. Deep, because the
+	// per-site maps are guarded too.
 	out := make(map[string]map[string]drush.UpdateHook, len(uh.hooks))
 	for site, hooks := range uh.hooks {
-		siteHooks := make(map[string]drush.UpdateHook, len(hooks))
-		for name, hook := range hooks {
-			siteHooks[name] = hook
-		}
-		out[site] = siteHooks
+		out[site] = maps.Clone(hooks)
 	}
 
 	return out
@@ -99,11 +98,8 @@ func (um *UnsupportedModules) ReportData() any {
 		return nil
 	}
 
-	modules := make([]drush.UnsupportedModule, 0, len(um.modules))
-	for _, module := range um.modules {
-		modules = append(modules, module)
-	}
-	sort.Slice(modules, func(i, j int) bool { return modules[i].Name < modules[j].Name })
+	modules := slices.Collect(maps.Values(um.modules))
+	slices.SortFunc(modules, func(a, b drush.UnsupportedModule) int { return strings.Compare(a.Name, b.Name) })
 
 	return modules
 }
@@ -200,9 +196,5 @@ func (tu *TranslationsUpdater) ReportData() any {
 	}
 
 	// Copy: the caller has no way to know this map is mutex-guarded state.
-	out := make(map[string]TranslationResult, len(tu.results))
-	for site, result := range tu.results {
-		out[site] = result
-	}
-	return out
+	return maps.Clone(tu.results)
 }

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -5,8 +5,9 @@ package logging
 
 import (
 	"errors"
+	"maps"
 	"net/url"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -95,12 +96,9 @@ func (r *Redactor) currentReplacer() *strings.Replacer {
 		return nil
 	}
 
-	values := make([]string, 0, len(r.secrets))
-	for v := range r.secrets {
-		values = append(values, v)
-	}
+	values := slices.Collect(maps.Keys(r.secrets))
 	// Longest first, so a secret that is a substring of another is not partially consumed.
-	sort.Slice(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
+	slices.SortFunc(values, func(a, b string) int { return len(b) - len(a) })
 
 	pairs := make([]string, 0, len(values)*2)
 	for _, v := range values {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -308,19 +309,11 @@ type CheckResult struct {
 
 // NewCheck assembles the check document from the results the command produced.
 func NewCheck(version string, results []CheckResult) Check {
-	ok := true
-	for _, r := range results {
-		if !r.OK {
-			ok = false
-			break
-		}
-	}
-
 	return Check{
 		SchemaVersion:    SchemaVersion,
 		DrupdaterVersion: version,
 		CheckedAt:        time.Now(),
-		OK:               ok,
+		OK:               !slices.ContainsFunc(results, func(r CheckResult) bool { return !r.OK }),
 		Results:          results,
 	}
 }

--- a/internal/services/event.go
+++ b/internal/services/event.go
@@ -32,6 +32,11 @@ func (e *BasicAddonEvent) Worktree() Worktree {
 	return e.worktree
 }
 
+// newBasicAddonEvent builds the context every addon event carries.
+func newBasicAddonEvent(ctx context.Context, path string, worktree Worktree) BasicAddonEvent {
+	return BasicAddonEvent{ctx: ctx, path: path, worktree: worktree}
+}
+
 type PreComposerUpdateEvent struct {
 	event.BasicEvent
 	BasicAddonEvent
@@ -42,11 +47,7 @@ type PreComposerUpdateEvent struct {
 
 func NewPreComposerUpdateEvent(ctx context.Context, path string, worktree Worktree, packagesToUpdate []string, packagesToKeep []string, minimalChanges bool) *PreComposerUpdateEvent {
 	evt := &PreComposerUpdateEvent{
-		BasicAddonEvent: BasicAddonEvent{
-			ctx:      ctx,
-			path:     path,
-			worktree: worktree,
-		},
+		BasicAddonEvent:  newBasicAddonEvent(ctx, path, worktree),
 		PackagesToUpdate: packagesToUpdate,
 		PackagesToKeep:   packagesToKeep,
 		MinimalChanges:   minimalChanges,
@@ -62,10 +63,7 @@ type PostComposerUpdateEvent struct {
 
 func NewPostComposerUpdateEvent(ctx context.Context, path string, worktree Worktree) *PostComposerUpdateEvent {
 	evt := &PostComposerUpdateEvent{
-		BasicAddonEvent: BasicAddonEvent{
-			ctx:      ctx,
-			path:     path,
-			worktree: worktree},
+		BasicAddonEvent: newBasicAddonEvent(ctx, path, worktree),
 	}
 	evt.SetName("post-composer-update")
 	return evt
@@ -78,11 +76,7 @@ type PostCodeUpdateEvent struct {
 
 func NewPostCodeUpdateEvent(ctx context.Context, path string, worktree Worktree) *PostCodeUpdateEvent {
 	evt := &PostCodeUpdateEvent{
-		BasicAddonEvent: BasicAddonEvent{
-			ctx:      ctx,
-			path:     path,
-			worktree: worktree,
-		},
+		BasicAddonEvent: newBasicAddonEvent(ctx, path, worktree),
 	}
 	evt.SetName("post-code-update")
 	return evt
@@ -96,12 +90,8 @@ type PreSiteUpdateEvent struct {
 
 func NewPreSiteUpdateEvent(ctx context.Context, path string, worktree Worktree, site string) *PreSiteUpdateEvent {
 	evt := &PreSiteUpdateEvent{
-		BasicAddonEvent: BasicAddonEvent{
-			ctx:      ctx,
-			path:     path,
-			worktree: worktree,
-		},
-		site: site,
+		BasicAddonEvent: newBasicAddonEvent(ctx, path, worktree),
+		site:            site,
 	}
 	evt.SetName("pre-site-update")
 	return evt
@@ -119,12 +109,8 @@ type PostSiteUpdateEvent struct {
 
 func NewPostSiteUpdateEvent(ctx context.Context, path string, worktree Worktree, site string) *PostSiteUpdateEvent {
 	evt := &PostSiteUpdateEvent{
-		BasicAddonEvent: BasicAddonEvent{
-			ctx:      ctx,
-			path:     path,
-			worktree: worktree,
-		},
-		site: site,
+		BasicAddonEvent: newBasicAddonEvent(ctx, path, worktree),
+		site:            site,
 	}
 	evt.SetName("post-site-update")
 	return evt

--- a/internal/services/preflight.go
+++ b/internal/services/preflight.go
@@ -18,11 +18,13 @@ type CheckResult struct {
 	Detail string
 }
 
-func checkOK(name string) CheckResult {
+// CheckOK reports a passing check.
+func CheckOK(name string) CheckResult {
 	return CheckResult{Name: name, OK: true}
 }
 
-func checkFailed(name string, detail string) CheckResult {
+// CheckFailed reports a failing check, with detail explaining why.
+func CheckFailed(name string, detail string) CheckResult {
 	return CheckResult{Name: name, OK: false, Detail: detail}
 }
 
@@ -40,12 +42,12 @@ func CheckGitHistoryComplete(repository ShallowCloneChecker, workingDir string) 
 
 	shallow, err := repository.IsShallowClone(workingDir)
 	if err != nil {
-		return checkFailed(name, fmt.Sprintf("could not determine clone depth: %s", err))
+		return CheckFailed(name, fmt.Sprintf("could not determine clone depth: %s", err))
 	}
 	if shallow {
-		return checkFailed(name, `shallow checkout detected: fetch full history (set "fetch-depth: 0" in GitHub Actions, or GIT_DEPTH: "0" in GitLab CI)`)
+		return CheckFailed(name, `shallow checkout detected: fetch full history (set "fetch-depth: 0" in GitHub Actions, or GIT_DEPTH: "0" in GitLab CI)`)
 	}
-	return checkOK(name)
+	return CheckOK(name)
 }
 
 // PlatformReqsChecker is all CheckPlatformRequirements needs, narrow for the same reason as
@@ -61,9 +63,9 @@ func CheckPlatformRequirements(ctx context.Context, composer PlatformReqsChecker
 
 	out, err := composer.CheckPlatformReqs(ctx, workingDir)
 	if err != nil {
-		return checkFailed(name, out)
+		return CheckFailed(name, out)
 	}
-	return checkOK(name)
+	return CheckOK(name)
 }
 
 // ComposerConfigGetter is all CheckSiteSettings needs, narrow for the same reason as
@@ -80,13 +82,13 @@ func CheckSiteSettings(ctx context.Context, composer ComposerConfigGetter, fs af
 
 	webroot, err := composer.GetConfig(ctx, workingDir, "extra.drupal-scaffold.locations.web-root")
 	if err != nil {
-		return checkFailed(name, fmt.Sprintf("could not determine web root: %s", err))
+		return CheckFailed(name, fmt.Sprintf("could not determine web root: %s", err))
 	}
 	webroot = strings.TrimSuffix(webroot, "/")
 
 	relPath := filepath.Join(webroot, "sites", site, "settings.php")
 	if _, err := fs.Stat(filepath.Join(workingDir, relPath)); err != nil {
-		return checkFailed(name, fmt.Sprintf("not found at %s", relPath))
+		return CheckFailed(name, fmt.Sprintf("not found at %s", relPath))
 	}
-	return checkOK(name)
+	return CheckOK(name)
 }

--- a/internal/services/preflight.go
+++ b/internal/services/preflight.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
+	composerpkg "github.com/drupdater/drupdater/pkg/composer"
 	"github.com/spf13/afero"
 )
 
@@ -80,11 +80,10 @@ type ComposerConfigGetter interface {
 func CheckSiteSettings(ctx context.Context, composer ComposerConfigGetter, fs afero.Fs, workingDir string, site string) CheckResult {
 	name := fmt.Sprintf("site %q: settings.php", site)
 
-	webroot, err := composer.GetConfig(ctx, workingDir, "extra.drupal-scaffold.locations.web-root")
+	webroot, err := composerpkg.WebRoot(ctx, composer, workingDir)
 	if err != nil {
 		return CheckFailed(name, fmt.Sprintf("could not determine web root: %s", err))
 	}
-	webroot = strings.TrimSuffix(webroot, "/")
 
 	relPath := filepath.Join(webroot, "sites", site, "settings.php")
 	if _, err := fs.Stat(filepath.Join(workingDir, relPath)); err != nil {

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -346,8 +346,14 @@ func (ws *WorkflowBaseService) cleanup(path string) {
 		}
 		return
 	}
-	parent := filepath.Dir(path)
-	for _, site := range ws.config.Sites {
+	CleanupSiteArtifacts(filepath.Dir(path), ws.config.Sites)
+}
+
+// CleanupSiteArtifacts removes the SQLite databases and private files a site install writes
+// beside the checkout, given the directory the checkout sits in. Shared with "drupdater check
+// --full", which performs the same installs and owes the same cleanup.
+func CleanupSiteArtifacts(parent string, sites []string) {
+	for _, site := range sites {
 		os.Remove(filepath.Join(parent, site+".sqlite"))
 		// Only the per-site directory, never the whole "private" tree: that is a standard Drupal
 		// layout and can hold real project data this run does not own.

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -17,11 +17,11 @@ import (
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/report"
 	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/drupdater/drupdater/pkg/repo"
 
 	git "github.com/go-git/go-git/v5"
 	gitConfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
@@ -550,10 +550,7 @@ func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRe
 		RefSpecs: []gitConfig.RefSpec{
 			gitConfig.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads/%s", updateBranchName, updateBranchName)),
 		},
-		Auth: &http.BasicAuth{
-			Username: "du", // yes, this can be anything except an empty string
-			Password: ws.config.Token,
-		},
+		Auth: repo.BasicAuth(ws.config.Token),
 	})
 
 	if err != nil {

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -586,8 +586,14 @@ func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRe
 	return nil
 }
 
+// descriptionTemplates parses the embedded merge request templates once. The FS is compiled in,
+// so the result — success or failure — is the same on every call.
+var descriptionTemplates = sync.OnceValues(func() (*template.Template, error) {
+	return template.ParseFS(templates, "templates/*.go.tmpl")
+})
+
 func (ws *WorkflowBaseService) GenerateDescription(data any, filename string) (string, error) {
-	tmpl, err := template.ParseFS(templates, "templates/*.go.tmpl")
+	tmpl, err := descriptionTemplates()
 	if err != nil {
 		return "", fmt.Errorf("failed to parse template: %w", err)
 	}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -75,36 +75,21 @@ func Env(env []string) []string {
 	return append(result, requiredComposerEnv...)
 }
 
+// command returns the runner for a composer invocation in dir. Built per call so a test that
+// swaps execCommand after the CLI was constructed still diverts the subprocess.
+func (s *CLI) command(dir string) Command {
+	return Command{New: execCommand, Logger: s.logger, Dir: dir}
+}
+
 func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (string, error) {
-	command := execCommand(ctx, "composer", args...)
-	command.Dir = dir
-	// Environ() falls back to os.Environ(), so this layers on the deployment's environment
-	// instead of replacing it.
-	command.Env = Env(command.Environ())
-
-	out, err := command.CombinedOutput()
-	output := strings.TrimSuffix(string(out), "\n")
-	s.logger.Debug(command.String() + "\n" + output)
-
-	return output, err
+	return s.command(dir).Combined(ctx, args...)
 }
 
 // execComposerJSON returns stdout only. Commands whose output is parsed as JSON must use this:
 // composer's stderr notices would otherwise corrupt the payload. stderr still reaches the log.
 func (s *CLI) execComposerJSON(ctx context.Context, dir string, args ...string) (string, error) {
-	command := execCommand(ctx, "composer", args...)
-	command.Dir = dir
-	command.Env = Env(command.Environ())
-
-	var stdout, stderr bytes.Buffer
-	command.Stdout = &stdout
-	command.Stderr = &stderr
-	err := command.Run()
-
-	output := strings.TrimSuffix(stdout.String(), "\n")
-	s.logger.Debug(command.String() + "\nstdout: " + output + "\nstderr: " + strings.TrimSuffix(stderr.String(), "\n"))
-
-	return output, err
+	stdout, _, err := s.command(dir).Split(ctx, args...)
+	return stdout, err
 }
 
 type PackageChange struct {

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -889,13 +889,29 @@ func (s *CLI) UpdateLockHash(ctx context.Context, dir string) error {
 	return err
 }
 
+// ConfigGetter is the one method WebRoot needs, so a caller's own narrow composer interface
+// satisfies it without importing this package's whole CLI.
+type ConfigGetter interface {
+	GetConfig(ctx context.Context, dir string, key string) (string, error)
+}
+
+// WebRoot returns the project's Drupal web root, relative to dir and without a trailing slash.
+// Everything Drupal — settings.php, custom modules, the config sync directory — is addressed
+// from it, so several packages need the same lookup.
+func WebRoot(ctx context.Context, cfg ConfigGetter, dir string) (string, error) {
+	webroot, err := cfg.GetConfig(ctx, dir, "extra.drupal-scaffold.locations.web-root")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(webroot, "/"), nil
+}
+
 func (s *CLI) GetCustomCodeDirectories(ctx context.Context, dir string) ([]string, error) {
-	webroot, err := s.GetConfig(ctx, dir, "extra.drupal-scaffold.locations.web-root")
+	webroot, err := WebRoot(ctx, s, dir)
 	if err != nil {
 		s.logger.Error("failed to get Drupal web dir", zap.String("dir", dir), zap.Error(err))
 		return nil, err
 	}
-	webroot = strings.TrimSuffix(webroot, "/")
 
 	possibleDirectories := []string{webroot + "/modules/custom", webroot + "/themes/custom", webroot + "/profiles/custom"}
 	var customCodeDirectories []string

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -124,12 +124,11 @@ func (s *CLI) Update(ctx context.Context, dir string, packages []string, package
 	for _, pattern := range packageChangePatterns {
 		for _, match := range pattern.re.FindAllStringSubmatch(out, -1) {
 			change := PackageChange{Action: pattern.action, Package: match[1]}
-			if pattern.twoVersions {
-				change.From, change.To = match[2], match[3]
-			} else if pattern.isRemoval {
-				change.From = match[2]
-			} else {
-				change.To = match[2]
+			if pattern.from > 0 {
+				change.From = match[pattern.from]
+			}
+			if pattern.to > 0 {
+				change.To = match[pattern.to]
 			}
 			changes = append(changes, change)
 		}
@@ -145,15 +144,15 @@ func (s *CLI) Update(ctx context.Context, dir string, packages []string, package
 var packageChangePatterns = []struct {
 	action string
 	re     *regexp.Regexp
-	// twoVersions marks the "(from => to)" form. Otherwise the single captured version is To,
-	// unless isRemoval says the package is going away and it is therefore From.
-	twoVersions bool
-	isRemoval   bool
+	// from and to are the capture groups holding those versions; 0 means the action has none.
+	// A removal reports only the version going away, an install only the one arriving.
+	from int
+	to   int
 }{
-	{action: "Upgrade", re: twoVersionRegex("Upgrading"), twoVersions: true},
-	{action: "Downgrade", re: twoVersionRegex("Downgrading"), twoVersions: true},
-	{action: "Remove", re: oneVersionRegex("Removing"), isRemoval: true},
-	{action: "Install", re: oneVersionRegex("Installing")},
+	{action: "Upgrade", re: twoVersionRegex("Upgrading"), from: 2, to: 3},
+	{action: "Downgrade", re: twoVersionRegex("Downgrading"), from: 2, to: 3},
+	{action: "Remove", re: oneVersionRegex("Removing"), from: 2},
+	{action: "Install", re: oneVersionRegex("Installing"), to: 2},
 }
 
 // versionPattern includes "+" and "~" in the class so build-metadata versions (1.0.0+21AF26D3)

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -118,50 +119,53 @@ func (s *CLI) Update(ctx context.Context, dir string, packages []string, package
 		return changes, fmt.Errorf("failed to update dependencies: %w, output: %s, arg: %v", err, out, args)
 	}
 
-	// "+" and "~" are in the class so build-metadata versions (1.0.0+21AF26D3) still match.
-	const version = `[\w.\-+~]+`
-	upgradeRegex := regexp.MustCompile(`- Upgrading ([\w\-/]+) \((` + version + `) => (` + version + `)\)`)
-	downgradingRegex := regexp.MustCompile(`- Downgrading ([\w\-/]+) \((` + version + `) => (` + version + `)\)`)
-	removeRegex := regexp.MustCompile(`- Removing ([\w\-/]+) \((` + version + `)\)`)
-	installRegex := regexp.MustCompile(`- Installing ([\w\-/]+) \((` + version + `)\)`)
-
-	for _, match := range upgradeRegex.FindAllStringSubmatch(out, -1) {
-		changes = append(changes, PackageChange{
-			Action:  "Upgrade",
-			Package: match[1],
-			From:    match[2],
-			To:      match[3],
-		})
-	}
-
-	for _, match := range downgradingRegex.FindAllStringSubmatch(out, -1) {
-		changes = append(changes, PackageChange{
-			Action:  "Downgrade",
-			Package: match[1],
-			From:    match[2],
-			To:      match[3],
-		})
-	}
-
-	for _, match := range removeRegex.FindAllStringSubmatch(out, -1) {
-		changes = append(changes, PackageChange{
-			Action:  "Remove",
-			Package: match[1],
-			From:    match[2],
-			To:      "",
-		})
-	}
-
-	for _, match := range installRegex.FindAllStringSubmatch(out, -1) {
-		changes = append(changes, PackageChange{
-			Action:  "Install",
-			Package: match[1],
-			From:    "",
-			To:      match[2],
-		})
+	// Grouped by action rather than scanned line by line, so the result stays ordered by action
+	// however composer interleaved its output.
+	for _, pattern := range packageChangePatterns {
+		for _, match := range pattern.re.FindAllStringSubmatch(out, -1) {
+			change := PackageChange{Action: pattern.action, Package: match[1]}
+			if pattern.twoVersions {
+				change.From, change.To = match[2], match[3]
+			} else if pattern.isRemoval {
+				change.From = match[2]
+			} else {
+				change.To = match[2]
+			}
+			changes = append(changes, change)
+		}
 	}
 
 	return changes, nil
+}
+
+// packageChangePatterns matches composer update's report of what it did, one entry per action.
+//
+// The order is the order the changes come back in, which the merge request description and the
+// report both carry, so it is part of what a consumer sees.
+var packageChangePatterns = []struct {
+	action string
+	re     *regexp.Regexp
+	// twoVersions marks the "(from => to)" form. Otherwise the single captured version is To,
+	// unless isRemoval says the package is going away and it is therefore From.
+	twoVersions bool
+	isRemoval   bool
+}{
+	{action: "Upgrade", re: twoVersionRegex("Upgrading"), twoVersions: true},
+	{action: "Downgrade", re: twoVersionRegex("Downgrading"), twoVersions: true},
+	{action: "Remove", re: oneVersionRegex("Removing"), isRemoval: true},
+	{action: "Install", re: oneVersionRegex("Installing")},
+}
+
+// versionPattern includes "+" and "~" in the class so build-metadata versions (1.0.0+21AF26D3)
+// still match.
+const versionPattern = `[\w.\-+~]+`
+
+func twoVersionRegex(verb string) *regexp.Regexp {
+	return regexp.MustCompile(`- ` + verb + ` ([\w\-/]+) \((` + versionPattern + `) => (` + versionPattern + `)\)`)
+}
+
+func oneVersionRegex(verb string) *regexp.Regexp {
+	return regexp.MustCompile(`- ` + verb + ` ([\w\-/]+) \((` + versionPattern + `)\)`)
 }
 
 func (s *CLI) Install(ctx context.Context, dir string) error {
@@ -272,25 +276,23 @@ func flattenAdvisories(advisoriesData any) ([]Advisory, error) {
 
 	var advisories []Advisory
 	for _, value := range advMap {
+		var items []any
 		switch v := value.(type) {
 		case []any: // Simple advisory list
-			for _, item := range v {
-				var adv Advisory
-				itemBytes, _ := json.Marshal(item)
-				if err := json.Unmarshal(itemBytes, &adv); err != nil {
-					return nil, err
-				}
-				advisories = append(advisories, adv)
-			}
+			items = v
 		case map[string]any: // Nested map (e.g., drupal/core)
-			for _, nestedItem := range v {
-				var adv Advisory
-				nestedBytes, _ := json.Marshal(nestedItem)
-				if err := json.Unmarshal(nestedBytes, &adv); err != nil {
-					return nil, err
-				}
-				advisories = append(advisories, adv)
+			items = slices.Collect(maps.Values(v))
+		default:
+			continue
+		}
+
+		for _, item := range items {
+			var adv Advisory
+			itemBytes, _ := json.Marshal(item)
+			if err := json.Unmarshal(itemBytes, &adv); err != nil {
+				return nil, err
 			}
+			advisories = append(advisories, adv)
 		}
 	}
 
@@ -736,35 +738,10 @@ type patchTestConfig struct {
 	Patches map[string]map[string]string `json:"patches"`
 }
 
+// CheckIfPatchApplies reports whether a single patch still applies to packageName at
+// packageVersion.
 func (s *CLI) CheckIfPatchApplies(ctx context.Context, projectDir string, packageName string, packageVersion string, patchPath string) (bool, error) {
-
-	s.initOnce.Do(s.initTempDir)
-	if s.initErr != nil {
-		return false, s.initErr
-	}
-	if err := s.resetScratchProject(projectDir); err != nil {
-		return false, err
-	}
-
-	// Marshalled rather than formatted, so special characters in the arguments stay escaped.
-	patchConfig := patchTestConfig{
-		Patches: map[string]map[string]string{
-			packageName: {
-				packageVersion: patchPath,
-			},
-		},
-	}
-	patchesJSONBytes, err := json.Marshal(patchConfig)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal patch config: %w", err)
-	}
-	patchesJSON := string(patchesJSONBytes)
-
-	if err := afero.WriteFile(s.fs, s.tempDir+"/composer.patches.json", []byte(patchesJSON), 0644); err != nil {
-		return false, err
-	}
-
-	return s.requireIntoScratch(ctx, packageName, packageVersion)
+	return s.CheckIfPatchesApply(ctx, projectDir, packageName, packageVersion, []string{patchPath})
 }
 
 // requireIntoScratch installs the package under test and classifies the outcome: true when the
@@ -808,14 +785,7 @@ func unresolvableReason(out string) (string, bool) {
 		return "", false
 	}
 
-	for _, candidate := range []struct{ pattern, reason string }{
-		{"could not find package", "not available from any configured repository"},
-		{"could not find a matching version", "not available from any configured repository"},
-		{"could not be found", "not available from any configured repository"},
-		{"invalid credentials", "repository authentication failed"},
-		{"authentication required", "repository authentication failed"},
-		{"could not be downloaded", "a required download failed"},
-	} {
+	for _, candidate := range unresolvablePatterns {
 		if strings.Contains(lower, candidate.pattern) {
 			return candidate.reason, true
 		}
@@ -823,6 +793,18 @@ func unresolvableReason(out string) (string, bool) {
 	return "", false
 }
 
+var unresolvablePatterns = []struct{ pattern, reason string }{
+	{"could not find package", "not available from any configured repository"},
+	{"could not find a matching version", "not available from any configured repository"},
+	{"could not be found", "not available from any configured repository"},
+	{"invalid credentials", "repository authentication failed"},
+	{"authentication required", "repository authentication failed"},
+	{"could not be downloaded", "a required download failed"},
+}
+
+// CheckIfPatchesApply reports whether patchPaths all apply together to packageName at
+// packageVersion. The keys are zero-padded indexes: composer-patches v1 treats them as free-text
+// descriptions, but applies them in key order, so the caller's order must survive JSON encoding.
 func (s *CLI) CheckIfPatchesApply(ctx context.Context, projectDir string, packageName string, packageVersion string, patchPaths []string) (bool, error) {
 	s.initOnce.Do(s.initTempDir)
 	if s.initErr != nil {
@@ -837,6 +819,7 @@ func (s *CLI) CheckIfPatchesApply(ctx context.Context, projectDir string, packag
 		patchMap[fmt.Sprintf("%010d", i)] = p
 	}
 
+	// Marshalled rather than formatted, so special characters in the arguments stay escaped.
 	patchesJSONBytes, err := json.Marshal(patchTestConfig{
 		Patches: map[string]map[string]string{packageName: patchMap},
 	})
@@ -851,6 +834,10 @@ func (s *CLI) CheckIfPatchesApply(ctx context.Context, projectDir string, packag
 	return s.requireIntoScratch(ctx, packageName, packageVersion)
 }
 
+// dependsRegex matches a row of `composer depends`. The version token matches any non-space
+// run, so dev-main and 1.0.0-beta1 are captured too.
+var dependsRegex = regexp.MustCompile(`(?m)^(\S+)\s+\S+\s+requires\b`)
+
 func (s *CLI) GetInstalledPlugins(ctx context.Context, dir string) (map[string]any, error) {
 
 	out, err := s.execComposer(ctx, dir, "depends", "composer-plugin-api", "--locked")
@@ -858,10 +845,8 @@ func (s *CLI) GetInstalledPlugins(ctx context.Context, dir string) (map[string]a
 		return nil, err
 	}
 
-	// The version token matches any non-space run, so dev-main and 1.0.0-beta1 are captured too.
 	var packages = make(map[string]any)
-	reg := regexp.MustCompile(`(?m)^(\S+)\s+\S+\s+requires\b`)
-	matches := reg.FindAllStringSubmatch(out, -1)
+	matches := dependsRegex.FindAllStringSubmatch(out, -1)
 
 	for _, match := range matches {
 		if len(match) > 1 {

--- a/pkg/composer/exec.go
+++ b/pkg/composer/exec.go
@@ -1,0 +1,72 @@
+package composer
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// CommandFactory builds the *exec.Cmd to run. Every package that shells out to composer keeps
+// its own package-level variable of this type as its test seam and passes it in per call, so
+// swapping the variable still diverts the subprocess.
+type CommandFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+// Command is one composer invocation: run in Dir, under the environment Env guarantees.
+//
+// Shared by every package that drives composer — drush, phpcs and rector all run through
+// `composer exec` — so the process timeout and the debug logging are stated once.
+type Command struct {
+	New    CommandFactory
+	Logger *zap.Logger
+	Dir    string
+	// ExtraEnv is appended after Env, so it wins over anything inherited — drush's SITE_NAME.
+	ExtraEnv []string
+}
+
+func (c Command) build(ctx context.Context, args ...string) *exec.Cmd {
+	command := c.New(ctx, "composer", args...)
+	command.Dir = c.Dir
+	// Environ() falls back to os.Environ(), so this layers on the deployment's environment
+	// instead of replacing it.
+	command.Env = append(Env(command.Environ()), c.ExtraEnv...)
+	return command
+}
+
+// Combined runs the command with stdout and stderr merged, as CombinedOutput does, and returns
+// the output with its trailing newline stripped.
+func (c Command) Combined(ctx context.Context, args ...string) (string, error) {
+	command := c.build(ctx, args...)
+
+	// One buffer for both streams: what CombinedOutput does internally, kept here because
+	// CombinedOutput refuses a command whose Stdout is already set.
+	var merged bytes.Buffer
+	command.Stdout = &merged
+	command.Stderr = &merged
+	err := command.Run()
+
+	output := strings.TrimSuffix(merged.String(), "\n")
+	c.Logger.Debug(command.String() + "\n" + output)
+
+	return output, err
+}
+
+// Split keeps the streams apart. Commands whose stdout is parsed as JSON must use this: a
+// composer or PHP notice on stderr would otherwise corrupt the payload. stderr still reaches
+// the log, and is returned so a caller can quote it in an error.
+func (c Command) Split(ctx context.Context, args ...string) (stdout string, stderr string, err error) {
+	command := c.build(ctx, args...)
+
+	var so, se bytes.Buffer
+	command.Stdout = &so
+	command.Stderr = &se
+	err = command.Run()
+
+	stdout = strings.TrimSuffix(so.String(), "\n")
+	stderr = strings.TrimSuffix(se.String(), "\n")
+	c.Logger.Debug(command.String() + "\nstdout: " + stdout + "\nstderr: " + stderr)
+
+	return stdout, stderr, err
+}

--- a/pkg/drupal/installer.go
+++ b/pkg/drupal/installer.go
@@ -132,30 +132,49 @@ if (isset($settings['config_exclude_modules'])) {
 	return nil
 }
 
-func (is *Installer) isSqliteModuleEnabled(ctx context.Context, dir string, site string) (bool, error) {
-	siteLogger := is.logger.With(zap.String("site", site))
-
+// coreExtensionPath returns the site's core.extension.yml, the file that records which modules
+// and profile the site was installed with.
+func (is *Installer) coreExtensionPath(ctx context.Context, dir string, site string) (string, error) {
 	configSyncDir, err := is.drush.GetConfigSyncDir(ctx, dir, site, false)
 	if err != nil {
-		return false, err
+		return "", err
 	}
-	coreExtensionPath := configSyncDir + "/core.extension.yml"
-	siteLogger.Debug("checking if sqlite module is enabled", zap.String("path", coreExtensionPath))
+	return configSyncDir + "/core.extension.yml", nil
+}
 
-	file, err := afero.ReadFile(is.fs, coreExtensionPath)
+// readCoreExtension reads and decodes core.extension.yml, returning its path alongside the whole
+// document and its module section — a file without one is unusable to every caller here.
+func (is *Installer) readCoreExtension(ctx context.Context, dir string, site string) (path string, config map[string]any, modules map[string]any, err error) {
+	path, err = is.coreExtensionPath(ctx, dir, site)
 	if err != nil {
-		return false, fmt.Errorf("failed to read core extension file: %w", err)
+		return "", nil, nil, err
 	}
 
-	var config map[string]any
+	file, err := afero.ReadFile(is.fs, path)
+	if err != nil {
+		return path, nil, nil, fmt.Errorf("failed to read core extension file: %w", err)
+	}
+
 	if err := yaml.Unmarshal(file, &config); err != nil {
-		return false, fmt.Errorf("failed to unmarshal core extension file: %w", err)
+		return path, nil, nil, fmt.Errorf("failed to unmarshal core extension file: %w", err)
 	}
 
 	modules, ok := config["module"].(map[string]any)
 	if !ok {
-		return false, fmt.Errorf("core extension file %s has no module section", coreExtensionPath)
+		return path, config, nil, fmt.Errorf("core extension file %s has no module section", path)
 	}
+	return path, config, modules, nil
+}
+
+func (is *Installer) isSqliteModuleEnabled(ctx context.Context, dir string, site string) (bool, error) {
+	siteLogger := is.logger.With(zap.String("site", site))
+
+	coreExtensionPath, _, modules, err := is.readCoreExtension(ctx, dir, site)
+	if err != nil {
+		return false, err
+	}
+	siteLogger.Debug("checking if sqlite module is enabled", zap.String("path", coreExtensionPath))
+
 	if enabled, exists := modules["sqlite"]; exists && enabled == 0 {
 		siteLogger.Debug("sqlite module is enabled")
 		return true, nil
@@ -169,24 +188,9 @@ func (is *Installer) addSqliteModule(ctx context.Context, dir string, site strin
 
 	siteLogger := is.logger.With(zap.String("site", site))
 
-	configSyncDir, err := is.drush.GetConfigSyncDir(ctx, dir, site, false)
+	coreExtensionPath, config, modules, err := is.readCoreExtension(ctx, dir, site)
 	if err != nil {
 		return err
-	}
-	coreExtensionPath := configSyncDir + "/core.extension.yml"
-	file, err := afero.ReadFile(is.fs, coreExtensionPath)
-	if err != nil {
-		return fmt.Errorf("failed to read core extension file: %w", err)
-	}
-
-	var config map[string]any
-	if err := yaml.Unmarshal(file, &config); err != nil {
-		return fmt.Errorf("failed to unmarshal core extension file: %w", err)
-	}
-
-	modules, ok := config["module"].(map[string]any)
-	if !ok {
-		return fmt.Errorf("core extension file %s has no module section", coreExtensionPath)
 	}
 	modules["sqlite"] = 0
 
@@ -206,11 +210,10 @@ func (is *Installer) addSqliteModule(ctx context.Context, dir string, site strin
 func (is *Installer) RemoveProfile(ctx context.Context, dir string, site string) error {
 	siteLogger := is.logger.With(zap.String("site", site))
 
-	configSyncDir, err := is.drush.GetConfigSyncDir(ctx, dir, site, false)
+	coreExtensionPath, err := is.coreExtensionPath(ctx, dir, site)
 	if err != nil {
 		return err
 	}
-	coreExtensionPath := configSyncDir + "/core.extension.yml"
 
 	fileToRead, err := is.fs.Open(coreExtensionPath)
 	if err != nil {

--- a/pkg/drupal/installer.go
+++ b/pkg/drupal/installer.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 
@@ -69,11 +70,10 @@ func (is *Installer) ConfigureDatabase(ctx context.Context, dir string, site str
 	siteLogger := is.logger.With(zap.String("site", site))
 	siteLogger.Debug("configuring database", zap.String("dir", dir))
 
-	webroot, err := is.composer.GetConfig(ctx, dir, "extra.drupal-scaffold.locations.web-root")
+	webroot, err := composer.WebRoot(ctx, is.composer, dir)
 	if err != nil {
 		return fmt.Errorf("failed to get Drupal web dir: %w", err)
 	}
-	webroot = strings.TrimSuffix(webroot, "/")
 
 	settingsPath := dir + "/" + webroot + "/sites/" + site + "/settings.php"
 	if existing, err := afero.ReadFile(is.fs, settingsPath); err == nil && strings.Contains(string(existing), settingsMarker) {

--- a/pkg/drush/drush.go
+++ b/pkg/drush/drush.go
@@ -1,7 +1,6 @@
 package drush
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,39 +27,30 @@ func NewCLI(logger *zap.Logger, cache otter.Cache[string, string]) *CLI {
 	}
 }
 
+// command returns the runner for a drush invocation on site. drush runs through `composer exec`
+// and inherits composer's process timeout, which `site:install` and `updatedb` both outlast;
+// SITE_NAME comes after that environment so it wins over any value the parent process set.
+func (e *CLI) command(dir string, site string) composer.Command {
+	return composer.Command{
+		New:      execCommand,
+		Logger:   e.logger,
+		Dir:      dir,
+		ExtraEnv: []string{"SITE_NAME=" + site},
+	}
+}
+
+func drushArgs(args []string) []string {
+	return append([]string{"exec", "--", "drush"}, args...)
+}
+
 func (e *CLI) execDrush(ctx context.Context, dir string, site string, args ...string) (string, error) {
-	command := execCommand(ctx, "composer", append([]string{"exec", "--", "drush"}, args...)...)
-	command.Dir = dir
-	// The composer environment first: drush runs through `composer exec` and inherits its
-	// process timeout, which `site:install` and `updatedb` both outlast. Then SITE_NAME, so it
-	// wins over any value the parent process already set.
-	command.Env = append(composer.Env(command.Environ()), "SITE_NAME="+site)
-
-	out, err := command.CombinedOutput()
-	output := strings.TrimSuffix(string(out), "\n")
-
-	e.logger.Debug(command.String() + "\n" + output)
-
-	return output, err
+	return e.command(dir, site).Combined(ctx, drushArgs(args)...)
 }
 
 // execDrushStreams keeps stdout and stderr apart. Commands whose stdout is parsed as JSON must
 // use this: drush's stderr notices would otherwise corrupt the payload.
 func (e *CLI) execDrushStreams(ctx context.Context, dir string, site string, args ...string) (stdout string, stderr string, err error) {
-	command := execCommand(ctx, "composer", append([]string{"exec", "--", "drush"}, args...)...)
-	command.Dir = dir
-	command.Env = append(composer.Env(command.Environ()), "SITE_NAME="+site)
-
-	var so, se bytes.Buffer
-	command.Stdout = &so
-	command.Stderr = &se
-	err = command.Run()
-
-	stdout = strings.TrimSuffix(so.String(), "\n")
-	stderr = strings.TrimSuffix(se.String(), "\n")
-	e.logger.Debug(command.String() + "\nstdout: " + stdout + "\nstderr: " + stderr)
-
-	return stdout, stderr, err
+	return e.command(dir, site).Split(ctx, drushArgs(args)...)
 }
 
 func (e *CLI) InstallSite(ctx context.Context, dir string, site string) error {

--- a/pkg/phpcs/phpcs.go
+++ b/pkg/phpcs/phpcs.go
@@ -1,11 +1,9 @@
 package phpcs
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"os/exec"
-	"strings"
 
 	"go.uber.org/zap"
 
@@ -24,35 +22,10 @@ func NewCLI(logger *zap.Logger) *CLI {
 	}
 }
 
-func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (string, error) {
-	command := execCommand(ctx, "composer", args...)
-	command.Dir = dir
-	// phpcs runs through `composer exec` and inherits composer's process timeout.
-	command.Env = composer.Env(command.Environ())
-
-	out, err := command.CombinedOutput()
-	output := strings.TrimSuffix(string(out), "\n")
-
-	s.logger.Debug(command.String() + "\n" + output)
-
-	return output, err
-}
-
-// execComposerJSON returns stdout only, so PHP notices on stderr can't corrupt the JSON report.
-func (s *CLI) execComposerJSON(ctx context.Context, dir string, args ...string) (string, error) {
-	command := execCommand(ctx, "composer", args...)
-	command.Dir = dir
-	command.Env = composer.Env(command.Environ())
-
-	var stdout, stderr bytes.Buffer
-	command.Stdout = &stdout
-	command.Stderr = &stderr
-	err := command.Run()
-
-	output := strings.TrimSuffix(stdout.String(), "\n")
-	s.logger.Debug(command.String() + "\nstdout: " + output + "\nstderr: " + strings.TrimSuffix(stderr.String(), "\n"))
-
-	return output, err
+// command returns the runner for a phpcs invocation. phpcs runs through `composer exec` and
+// inherits composer's process timeout.
+func (s *CLI) command(dir string) composer.Command {
+	return composer.Command{New: execCommand, Logger: s.logger, Dir: dir}
 }
 
 type ReturnOutput struct {
@@ -81,8 +54,10 @@ type ReturnOutputTotals struct {
 	Fixable  int `json:"fixable"`
 }
 
+// Run reports the violations. Split, not combined: a PHP notice on stderr would corrupt the
+// JSON report.
 func (s *CLI) Run(ctx context.Context, dir string) (ReturnOutput, error) {
-	out, err := s.execComposerJSON(ctx, dir, "exec", "--", "phpcs", "--report=json", "-q", "--runtime-set", "ignore_errors_on_exit", "1", "--runtime-set", "ignore_warnings_on_exit", "1")
+	out, _, err := s.command(dir).Split(ctx, "exec", "--", "phpcs", "--report=json", "-q", "--runtime-set", "ignore_errors_on_exit", "1", "--runtime-set", "ignore_warnings_on_exit", "1")
 	if err != nil {
 		return ReturnOutput{}, err
 	}
@@ -95,6 +70,6 @@ func (s *CLI) Run(ctx context.Context, dir string) (ReturnOutput, error) {
 }
 
 func (s *CLI) RunCBF(ctx context.Context, dir string) error {
-	_, err := s.execComposer(ctx, dir, "exec", "--", "phpcbf")
+	_, err := s.command(dir).Combined(ctx, "exec", "--", "phpcbf")
 	return err
 }

--- a/pkg/rector/rector.go
+++ b/pkg/rector/rector.go
@@ -1,12 +1,10 @@
 package rector
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"strings"
 
 	"go.uber.org/zap"
 
@@ -25,23 +23,10 @@ func NewCLI(logger *zap.Logger) *CLI {
 	}
 }
 
-// execComposerJSON returns stdout only: rector's --debug output and PHP notices go to stderr
-// and would corrupt the JSON report.
-func (s *CLI) execComposerJSON(ctx context.Context, dir string, args ...string) (string, error) {
-	command := execCommand(ctx, "composer", args...)
-	command.Dir = dir
-	// rector runs through `composer exec` and inherits composer's process timeout.
-	command.Env = composer.Env(command.Environ())
-
-	var stdout, stderr bytes.Buffer
-	command.Stdout = &stdout
-	command.Stderr = &stderr
-	err := command.Run()
-
-	output := strings.TrimSuffix(stdout.String(), "\n")
-	s.logger.Debug(command.String() + "\nstdout: " + output + "\nstderr: " + strings.TrimSuffix(stderr.String(), "\n"))
-
-	return output, err
+// command returns the runner for a rector invocation. rector runs through `composer exec` and
+// inherits composer's process timeout.
+func (s *CLI) command(dir string) composer.Command {
+	return composer.Command{New: execCommand, Logger: s.logger, Dir: dir}
 }
 
 type ReturnOutput struct {
@@ -81,7 +66,9 @@ func (s *CLI) Run(ctx context.Context, dir string, customCodeDirectories []strin
 	args := []string{"exec", "--", "rector", "process", "--config=/opt/drupdater/rector.php", "--no-progress-bar", "--no-diffs", "--debug", "--output-format=json"}
 	args = append(args, customCodeDirectories...)
 
-	out, err := s.execComposerJSON(ctx, dir, args...)
+	// Split, not combined: rector's --debug output and PHP notices go to stderr and would
+	// corrupt the JSON report.
+	out, _, err := s.command(dir).Split(ctx, args...)
 
 	if err != nil {
 		return ReturnOutput{}, fmt.Errorf("failed to run composer command: %w", err)

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -49,6 +49,24 @@ type GitRepositoryService struct {
 	fs     afero.Fs
 }
 
+// BasicAuth is the credential go-git needs for an authenticated fetch, list or push.
+func BasicAuth(token string) *http.BasicAuth {
+	return &http.BasicAuth{
+		Username: "du", // yes, this can be anything except an empty string
+		Password: token,
+	}
+}
+
+// open opens the checkout at path, naming it in the error — every caller here is given the path
+// by the user or by CI, so a bad one must say which.
+func (rs *GitRepositoryService) open(path string) (*git.Repository, error) {
+	checkout, err := git.PlainOpen(path)
+	if err != nil {
+		return nil, fmt.Errorf("git open %q: %w", path, err)
+	}
+	return checkout, nil
+}
+
 func NewGitRepositoryService(logger *zap.Logger) *GitRepositoryService {
 	return &GitRepositoryService{
 		logger: logger,
@@ -74,11 +92,8 @@ func (rs *GitRepositoryService) CloneRepository(repository string, branch string
 		URL:           repository,
 		Depth:         1,
 		ReferenceName: plumbing.NewBranchReferenceName(branch),
-		Auth: &http.BasicAuth{
-			Username: "du", // yes, this can be anything except an empty string
-			Password: token,
-		},
-		Tags: git.NoTags,
+		Auth:          BasicAuth(token),
+		Tags:          git.NoTags,
 	})
 
 	if err != nil {
@@ -91,9 +106,9 @@ func (rs *GitRepositoryService) CloneRepository(repository string, branch string
 // OpenRepository opens an existing checkout instead of cloning, with the same git-user and hook
 // setup as CloneRepository so commits and pushes behave identically.
 func (rs *GitRepositoryService) OpenRepository(path string, username string, email string) (Repository, Worktree, string, error) {
-	checkout, err := git.PlainOpen(path)
+	checkout, err := rs.open(path)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("git open %q: %w", path, err)
+		return nil, nil, "", err
 	}
 	return rs.prepareCheckout(checkout, username, email)
 }
@@ -102,9 +117,9 @@ func (rs *GitRepositoryService) OpenRepository(path string, username string, ema
 // repository without being told. Embedded credentials (GitLab CI puts a token here) are
 // stripped.
 func (rs *GitRepositoryService) GetRemoteURL(path string) (string, error) {
-	checkout, err := git.PlainOpen(path)
+	checkout, err := rs.open(path)
 	if err != nil {
-		return "", fmt.Errorf("git open %q: %w", path, err)
+		return "", err
 	}
 	remote, err := checkout.Remote("origin")
 	if err != nil {
@@ -124,9 +139,9 @@ func (rs *GitRepositoryService) GetRemoteURL(path string) (string, error) {
 // GetCurrentBranch returns HEAD's branch, or "" when detached (the usual CI state) — callers
 // fall back to CI environment variables then.
 func (rs *GitRepositoryService) GetCurrentBranch(path string) (string, error) {
-	checkout, err := git.PlainOpen(path)
+	checkout, err := rs.open(path)
 	if err != nil {
-		return "", fmt.Errorf("git open %q: %w", path, err)
+		return "", err
 	}
 	head, err := checkout.Head()
 	if err != nil {
@@ -142,9 +157,9 @@ func (rs *GitRepositoryService) GetCurrentBranch(path string) (string, error) {
 // checkout commits fine but fails the later push with "object not found": the remote needs an
 // ancestry the clone does not have.
 func (rs *GitRepositoryService) IsShallowClone(path string) (bool, error) {
-	checkout, err := git.PlainOpen(path)
+	checkout, err := rs.open(path)
 	if err != nil {
-		return false, fmt.Errorf("git open %q: %w", path, err)
+		return false, err
 	}
 	shallow, err := checkout.Storer.Shallow()
 	if err != nil {
@@ -219,12 +234,7 @@ func (rs *GitRepositoryService) BranchExists(repository Repository, branch strin
 		return false, fmt.Errorf("failed to get origin remote: %w", err)
 	}
 
-	refs, err := remote.List(&git.ListOptions{
-		Auth: &http.BasicAuth{
-			Username: "du", // yes, this can be anything except an empty string
-			Password: token,
-		},
-	})
+	refs, err := remote.List(&git.ListOptions{Auth: BasicAuth(token)})
 	if err != nil {
 		return false, fmt.Errorf("failed to list remote refs: %w", err)
 	}


### PR DESCRIPTION
pkg/composer, pkg/drush, pkg/phpcs and pkg/rector each carried their own
execComposer/execComposerJSON pair doing the identical five things: build the
command, set Dir, apply composer.Env, capture output, trim the trailing
newline, and log it at Debug. Eight functions, one behaviour.

composer.Command now states it once. Each package keeps its own execCommand
variable and passes it in as the CommandFactory, so the test seams stay exactly
where they were and no test needed changing.

Combined sets one buffer on both streams rather than calling CombinedOutput,
which refuses a command whose Stdout is already set. The interleaving is the
same, which Update's output parser depends on.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KMPPYRoB9rLgAZVPLfjeAj