### PR TITLE
Register the multi-site integration fixture

### DIFF
--- a/.github/integration-fixtures.json
+++ b/.github/integration-fixtures.json
@@ -59,5 +59,64 @@
         ]
       }
     }
+  },
+  {
+    "name": "drupal-multisite",
+    "description": "Two sites sharing one codebase, so the per-site phases run concurrently against separate config trees",
+    "repository_url": "https://github.com/drupdater/test-drupal-multisite.git",
+    "branch": "main",
+    "expect": {
+      "normal": {
+        "status": [
+          "success"
+        ],
+        "min_packages": 1,
+        "packages_match": [
+          "^drupal/core"
+        ],
+        "forbid_actions": [
+          "Downgrade"
+        ],
+        "phases": [
+          "acquire working copy",
+          "preflight",
+          "composer install",
+          "baseline site install",
+          "update shared code",
+          "site update",
+          "render merge request"
+        ],
+        "addons": [
+          "update_hooks",
+          "unsupported_modules",
+          "composer_audit",
+          "translations_updater"
+        ]
+      },
+      "security": {
+        "status": [
+          "success"
+        ],
+        "min_packages": 1,
+        "audit_fixed_min": 1,
+        "forbid_actions": [
+          "Downgrade"
+        ],
+        "phases": [
+          "acquire working copy",
+          "preflight",
+          "composer install",
+          "baseline site install",
+          "update shared code",
+          "site update",
+          "render merge request"
+        ],
+        "addons": [
+          "composer_audit",
+          "unsupported_modules",
+          "update_hooks"
+        ]
+      }
+    }
   }
 ]

--- a/.github/integration-fixtures.json
+++ b/.github/integration-fixtures.json
@@ -13,9 +13,6 @@
         "packages_match": [
           "^drupal/core"
         ],
-        "forbid_actions": [
-          "Downgrade"
-        ],
         "phases": [
           "acquire working copy",
           "preflight",
@@ -40,9 +37,6 @@
         ],
         "min_packages": 1,
         "audit_fixed_min": 1,
-        "forbid_actions": [
-          "Downgrade"
-        ],
         "phases": [
           "acquire working copy",
           "preflight",

--- a/.github/integration-fixtures.json
+++ b/.github/integration-fixtures.json
@@ -74,9 +74,6 @@
         "packages_match": [
           "^drupal/core"
         ],
-        "forbid_actions": [
-          "Downgrade"
-        ],
         "phases": [
           "acquire working copy",
           "preflight",
@@ -99,9 +96,6 @@
         ],
         "min_packages": 1,
         "audit_fixed_min": 1,
-        "forbid_actions": [
-          "Downgrade"
-        ],
         "phases": [
           "acquire working copy",
           "preflight",

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -426,6 +426,12 @@ jobs:
 
           args=(--working-dir /workspace/project --report /workspace/report-second.json --dry-run)
           [ "$VERBOSE" = "true" ] && args+=(--verbose)
+          # The chown has to happen even when the run fails, so it is a trap rather than the
+          # next line: report-second.json is written on every exit path, owned by root and
+          # 0600, and set -e would otherwise skip straight past. The upload step then dies
+          # with EACCES on it and reports that instead of what actually went wrong.
+          trap 'sudo chown -R "$(id -u):$(id -g)" ./run || true' EXIT
+
           docker run --rm \
             -e DRUPALCODE_ACCESS_TOKEN \
             -v "$(pwd)/run:/workspace" \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -377,20 +377,27 @@ jobs:
         if: always() && steps.report.outputs.status == 'success'
         run: |
           set -euo pipefail
-          # A lock that does not match composer.json, or one that cannot be
-          # resolved for the target platform, makes the merge request useless
-          # however good the changelog looks. composer is in the image, so this
-          # runs against exactly the version the update itself used.
+          # A lock that does not match composer.json, or one that is internally
+          # inconsistent, makes the merge request useless however good the
+          # changelog looks. composer is in the image, so this runs against
+          # exactly the version the update itself used.
           #
           # --no-check-publish drops the rules about publishable packages
           # (name, description, license); a site is not a library. The lock
           # check is deliberately kept.
+          #
+          # --ignore-platform-reqs because drupdater passes it on every composer
+          # call it makes (pkg/composer/composer.go), so a lock it produced can
+          # legitimately require an extension this image does not carry --
+          # drupal/ai_provider_amazeeio wants ext-pgsql. Without the flag this
+          # step asserts a stronger property than drupdater ever promises, and
+          # fails on the runtime's extension set rather than on the update.
           docker run --rm -v "$(pwd)/run:/workspace" -w /workspace/project \
             --entrypoint composer drupdater:test \
             validate --no-check-publish --no-interaction | tee -a "$GITHUB_STEP_SUMMARY"
           docker run --rm -v "$(pwd)/run:/workspace" -w /workspace/project \
             --entrypoint composer drupdater:test \
-            install --dry-run --no-scripts --no-interaction \
+            install --dry-run --no-scripts --no-interaction --ignore-platform-reqs \
             | tail -20 | tee -a "$GITHUB_STEP_SUMMARY"
 
       # Running drupdater on its own output must find nothing left to do. It is

--- a/docs/explanation/how-a-run-works.md
+++ b/docs/explanation/how-a-run-works.md
@@ -62,7 +62,12 @@ The centre of the run:
 3. Run `composer update` with those constraints. **If nothing changed, the run aborts
    here** — reported as `no_changes`, exit `0`.
 4. Fire **`post-composer-update`** — the dependency diff and normalisation.
-5. Commit `composer.json` and `composer.lock`.
+5. Commit `composer.json` and `composer.lock`, together with anything else the update
+   rewrote that git already tracks — `drupal-scaffold` owns files in the web root such as
+   `.htaccess`, `robots.txt` and `index.php`, and a core update changes them. Untracked
+   paths are left alone: `vendor/`, `web/core` and the site's generated files belong to
+   nobody. Each site's `settings.php` is excluded too, because the baseline install
+   appended a throwaway SQLite database to it.
 6. Fire **`post-code-update`** — Rector, PHPCBF, and the post-update security audit.
 7. Compute the final branch name from a hash of the resulting `composer.lock`, and check
    it does not already exist.

--- a/docs/how-to/update-multiple-sites.md
+++ b/docs/how-to/update-multiple-sites.md
@@ -116,3 +116,10 @@ heading per site:
   whether it was skipped and why.
 - [`unsupported_modules`](../reference/addons/unsupported-modules.md) deduplicates across
   sites, so a module installed everywhere is listed once.
+
+## A working example
+
+[`drupdater/test-drupal-multisite`](https://github.com/drupdater/test-drupal-multisite) is
+a two-site project laid out exactly as described above, and Drupdater's integration job
+runs against it on every release. Read it if you would rather copy a working `sites.php`,
+`settings.php` and configuration layout than assemble one from the snippets here.

--- a/docs/reference/addons/code-beautifier.md
+++ b/docs/reference/addons/code-beautifier.md
@@ -9,7 +9,7 @@ a PHPCS configuration first if the project has none.
 | Events | `post-code-update` (Normal) |
 | Report key | `code_beautifier` |
 | Pull request section | *(none)* |
-| Commits | `Add PHPCS config`, `Install drupal/coder`, `Update coding styles` |
+| Commits | `Add PHPCS config`, `Install drupal/coder`, `Update coding styles`, `Remove temporary drupal/coder installation` |
 
 ## What it does
 
@@ -26,9 +26,18 @@ Two cases stop it short:
 - **A config exists but declares no `<file>` paths** — a warning is logged and the addon
   skips, rather than guessing at a scope the project deliberately left open.
 
-### Ensures `drupal/coder` is installed
+### Ensures `drupal/coder` is installed, then puts it back
 
 If absent, it is required as a dev dependency and committed as `Install drupal/coder`.
+
+It is removed again once `phpcs` and `phpcbf` have run, in a
+`Remove temporary drupal/coder installation` commit. Removing it rarely restores
+`composer.lock` byte-for-byte, so the remainder is committed here rather than left for
+another addon's `composer.*` staging to sweep into an unrelated commit.
+
+A project that already depends on `drupal/coder` keeps it: the addon only removes what it
+installed itself. Otherwise the merge request would carry a dev dependency nobody asked
+for, in a lock change the [run report](../run-report.md)'s package list never mentions.
 
 ### Fixes and commits
 

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -296,7 +296,9 @@ func (cb *CodeBeautifier) InstallCoder(ctx context.Context, path string, worktre
 // to sweep into its own commit.
 func (cb *CodeBeautifier) removeCoder(ctx context.Context, path string, worktree Worktree) error {
 	cb.logger.Debug("removing drupal/coder")
-	if _, err := cb.composer.Remove(ctx, path, "drupal/coder"); err != nil {
+	// --dev because InstallCoder required it there. Without the flag composer refuses with
+	// "could not be found in require but it is present in require-dev" and fails the run.
+	if _, err := cb.composer.Remove(ctx, path, "--dev", "drupal/coder"); err != nil {
 		return err
 	}
 

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -94,7 +94,7 @@ var hasPHPCSPathDefinitions = func(path string) (bool, error) {
 	return len(ruleset.Files) > 0, nil
 }
 
-func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error { //nolint:cyclop
+func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) (err error) { //nolint:cyclop
 	event := e.(*services.PostCodeUpdateEvent)
 	cb.logger.Info("updating coding styles")
 
@@ -122,6 +122,15 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) error { //nolint:
 		if err := cb.InstallCoder(event.Context(), event.Path(), event.Worktree()); err != nil {
 			return err
 		}
+		// Deferred rather than called at the end: every path below returns early -- nothing
+		// fixable, nothing staged, phpcs failing -- and a coder left behind is a dev dependency
+		// the project never asked for, committed into the update branch and absent from the run
+		// report's package list, which is exactly what the lock-versus-report check catches.
+		defer func() {
+			if removeErr := cb.removeCoder(event.Context(), event.Path(), event.Worktree()); removeErr != nil && err == nil {
+				err = removeErr
+			}
+		}()
 	}
 
 	codingStyleUpdateResult, err := cb.phpcs.Run(event.Context(), event.Path())
@@ -280,4 +289,27 @@ func (cb *CodeBeautifier) InstallCoder(ctx context.Context, path string, worktre
 	}
 
 	return nil
+}
+
+// removeCoder undoes InstallCoder. Removing it rarely restores composer.lock byte-for-byte, so
+// the remainder is committed here rather than left for another listener's AddGlob("composer.*")
+// to sweep into its own commit.
+func (cb *CodeBeautifier) removeCoder(ctx context.Context, path string, worktree Worktree) error {
+	cb.logger.Debug("removing drupal/coder")
+	if _, err := cb.composer.Remove(ctx, path, "drupal/coder"); err != nil {
+		return err
+	}
+
+	if err := worktree.AddGlob("composer.*"); err != nil {
+		return fmt.Errorf("failed to add file to commit: %w", err)
+	}
+	staged, err := stagedAnyOf(worktree, []string{"composer.json", "composer.lock"})
+	if err != nil {
+		return err
+	}
+	if !staged {
+		return nil
+	}
+	_, err = worktree.Commit("Remove temporary drupal/coder installation", &git.CommitOptions{})
+	return err
 }

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -456,15 +456,47 @@ func TestCodingStyles(t *testing.T) {
 		composer := NewMockComposer(t)
 		composer.EXPECT().IsPackageInstalled(anyCtx, "/tmp", "drupal/coder").Return(false, nil)
 		composer.EXPECT().Require(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
+		// Coder was installed only to run phpcs, so it has to go again -- even on this path,
+		// where there was nothing to fix. Left behind, it reaches the merge request as a dev
+		// dependency the project never asked for and that no report mentions.
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
 
 		worktree.EXPECT().AddGlob("composer.*").Return(nil)
 		worktree.EXPECT().Commit("Install drupal/coder", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
+		worktree.EXPECT().Status().Return(git.Status{
+			"composer.lock": {Staging: git.Modified},
+		}, nil).Once()
+		worktree.EXPECT().Commit("Remove temporary drupal/coder installation", &git.CommitOptions{}).
+			Return(plumbing.NewHash(""), nil)
 
 		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
 		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)
 		err := updateCodingStyles.postCodeUpdateHandler(postCodeUpdate)
 		require.NoError(t, err)
 		runner.AssertExpectations(t)
+		composer.AssertExpectations(t)
+	})
+
+	t.Run("Coder that was already installed is left alone", func(t *testing.T) {
+		// The project depends on coder itself. Removing it would be drupdater uninstalling a
+		// dependency the project chose, so IsPackageInstalled is what gates the whole cycle.
+		fileExists = func(_ string) bool { return true }
+		oldFn := hasPHPCSPathDefinitions
+		hasPHPCSPathDefinitions = func(_ string) (bool, error) { return true, nil }
+		defer func() { hasPHPCSPathDefinitions = oldFn }()
+
+		runner := NewMockPHPCS(t)
+		runner.EXPECT().Run(anyCtx, "/tmp").Return(phpcs.ReturnOutput{
+			Totals: phpcs.ReturnOutputTotals{Fixable: 0},
+			Files:  map[string]phpcs.ReturnOutputFile{},
+		}, nil)
+
+		composer := NewMockComposer(t)
+		composer.EXPECT().IsPackageInstalled(anyCtx, "/tmp", "drupal/coder").Return(true, nil)
+
+		updateCodingStyles := NewCodeBeautifier(logger, runner, composer)
+		postCodeUpdate := services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)
+		require.NoError(t, updateCodingStyles.postCodeUpdateHandler(postCodeUpdate))
 		composer.AssertExpectations(t)
 	})
 

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/drupdater/drupdater/internal/services"
@@ -460,7 +461,7 @@ func TestCodingStyles(t *testing.T) {
 		// Coder was installed only to run phpcs, so it has to go again -- even on this path,
 		// where there was nothing to fix. Left behind, it reaches the merge request as a dev
 		// dependency the project never asked for and that no report mentions.
-		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
 
 		worktree.EXPECT().AddGlob("composer.*").Return(nil)
 		worktree.EXPECT().Commit("Install drupal/coder", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
@@ -695,7 +696,7 @@ func TestRemoveCoder(t *testing.T) {
 
 	t.Run("commits the leftover lock diff", func(t *testing.T) {
 		composer := NewMockComposer(t)
-		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
 
 		worktree := NewMockWorktree(t)
 		worktree.EXPECT().AddGlob("composer.*").Return(nil)
@@ -711,7 +712,7 @@ func TestRemoveCoder(t *testing.T) {
 		// go-git rejects an empty commit, so a removal that happened to leave composer.json and
 		// composer.lock byte-for-byte identical must not try to make one.
 		composer := NewMockComposer(t)
-		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
 
 		worktree := NewMockWorktree(t)
 		worktree.EXPECT().AddGlob("composer.*").Return(nil)
@@ -723,7 +724,7 @@ func TestRemoveCoder(t *testing.T) {
 
 	t.Run("propagates a removal failure", func(t *testing.T) {
 		composer := NewMockComposer(t)
-		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", assert.AnError)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", assert.AnError)
 
 		cb := NewCodeBeautifier(logger, nil, composer)
 		require.ErrorIs(t, cb.removeCoder(context.Background(), "/tmp", NewMockWorktree(t)), assert.AnError)
@@ -731,7 +732,7 @@ func TestRemoveCoder(t *testing.T) {
 
 	t.Run("propagates a staging failure", func(t *testing.T) {
 		composer := NewMockComposer(t)
-		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
 
 		worktree := NewMockWorktree(t)
 		worktree.EXPECT().AddGlob("composer.*").Return(assert.AnError)
@@ -744,7 +745,7 @@ func TestRemoveCoder(t *testing.T) {
 
 	t.Run("propagates a status failure", func(t *testing.T) {
 		composer := NewMockComposer(t)
-		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
 
 		worktree := NewMockWorktree(t)
 		worktree.EXPECT().AddGlob("composer.*").Return(nil)
@@ -756,7 +757,7 @@ func TestRemoveCoder(t *testing.T) {
 
 	t.Run("propagates a commit failure", func(t *testing.T) {
 		composer := NewMockComposer(t)
-		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
 
 		worktree := NewMockWorktree(t)
 		worktree.EXPECT().AddGlob("composer.*").Return(nil)
@@ -788,7 +789,7 @@ func TestCoderRemovalErrorDoesNotMaskTheRealFailure(t *testing.T) {
 	composer := NewMockComposer(t)
 	composer.EXPECT().IsPackageInstalled(anyCtx, "/tmp", "drupal/coder").Return(false, nil)
 	composer.EXPECT().Require(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
-	composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", assert.AnError)
+	composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", assert.AnError)
 
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().AddGlob("composer.*").Return(nil)
@@ -820,7 +821,7 @@ func TestCoderRemovalFailureSurfacesOnAnOtherwiseCleanRun(t *testing.T) {
 	composer := NewMockComposer(t)
 	composer.EXPECT().IsPackageInstalled(anyCtx, "/tmp", "drupal/coder").Return(false, nil)
 	composer.EXPECT().Require(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
-	composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", assert.AnError)
+	composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", assert.AnError)
 
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().AddGlob("composer.*").Return(nil)
@@ -830,4 +831,57 @@ func TestCoderRemovalFailureSurfacesOnAnOtherwiseCleanRun(t *testing.T) {
 	err := cb.postCodeUpdateHandler(services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree))
 
 	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestCoderIsRemovedFromTheSectionItWasInstalledInto(t *testing.T) {
+	// Install and removal must name the same dependency section. composer rejects the mismatch
+	// outright -- "drupal/coder could not be found in require but it is present in require-dev"
+	// -- and the whole run fails in post-code-update.
+	//
+	// Asserting the two calls against each other rather than against a hard-coded flag: a mock
+	// that simply echoes back whatever the code passes will happily agree with a wrong flag, and
+	// did, until an integration run caught it.
+	logger := zap.NewNop()
+
+	fileExists = func(_ string) bool { return true }
+	oldFn := hasPHPCSPathDefinitions
+	hasPHPCSPathDefinitions = func(_ string) (bool, error) { return true, nil }
+	defer func() { hasPHPCSPathDefinitions = oldFn }()
+
+	runner := NewMockPHPCS(t)
+	runner.EXPECT().Run(anyCtx, "/tmp").Return(phpcs.ReturnOutput{
+		Totals: phpcs.ReturnOutputTotals{Fixable: 0},
+		Files:  map[string]phpcs.ReturnOutputFile{},
+	}, nil)
+
+	var requireArgs, removeArgs []string
+	composer := NewMockComposer(t)
+	composer.EXPECT().IsPackageInstalled(anyCtx, "/tmp", "drupal/coder").Return(false, nil)
+	composer.EXPECT().Require(anyCtx, "/tmp", mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, args ...string) (string, error) {
+			requireArgs = args
+			return "", nil
+		})
+	composer.EXPECT().Remove(anyCtx, "/tmp", mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, args ...string) (string, error) {
+			removeArgs = args
+			return "", nil
+		})
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().AddGlob("composer.*").Return(nil)
+	worktree.EXPECT().Commit("Install drupal/coder", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().Status().Return(git.Status{"composer.lock": {Staging: git.Modified}}, nil)
+	worktree.EXPECT().Commit("Remove temporary drupal/coder installation", &git.CommitOptions{}).
+		Return(plumbing.NewHash(""), nil)
+
+	cb := NewCodeBeautifier(logger, runner, composer)
+	require.NoError(t, cb.postCodeUpdateHandler(services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree)))
+
+	assert.Contains(t, requireArgs, "drupal/coder")
+	assert.Contains(t, removeArgs, "drupal/coder")
+	assert.Equal(t,
+		slices.Contains(requireArgs, "--dev"), slices.Contains(removeArgs, "--dev"),
+		"coder must be removed from the same section it was installed into: require=%v remove=%v",
+		requireArgs, removeArgs)
 }

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -687,4 +688,146 @@ func TestCodingStyles(t *testing.T) {
 		composer.AssertExpectations(t)
 	})
 
+}
+
+func TestRemoveCoder(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("commits the leftover lock diff", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().AddGlob("composer.*").Return(nil)
+		worktree.EXPECT().Status().Return(git.Status{"composer.lock": {Staging: git.Modified}}, nil)
+		worktree.EXPECT().Commit("Remove temporary drupal/coder installation", &git.CommitOptions{}).
+			Return(plumbing.NewHash(""), nil)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+		require.NoError(t, cb.removeCoder(context.Background(), "/tmp", worktree))
+	})
+
+	t.Run("commits nothing when the removal restored the lock", func(t *testing.T) {
+		// go-git rejects an empty commit, so a removal that happened to leave composer.json and
+		// composer.lock byte-for-byte identical must not try to make one.
+		composer := NewMockComposer(t)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().AddGlob("composer.*").Return(nil)
+		worktree.EXPECT().Status().Return(git.Status{"composer.lock": {Staging: git.Unmodified}}, nil)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+		require.NoError(t, cb.removeCoder(context.Background(), "/tmp", worktree))
+	})
+
+	t.Run("propagates a removal failure", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", assert.AnError)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+		require.ErrorIs(t, cb.removeCoder(context.Background(), "/tmp", NewMockWorktree(t)), assert.AnError)
+	})
+
+	t.Run("propagates a staging failure", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().AddGlob("composer.*").Return(assert.AnError)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+		err := cb.removeCoder(context.Background(), "/tmp", worktree)
+		require.ErrorIs(t, err, assert.AnError)
+		assert.Contains(t, err.Error(), "failed to add file to commit")
+	})
+
+	t.Run("propagates a status failure", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().AddGlob("composer.*").Return(nil)
+		worktree.EXPECT().Status().Return(nil, assert.AnError)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+		require.ErrorIs(t, cb.removeCoder(context.Background(), "/tmp", worktree), assert.AnError)
+	})
+
+	t.Run("propagates a commit failure", func(t *testing.T) {
+		composer := NewMockComposer(t)
+		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", nil)
+
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().AddGlob("composer.*").Return(nil)
+		worktree.EXPECT().Status().Return(git.Status{"composer.json": {Staging: git.Modified}}, nil)
+		worktree.EXPECT().Commit("Remove temporary drupal/coder installation", &git.CommitOptions{}).
+			Return(plumbing.ZeroHash, assert.AnError)
+
+		cb := NewCodeBeautifier(logger, nil, composer)
+		require.ErrorIs(t, cb.removeCoder(context.Background(), "/tmp", worktree), assert.AnError)
+	})
+}
+
+func TestCoderRemovalErrorDoesNotMaskTheRealFailure(t *testing.T) {
+	// The deferred cleanup reports its own failure only when the handler was otherwise fine.
+	// Letting it overwrite a live error would replace "phpcs blew up" with "could not uninstall
+	// coder", and the run report would name the wrong cause.
+	logger := zap.NewNop()
+
+	fileExists = func(_ string) bool { return true }
+	oldFn := hasPHPCSPathDefinitions
+	hasPHPCSPathDefinitions = func(_ string) (bool, error) { return true, nil }
+	defer func() { hasPHPCSPathDefinitions = oldFn }()
+
+	phpcsErr := errors.New("phpcs exploded")
+
+	runner := NewMockPHPCS(t)
+	runner.EXPECT().Run(anyCtx, "/tmp").Return(phpcs.ReturnOutput{}, phpcsErr)
+
+	composer := NewMockComposer(t)
+	composer.EXPECT().IsPackageInstalled(anyCtx, "/tmp", "drupal/coder").Return(false, nil)
+	composer.EXPECT().Require(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
+	composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", assert.AnError)
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().AddGlob("composer.*").Return(nil)
+	worktree.EXPECT().Commit("Install drupal/coder", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
+
+	cb := NewCodeBeautifier(logger, runner, composer)
+	err := cb.postCodeUpdateHandler(services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree))
+
+	require.ErrorIs(t, err, phpcsErr)
+	require.NotErrorIs(t, err, assert.AnError)
+}
+
+func TestCoderRemovalFailureSurfacesOnAnOtherwiseCleanRun(t *testing.T) {
+	// The mirror image: nothing else went wrong, so the cleanup failure is the run's failure.
+	// Swallowing it would leave coder in the committed lock with the run still reported green.
+	logger := zap.NewNop()
+
+	fileExists = func(_ string) bool { return true }
+	oldFn := hasPHPCSPathDefinitions
+	hasPHPCSPathDefinitions = func(_ string) (bool, error) { return true, nil }
+	defer func() { hasPHPCSPathDefinitions = oldFn }()
+
+	runner := NewMockPHPCS(t)
+	runner.EXPECT().Run(anyCtx, "/tmp").Return(phpcs.ReturnOutput{
+		Totals: phpcs.ReturnOutputTotals{Fixable: 0},
+		Files:  map[string]phpcs.ReturnOutputFile{},
+	}, nil)
+
+	composer := NewMockComposer(t)
+	composer.EXPECT().IsPackageInstalled(anyCtx, "/tmp", "drupal/coder").Return(false, nil)
+	composer.EXPECT().Require(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
+	composer.EXPECT().Remove(anyCtx, "/tmp", []string{"drupal/coder"}).Return("", assert.AnError)
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().AddGlob("composer.*").Return(nil)
+	worktree.EXPECT().Commit("Install drupal/coder", &git.CommitOptions{}).Return(plumbing.NewHash(""), nil)
+
+	cb := NewCodeBeautifier(logger, runner, composer)
+	err := cb.postCodeUpdateHandler(services.NewPostCodeUpdateEvent(t.Context(), "/tmp", worktree))
+
+	require.ErrorIs(t, err, assert.AnError)
 }

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -366,6 +366,15 @@ func (ws *WorkflowBaseService) stageScaffoldChanges(ctx context.Context, path st
 
 	staged := make([]string, 0, len(candidates))
 	for _, file := range candidates {
+		// Confined to the web root, because that is the only tree drupal-scaffold writes to.
+		// Everything outside it that a run touches belongs to a later phase: the configuration
+		// export and the translations update each commit their own directories, per site, after
+		// the sites have been updated. Sweeping those in here would commit them mid-update, in
+		// the state the baseline install left them -- core.extension.yml still carrying the
+		// installer's sqlite entry, for one.
+		if !strings.HasPrefix(file, webroot+"/") {
+			continue
+		}
 		if _, skip := excluded[file]; skip {
 			continue
 		}

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"text/template"
@@ -319,6 +320,66 @@ func (ws *WorkflowBaseService) acquireWorkingCopy(username, email string) (GitRe
 	return ws.repository.OpenRepository(ws.config.WorkingDir, username, email)
 }
 
+// stageScaffoldChanges stages what the dependency update rewrote outside composer.*.
+//
+// drupal-scaffold owns files in the web root -- .htaccess, robots.txt, index.php, update.php --
+// and a core update rewrites them. They are not covered by the composer.* glob, so without this
+// the run ends with a dirty working tree and the merge request omits changes the project is
+// expected to carry.
+//
+// Only paths git already tracks are staged. Untracked ones are left alone on purpose: vendor/,
+// web/core and the site's generated files legitimately sit in the checkout and belong to nobody.
+//
+// Each site's settings.php is excluded even though it is tracked and modified: the installer
+// appends the throwaway SQLite database to it (pkg/drupal/installer.go), and committing that
+// would put test credentials and a local path into the merge request.
+func (ws *WorkflowBaseService) stageScaffoldChanges(ctx context.Context, path string, worktree Worktree) error {
+	status, err := worktree.Status()
+	if err != nil {
+		return fmt.Errorf("failed to read worktree status: %w", err)
+	}
+
+	// Sorted so the staging order does not depend on map iteration, keeping a run's commit
+	// reproducible.
+	candidates := make([]string, 0, len(status))
+	for file, fileStatus := range status {
+		if fileStatus.Worktree == git.Untracked || fileStatus.Worktree == git.Unmodified {
+			continue
+		}
+		candidates = append(candidates, file)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	slices.Sort(candidates)
+
+	// Only looked up once there is something to stage: an update that rewrote nothing outside
+	// composer.* has no reason to shell out to composer again.
+	webroot, err := composer.WebRoot(ctx, ws.composer, path)
+	if err != nil {
+		return fmt.Errorf("failed to determine web root: %w", err)
+	}
+	excluded := make(map[string]struct{}, len(ws.config.Sites))
+	for _, site := range ws.config.Sites {
+		excluded[filepath.Join(webroot, "sites", site, "settings.php")] = struct{}{}
+	}
+
+	staged := make([]string, 0, len(candidates))
+	for _, file := range candidates {
+		if _, skip := excluded[file]; skip {
+			continue
+		}
+		if _, err := worktree.Add(file); err != nil {
+			return fmt.Errorf("failed to stage %s: %w", file, err)
+		}
+		staged = append(staged, file)
+	}
+	if len(staged) > 0 {
+		ws.logger.Info("staged scaffold changes", zap.Strings("files", staged))
+	}
+	return nil
+}
+
 // forEachSite runs fn for every configured site concurrently, bounded by config.Concurrency
 // (or GOMAXPROCS(0), which reflects the container's CPU quota, when unset), and cancels the
 // rest on the first error.
@@ -417,6 +478,9 @@ func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository 
 
 	if err := worktree.AddGlob("composer.*"); err != nil {
 		return "", fmt.Errorf("failed to add composer.* files: %w", err)
+	}
+	if err := ws.stageScaffoldChanges(ctx, path, worktree); err != nil {
+		return "", err
 	}
 	if _, err := worktree.Commit("Update composer.json and composer.lock", &git.CommitOptions{}); err != nil {
 		return "", fmt.Errorf("failed to commit composer.json and composer.lock: %w", err)

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -46,6 +46,7 @@ func TestStartUpdate(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -118,6 +119,7 @@ func TestStartUpdatePublishUsesLiveContext(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -186,6 +188,7 @@ func TestStartUpdateSiteFailureDoesNotPublish(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
@@ -391,6 +394,7 @@ func TestStartUpdateBranchAlreadyExists(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	// updateSharedCode checks out a dedicated work branch before doing any work.
 	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
 
@@ -456,6 +460,7 @@ func TestStartUpdateLocalBranchAlreadyExists(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
@@ -512,6 +517,7 @@ func TestStartUpdateLocalBranchLookupError(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
@@ -564,6 +570,7 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -628,6 +635,7 @@ func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -696,6 +704,7 @@ func TestPublishWorkDeletesBranchOnMRFailure(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -757,6 +766,7 @@ func TestPublishWorkLogsWarningWhenDeleteBranchFails(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -820,6 +830,7 @@ func TestPublishWorkPushFails(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -877,6 +888,7 @@ func TestStartUpdateGetLockHashError(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	// updateSharedCode checks out a dedicated work branch before doing any work.
 	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
 
@@ -925,6 +937,7 @@ func TestStartUpdateBranchExistsError(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	// updateSharedCode checks out a dedicated work branch before doing any work.
 	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
 
@@ -975,6 +988,7 @@ func TestStartUpdateConfigResaveError(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -1027,6 +1041,7 @@ func TestStartUpdateExportConfigurationError(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -1081,6 +1096,7 @@ func TestStartUpdateWithAutoMerge(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -1145,6 +1161,7 @@ func TestStartUpdateAutoMergeError(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -1208,6 +1225,7 @@ func TestStartUpdateAutoMergeSkippedWhenDisabled(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
@@ -1331,6 +1349,7 @@ func TestStartUpdateUsesExistingCheckout(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
 
 	installer.EXPECT().Install(anyCtx, checkout, "site1").Return(nil)
@@ -1497,6 +1516,7 @@ func TestStartUpdateDoesNotRestoreCheckoutOnSuccess(t *testing.T) {
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
 	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	// Only the work-branch/final-branch checkouts happen; no restore checkout on success.
 	worktree.EXPECT().Checkout(mock.Anything).Return(nil).Twice()
 
@@ -1761,3 +1781,106 @@ var workBranchCheckout = mock.MatchedBy(func(opts *git.CheckoutOptions) bool {
 		(strings.HasPrefix(opts.Branch.Short(), "drupdater-work-") ||
 			strings.HasPrefix(opts.Branch.Short(), "update-"))
 })
+
+func TestStageScaffoldChanges(t *testing.T) {
+	logger := zap.NewNop()
+
+	newComposer := func(webroot string) *MockComposer {
+		c := NewMockComposer(t)
+		c.EXPECT().GetConfig(mock.Anything, "/project", "extra.drupal-scaffold.locations.web-root").
+			Return(webroot, nil).Maybe()
+		return c
+	}
+
+	t.Run("stages tracked changes and leaves untracked files alone", func(t *testing.T) {
+		// A core update rewrites the scaffolded files; vendor/ is untracked and belongs to nobody.
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Status().Return(git.Status{
+			"web/.htaccess":       {Worktree: git.Modified},
+			"web/robots.txt":      {Worktree: git.Modified},
+			"web/core/foo.php":    {Worktree: git.Untracked},
+			"vendor/autoload.php": {Worktree: git.Untracked},
+			"README.md":           {Worktree: git.Unmodified},
+		}, nil)
+
+		var staged []string
+		worktree.EXPECT().Add(mock.Anything).RunAndReturn(func(path string) (plumbing.Hash, error) {
+			staged = append(staged, path)
+			return plumbing.ZeroHash, nil
+		})
+
+		ws := &WorkflowBaseService{
+			logger:   logger,
+			config:   internal.Config{Sites: []string{"default"}},
+			composer: newComposer("web/"),
+		}
+
+		require.NoError(t, ws.stageScaffoldChanges(context.Background(), "/project", worktree))
+		// Sorted, so the commit a run produces does not depend on map iteration order.
+		assert.Equal(t, []string{"web/.htaccess", "web/robots.txt"}, staged)
+	})
+
+	t.Run("never stages a site's settings.php", func(t *testing.T) {
+		// The installer appends the throwaway SQLite database to it. Committing that would put
+		// test credentials and a local path into the merge request.
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Status().Return(git.Status{
+			"web/sites/default/settings.php": {Worktree: git.Modified},
+			"web/sites/second/settings.php":  {Worktree: git.Modified},
+			"web/robots.txt":                 {Worktree: git.Modified},
+		}, nil)
+
+		var staged []string
+		worktree.EXPECT().Add(mock.Anything).RunAndReturn(func(path string) (plumbing.Hash, error) {
+			staged = append(staged, path)
+			return plumbing.ZeroHash, nil
+		})
+
+		ws := &WorkflowBaseService{
+			logger:   logger,
+			config:   internal.Config{Sites: []string{"default", "second"}},
+			composer: newComposer("web/"),
+		}
+
+		require.NoError(t, ws.stageScaffoldChanges(context.Background(), "/project", worktree))
+		assert.Equal(t, []string{"web/robots.txt"}, staged)
+	})
+
+	t.Run("propagates a status failure", func(t *testing.T) {
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Status().Return(nil, errors.New("boom"))
+
+		ws := &WorkflowBaseService{logger: logger, composer: newComposer("web/")}
+
+		err := ws.stageScaffoldChanges(context.Background(), "/project", worktree)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read worktree status")
+	})
+
+	t.Run("propagates a web root failure", func(t *testing.T) {
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Status().Return(git.Status{"web/robots.txt": {Worktree: git.Modified}}, nil)
+
+		composerCLI := NewMockComposer(t)
+		composerCLI.EXPECT().GetConfig(mock.Anything, "/project", "extra.drupal-scaffold.locations.web-root").
+			Return("", errors.New("no web root"))
+
+		ws := &WorkflowBaseService{logger: logger, composer: composerCLI}
+
+		err := ws.stageScaffoldChanges(context.Background(), "/project", worktree)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to determine web root")
+	})
+
+	t.Run("propagates a staging failure", func(t *testing.T) {
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Status().Return(git.Status{"web/robots.txt": {Worktree: git.Modified}}, nil)
+		worktree.EXPECT().Add("web/robots.txt").Return(plumbing.ZeroHash, errors.New("locked"))
+
+		ws := &WorkflowBaseService{logger: logger, composer: newComposer("web/")}
+
+		err := ws.stageScaffoldChanges(context.Background(), "/project", worktree)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to stage web/robots.txt")
+	})
+}

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -1884,3 +1884,48 @@ func TestStageScaffoldChanges(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to stage web/robots.txt")
 	})
 }
+
+func TestStartUpdateFailsWhenScaffoldChangesCannotBeStaged(t *testing.T) {
+	// Staging what the update rewrote is part of producing the commit, not a nicety: if it
+	// fails, the run must fail rather than push a branch missing the scaffold changes.
+	logger := zap.NewNop()
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	expectVersionLookup(mockComposer)
+	drush := NewMockDrush(t)
+
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Clone:         true,
+		Sites:         []string{"site1"},
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(nil, assert.AnError)
+
+	installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil)
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").
+		Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound).Maybe()
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+
+	mockComposer.EXPECT().CheckPlatformReqs(anyCtx, "/tmp").Return("", nil)
+	mockComposer.EXPECT().Install(anyCtx, "/tmp").Return(nil)
+	mockComposer.EXPECT().Update(anyCtx, "/tmp", mock.Anything, mock.Anything, false, false).
+		Return([]composer.PackageChange{{Package: "drupal/core", From: "9.0.0", To: "9.1.0"}}, nil)
+
+	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+	err := workflowService.StartUpdate(context.Background(), nil)
+
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "failed to read worktree status")
+}

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -1820,6 +1820,41 @@ func TestStageScaffoldChanges(t *testing.T) {
 		assert.Equal(t, []string{"web/.htaccess", "web/robots.txt"}, staged)
 	})
 
+	t.Run("stages nothing outside the web root", func(t *testing.T) {
+		// Regression: staging every tracked change swept the configuration export and the
+		// translations into the shared-code commit, in the state the baseline install had left
+		// them -- core.extension.yml still carrying the installer's sqlite entry. The next run
+		// then refused to install from that configuration ("Unable to uninstall the SQLite
+		// module because: The module 'SQLite' is providing the database driver 'sqlite'"), so
+		// the update looked fine and was not reinstallable. Those trees belong to the per-site
+		// export, which commits them itself, after the sites have been updated.
+		worktree := NewMockWorktree(t)
+		worktree.EXPECT().Status().Return(git.Status{
+			"web/robots.txt":                 {Worktree: git.Modified},
+			"config/sync/core.extension.yml": {Worktree: git.Modified},
+			"config/second/system.site.yml":  {Worktree: git.Modified},
+			"translations/drupal.de.po":      {Worktree: git.Modified},
+			"webhooks/notes.md":              {Worktree: git.Modified},
+		}, nil)
+
+		var staged []string
+		worktree.EXPECT().Add(mock.Anything).RunAndReturn(func(path string) (plumbing.Hash, error) {
+			staged = append(staged, path)
+			return plumbing.ZeroHash, nil
+		})
+
+		ws := &WorkflowBaseService{
+			logger:   logger,
+			config:   internal.Config{Sites: []string{"default"}},
+			composer: newComposer("web/"),
+		}
+
+		require.NoError(t, ws.stageScaffoldChanges(context.Background(), "/project", worktree))
+		// "webhooks/" is in the list because a prefix match on "web" rather than "web/" would
+		// pull it in.
+		assert.Equal(t, []string{"web/robots.txt"}, staged)
+	})
+
 	t.Run("never stages a site's settings.php", func(t *testing.T) {
 		// The installer appends the throwaway SQLite database to it. Committing that would put
 		// test credentials and a local path into the merge request.

--- a/internal/services/workflow_report_test.go
+++ b/internal/services/workflow_report_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/drupdater/drupdater/internal/codehosting"
 	"github.com/drupdater/drupdater/internal/report"
 	"github.com/drupdater/drupdater/pkg/composer"
+	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
@@ -88,6 +89,7 @@ func (h *reportHarness) expectFullRun(t *testing.T) {
 
 	h.worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil).Maybe()
 	h.worktree.EXPECT().AddGlob(mock.Anything).Return(nil).Maybe()
+	h.worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
 	h.worktree.EXPECT().Checkout(mock.Anything).Return(nil).Maybe()
 
 	h.installer.EXPECT().Install(anyCtx, "/tmp", "site1").Return(nil).Maybe()

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -156,6 +156,13 @@ func (s *CLI) Update(ctx context.Context, dir string, packages []string, package
 
 	// Grouped by action rather than scanned line by line, so the result stays ordered by action
 	// however composer interleaved its output.
+	//
+	// Deduplicated because composer reports a version change twice: once resolving the lock
+	// ("Lock file operations") and again installing it ("Package operations"), in identical
+	// wording. Installs differ between the two ("Locking" vs "Installing") and only the second is
+	// matched, so nothing is lost by keeping the first of each. One update produces at most one
+	// operation per package, so an exact repeat is always the same operation seen twice.
+	seen := make(map[PackageChange]struct{})
 	for _, pattern := range packageChangePatterns {
 		for _, match := range pattern.re.FindAllStringSubmatch(out, -1) {
 			change := PackageChange{Action: pattern.action, Package: match[1]}
@@ -165,6 +172,10 @@ func (s *CLI) Update(ctx context.Context, dir string, packages []string, package
 			if pattern.to > 0 {
 				change.To = match[pattern.to]
 			}
+			if _, ok := seen[change]; ok {
+				continue
+			}
+			seen[change] = struct{}{}
 			changes = append(changes, change)
 		}
 	}

--- a/pkg/composer/composer_extra_test.go
+++ b/pkg/composer/composer_extra_test.go
@@ -204,6 +204,59 @@ func TestUpdatePropagatesFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to update dependencies")
 }
 
+func TestUpdateDeduplicatesTheTwoOperationSections(t *testing.T) {
+	// composer reports a version change twice -- once resolving the lock, once installing it --
+	// in identical wording, so a naive scan reports every upgrade and downgrade double. That
+	// reaches the run report's .packages and the merge request's dependency table, where a
+	// reviewer sees each package listed twice.
+	//
+	// Installs are worded differently per section ("Locking" vs "Installing") and only the
+	// second form is matched, so they must still arrive exactly once.
+	stubComposerOutput(t, `Loading composer repositories with package information
+Updating dependencies
+Lock file operations: 1 install, 2 updates, 1 removal
+  - Upgrading drupal/core (11.3.9 => 11.4.4)
+  - Downgrading justinrainbow/json-schema (6.10.0 => 6.8.2)
+  - Locking symfony/runtime (v7.4.14)
+  - Removing marc-mabe/php-enum (v4.7.2)
+Writing lock file
+Installing dependencies from lock file (including require-dev)
+Package operations: 1 install, 2 updates, 1 removal
+  - Upgrading drupal/core (11.3.9 => 11.4.4)
+  - Downgrading justinrainbow/json-schema (6.10.0 => 6.8.2)
+  - Installing symfony/runtime (v7.4.14)
+  - Removing marc-mabe/php-enum (v4.7.2)
+Generating autoload files`)
+
+	service := &CLI{logger: zap.NewNop()}
+	changes, err := service.Update(t.Context(), "/tmp", nil, nil, false, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []PackageChange{
+		{Action: "Upgrade", Package: "drupal/core", From: "11.3.9", To: "11.4.4"},
+		{Action: "Downgrade", Package: "justinrainbow/json-schema", From: "6.10.0", To: "6.8.2"},
+		{Action: "Remove", Package: "marc-mabe/php-enum", From: "v4.7.2"},
+		{Action: "Install", Package: "symfony/runtime", To: "v7.4.14"},
+	}, changes)
+}
+
+func TestUpdateKeepsDistinctChangesToTheSamePackage(t *testing.T) {
+	// Dedup keys on the whole change, not the package name: a repeat is only dropped when every
+	// field matches, so a package genuinely reported with different versions still comes through.
+	stubComposerOutput(t, `Package operations: 0 installs, 2 updates, 0 removals
+  - Upgrading drupal/core (11.3.9 => 11.4.4)
+  - Upgrading drupal/core (11.4.4 => 11.4.5)`)
+
+	service := &CLI{logger: zap.NewNop()}
+	changes, err := service.Update(t.Context(), "/tmp", nil, nil, false, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []PackageChange{
+		{Action: "Upgrade", Package: "drupal/core", From: "11.3.9", To: "11.4.4"},
+		{Action: "Upgrade", Package: "drupal/core", From: "11.4.4", To: "11.4.5"},
+	}, changes)
+}
+
 func TestUpdateBuildsArgs(t *testing.T) {
 	// The flags that shape a run are assembled here, so assert they reach composer: package
 	// filters, --with pins, --minimal-changes, and --dry-run vs --bump-after-update.

--- a/pkg/drupal/installer.go
+++ b/pkg/drupal/installer.go
@@ -76,8 +76,27 @@ func (is *Installer) ConfigureDatabase(ctx context.Context, dir string, site str
 	}
 
 	settingsPath := dir + "/" + webroot + "/sites/" + site + "/settings.php"
+
+	// Ensured on every call, ahead of the marker check below, because the two states are
+	// independent. settings.php survives a run -- it is deliberately never committed -- while
+	// core.extension.yml comes back from git whenever the working copy is reused, and the
+	// configuration export writes it without sqlite (config_exclude_modules sees to that). A
+	// second run in the same directory therefore finds the marker set and the module entry gone,
+	// and Drupal refuses to install: "Unable to uninstall the SQLite module because: The module
+	// 'SQLite' is providing the database driver 'sqlite'".
+	isSqliteEnabled, _ := is.isSqliteModuleEnabled(ctx, dir, site)
+	if !isSqliteEnabled {
+		siteLogger.Debug("enabling sqlite module")
+		if err := is.addSqliteModule(ctx, dir, site); err != nil {
+			return fmt.Errorf("failed to enable sqlite module: %w", err)
+		}
+	}
+
+	// The marker guards only the append: without it a repeated call stacks a second $databases
+	// block onto the file. config_exclude_modules is part of that append, so it is already there
+	// from the first call.
 	if existing, err := afero.ReadFile(is.fs, settingsPath); err == nil && strings.Contains(string(existing), settingsMarker) {
-		siteLogger.Debug("database already configured, skipping", zap.String("path", settingsPath))
+		siteLogger.Debug("settings already configured, skipping", zap.String("path", settingsPath))
 		return nil
 	}
 
@@ -98,12 +117,7 @@ $settings['file_private_path'] = '` + privatesDir + `';
 $settings['hash_salt'] = 'changeme';
 `
 
-	isSqliteEnabled, _ := is.isSqliteModuleEnabled(ctx, dir, site)
 	if !isSqliteEnabled {
-		siteLogger.Debug("enabling sqlite module")
-		if err := is.addSqliteModule(ctx, dir, site); err != nil {
-			return fmt.Errorf("failed to enable sqlite module: %w", err)
-		}
 		settings += `
 if (isset($settings['config_exclude_modules'])) {
 	$settings['config_exclude_modules'][] = 'sqlite';

--- a/pkg/drupal/installer_extra_test.go
+++ b/pkg/drupal/installer_extra_test.go
@@ -121,8 +121,8 @@ func TestConfigureDatabaseIsIdempotent(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(first, settingsMarker))
 	assert.Equal(t, 1, strings.Count(first, "$settings['hash_salt']"))
 
-	// Second call: the marker is present, so it must return early without touching the file.
-	// GetConfig is still needed to locate settings.php; GetConfigSyncDir is not reached.
+	// Second call: the marker is present, so the append is skipped without touching the file.
+	// core.extension.yml is still checked, which is why GetConfigSyncDir is reached again.
 	require.NoError(t, installer.ConfigureDatabase(t.Context(), "/project", "site1"))
 
 	after, err = afero.ReadFile(fs, "/project/web/sites/site1/settings.php")
@@ -131,7 +131,7 @@ func TestConfigureDatabaseIsIdempotent(t *testing.T) {
 
 	// The skip is only visible in the log, so without this a silent second write and a correct
 	// skip would look identical from the outside.
-	assert.Equal(t, 1, logs.FilterMessage("database already configured, skipping").Len())
+	assert.Equal(t, 1, logs.FilterMessage("settings already configured, skipping").Len())
 	assert.Equal(t, 1, logs.FilterMessage("writing settings").Len())
 	writing := logs.FilterMessage("writing settings").All()[0].ContextMap()
 	assert.Equal(t, "/project/web/sites/site1/settings.php", writing["path"])
@@ -330,4 +330,39 @@ func TestRemoveProfileErrors(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(out), "profile: thunder")
 	})
+}
+
+func TestConfigureDatabaseRestoresSqliteOnAReusedWorkingCopy(t *testing.T) {
+	// Regression: settings.php and core.extension.yml go out of sync across runs, and only
+	// settings.php carries the marker.
+	//
+	// settings.php is deliberately never committed, so it survives a run with the marker in it.
+	// core.extension.yml does get committed, and the configuration export writes it *without*
+	// sqlite because config_exclude_modules excludes it. Reuse the working copy -- which is
+	// exactly what the integration job's idempotency check does, and what any CI runner with a
+	// cached checkout does -- and the second run finds the marker set and the module entry gone.
+	//
+	// Guarding the module entry behind the marker therefore left the site uninstallable:
+	// "Unable to uninstall the SQLite module because: The module 'SQLite' is providing the
+	// database driver 'sqlite'".
+	settingsFromEarlierRun := "<?php\n\n" + settingsMarker + "\n$databases['default']['default'] = [];\n"
+	installer, fs, drush, composer := newTestInstaller(t, coreExtensionWithoutSqlite, settingsFromEarlierRun)
+
+	composer.EXPECT().GetConfig(t.Context(), "/project", "extra.drupal-scaffold.locations.web-root").Return("web", nil)
+	drush.EXPECT().GetConfigSyncDir(t.Context(), "/project", "site1", false).Return("/config/sync", nil)
+
+	require.NoError(t, installer.ConfigureDatabase(t.Context(), "/project", "site1"))
+
+	core, err := afero.ReadFile(fs, "/config/sync/core.extension.yml")
+	require.NoError(t, err)
+	var parsed map[string]any
+	require.NoError(t, yaml.Unmarshal(core, &parsed))
+	assert.Equal(t, 0, parsed["module"].(map[string]any)["sqlite"],
+		"sqlite must be put back even though settings.php was already configured")
+
+	// The append stays skipped: the marker still does its original job.
+	after, err := afero.ReadFile(fs, "/project/web/sites/site1/settings.php")
+	require.NoError(t, err)
+	assert.Equal(t, settingsFromEarlierRun, string(after),
+		"settings.php must not gain a second database block")
 }


### PR DESCRIPTION
## Why

The per-site half of a run — baseline install, update hooks, config export, all of it concurrent via `forEachSite` — has no end-to-end coverage. The only fixture, `test-drupal-cms`, is `sites: [default]`, so `SITE_NAME` resolution, separate config trees per site and the addon mutexes are tested against an in-memory filesystem and nothing else.

## What

Adds [`drupdater/test-drupal-multisite`](https://github.com/drupdater/test-drupal-multisite) as a second fixture: two sites on one codebase, deliberately lighter than `test-drupal-cms` (plain `recommended-project`, no recipe stack) because a normal-mode run installs Drupal four times — two sites, twice over for the idempotency check.

The two sites differ in every way that matters:

| | `default` | `second` |
|---|---|---|
| Configuration | `config/default` (187 objects) | `config/second` (194 objects) |
| Languages | `en` + `de` | `en` |
| `locale` / `locale_deploy` | enabled | not enabled |
| Contrib enabled | — | `pathauto`, `redirect`, `token` |
| `translations_updater` reports | `updated` | a skip reason |

That last row is the point: it drives **both** branches of the `translations_updater` assertion in `.github/assert-report.jq`, which requires every reported site to be either updated or explicitly skipped. The differing module lists give `unsupported_modules` two sets to deduplicate across instead of one.

`composer.lock` is frozen at core 11.3.9 — a minor behind current, so `update_hooks` has `hook_update_N` to find, and below the `<11.3.10` advisory floor, so `--security` mode has something to fix.

The diff here is two files: the fixture entry, and a pointer from `docs/how-to/update-multiple-sites.md`, which showed snippets but named no project to copy them from.

## Verified

Against the pushed fixture:

- `drupdater check --full` passes every check, including `site "default"/"second" installs from configuration` — both sites install in a fresh clone through drupdater's own installer.
- `SITE_NAME=default|second` resolves to two different sites and two different config sync directories.
- A full cycle — reinstall both sites from committed config, export back, regenerate translations — leaves the working tree clean.
- `composer validate` clean; `composer audit --locked` non-empty (38 advisories); `composer outdated --direct --locked` shows core 11.3.9 → 11.4.4.
- `mkdocs build --strict` passes.

Not verified locally: a complete drupdater run, which needs the Docker image. That is what the `integration-test` label is for — worth applying to this PR before merging.