### PR TITLE
docs: tighten the comment rules in CLAUDE.md

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,7 @@
 name: docs
 
-# Builds the documentation site and publishes it to the gh-pages branch of
-# drupdater/drupdater.github.io, which GitHub Pages serves at https://drupdater.github.io/.
-#
-# The sources live here, beside the code, so a change to a flag or an addon updates its own
-# documentation in the same pull request. Only the built HTML is pushed to the site repository.
+# Builds docs/ and publishes the HTML to drupdater.github.io's gh-pages branch. The sources
+# live beside the code so a flag change updates its own documentation in the same pull request.
 on:
   push:
     branches: [main]
@@ -12,8 +9,7 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "requirements-docs.txt"
-      # Snippet sources: these files are embedded into pages verbatim, so a change to one
-      # changes the published site even though it is not under docs/.
+      # Embedded into pages verbatim, so a change here changes the published site.
       - "internal/addon/testdata/**"
       - ".github/assert-report.jq"
       - ".github/assert-lock-matches-report.jq"
@@ -42,12 +38,9 @@ jobs:
 
       - run: pip install -r requirements-docs.txt
 
-      # --strict fails the build on a broken internal link or a nav entry pointing at a
-      # file that does not exist, so a bad link is caught here rather than published.
-      #
-      # DRUPDATER_GOATCOUNTER is what puts the analytics script into the pages. It is set
-      # here and nowhere else, so only the published site is counted — a contributor
-      # running mkdocs serve or make docs-build gets no tracking script.
+      # --strict catches a broken link or nav entry here rather than publishing it.
+      # DRUPDATER_GOATCOUNTER is set here and nowhere else, so only the published site is
+      # counted and a local mkdocs serve emits no tracking script.
       - run: mkdocs build --strict
         env:
           DRUPDATER_GOATCOUNTER: "true"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -90,13 +90,8 @@ jobs:
       - name: Check for dead code
         run: go tool deadcode -test ./... | tee /tmp/deadcode.txt; [ ! -s /tmp/deadcode.txt ]
 
-  # Mutation testing, scoped to the lines this pull request touches.
-  #
-  # Line coverage only proves a line ran; this proves a test fails when the line
-  # is wrong. Scoring the whole module on every PR would take ~20 minutes and
-  # would fail on pre-existing survivors, so the gate looks at changed lines
-  # only -- new code has to be tested well, existing code is left to the weekly
-  # full run in mutation.yml.
+  # Mutation testing, scoped to the lines this pull request touches: the whole module takes
+  # ~20 minutes and would fail on pre-existing survivors. mutation.yml covers those weekly.
   mutation:
     name: mutation
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,30 +1,16 @@
 name: Integration Test
 
-# Runs drupdater end to end against real Drupal sites -- fixture repositories
-# whose composer.lock is deliberately frozen at an old resolution, so every run
-# has something to update.
+# Runs drupdater end to end against fixture repositories whose composer.lock is frozen at an old
+# resolution, so every run has something to update.
 #
-# Manual on purpose: every leg installs Drupal for real, far too slow to want on
-# every push, and the unit suite in go.yml covers the rest. The image is built
-# once and shared, so adding fixtures costs runs but not rebuilds. Two ways in:
+# Manual on purpose: every leg installs Drupal for real. Two ways in -- the "integration-test"
+# label on a PR (every fixture, both modes, always a dry run), or a dispatch aimed at one target.
 #
-#   * add the "integration-test" label to a pull request. Every fixture runs in
-#     both normal and security mode, always as a dry run, and each leg shows up
-#     as its own check on that PR. Remove and re-add the label to re-run.
-#   * dispatch from the Actions tab to aim at one target, pick the mode, or do a
-#     real non-dry run.
+# ADDING A FIXTURE: append an entry to .github/integration-fixtures.json; nothing here needs
+# editing. Beyond name/repository_url/branch/expect an entry may set `modes` (default both) and
+# `shallow` (only for asserting preflight rejects a shallow clone).
 #
-# ADDING A FIXTURE: append an entry to .github/integration-fixtures.json. The
-# label path picks it up automatically -- nothing here needs editing. Beyond
-# name/repository_url/branch/expect, an entry may set:
-#
-#   modes     which of normal/security to run; default both. Narrow it when the
-#             second mode would prove nothing -- a run that fails in preflight
-#             fails there in either mode.
-#   shallow   clone with --depth 1. Only for asserting that preflight rejects it.
-#
-# A fixture whose expect.status contains "failed" is a failure fixture: drupdater
-# is expected to exit non-zero, and the leg fails if it exits 0 instead.
+# A fixture whose expect.status contains "failed" must exit non-zero; the leg fails if it does not.
 
 on:
   pull_request:
@@ -57,24 +43,19 @@ on:
         default: false
         type: boolean
 
-# Per pull request rather than global, so labelling one PR does not cancel a run
-# already going on another.
+# Per pull request, so labelling one does not cancel a run already going on another.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Every job here only ever reads this repository: it clones the fixture over
-# plain HTTPS and talks to the fixture's remote with DRUPDATER_TEST_TOKEN, never
-# with GITHUB_TOKEN. Declared once at the top rather than per job so a job added
-# later inherits the restriction instead of silently getting the repository
-# default.
+# Read-only: fixtures are cloned over plain HTTPS and written with DRUPDATER_TEST_TOKEN, never
+# GITHUB_TOKEN. At the top so a job added later inherits the restriction.
 permissions:
   contents: read
 
 jobs:
-  # Decides what to run. A label means "everything", a dispatch means "exactly
-  # what I asked for", and keeping that decision in one place stops the matrix
-  # and the run flags from drifting apart.
+  # A label means "everything", a dispatch "exactly what I asked for". One place, so the
+  # matrix and the run flags cannot drift apart.
   plan:
     # Without this any label at all would start a run.
     if: >-
@@ -104,13 +85,9 @@ jobs:
             # One leg, exactly as asked.
             mode=normal; [ "$IN_SECURITY" = "true" ] && mode=security
             url=${IN_URL:-https://github.com/drupdater/test-drupal-cms.git}
-            # If the target happens to be a known fixture, take its expectations too, so a
-            # dispatch at the default gets the same verification a label does. Otherwise
-            # assert only the status -- a dispatch can be aimed at any repository.
-            #
-            # Matched on url AND branch, because several fixtures share a repository and
-            # differ only by branch: on the url alone a dispatch would inherit the wrong
-            # fixture's expectations, and a broken/* branch expects the opposite of main.
+            # A known target keeps its fixture's expectations, so a default dispatch is
+            # verified like a label; anything else asserts only the status. Matched on url
+            # AND branch, since fixtures share repositories and differ only by branch.
             include=$(jq -c \
               --arg n "$(basename "$url" .git)" \
               --arg u "$url" \
@@ -124,20 +101,15 @@ jobs:
             dry_run=$IN_DRY_RUN
             verbose=$IN_VERBOSE
           else
-            # A label means every fixture in every mode it declares. The default is both,
-            # because they exercise different code paths -- security mode is driven by
-            # composer_audit and updates only what has an advisory -- so one passing says
-            # nothing about the other. A fixture narrows it with "modes" when the second mode
-            # would prove nothing: a run that fails in preflight fails there either way.
+            # Both modes by default: security mode is driven by composer_audit and updates
+            # only what has an advisory, so one passing says nothing about the other.
             include=$(jq -c '[ .[] as $f | ($f.modes // ["normal","security"])[] as $m |
               {fixture:$f.name, repository_url:$f.repository_url, branch:$f.branch, mode:$m,
                shallow: ($f.shallow // false),
                expect: (($f.expect[$m] // {status:["success","no_changes"]}) | tojson)} ]' \
               .github/integration-fixtures.json)
-            # A label event carries none of the inputs above, and an unset
-            # dry_run would read as "not a dry run" -- a label would then quietly
-            # push branches and open merge requests against the fixtures. Only an
-            # explicit dispatch can turn it off.
+            # A label event carries no inputs, and an unset dry_run would read as "not a dry
+            # run" -- pushing branches to the fixtures. Only a dispatch can turn it off.
             dry_run=true
             verbose=false
           fi
@@ -153,8 +125,7 @@ jobs:
             + (if ((.expect | fromjson).status | index("failed")) then " -- expected to fail" else "" end)' \
             <<<"$include" >> "$GITHUB_STEP_SUMMARY"
 
-  # The image is identical for every leg, so build it once and pass it along as
-  # an artifact. Building per leg meant 2 builds for one fixture and 2N for N.
+  # One image for every leg, passed along as an artifact: per-leg meant 2N builds for N fixtures.
   build:
     needs: plan
     runs-on: ubuntu-latest
@@ -165,10 +136,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # One version, no matrix over PHP: this job proves drupdater works against
-      # a real site, not that Drupal runs on every PHP release. 8.4 has to match
-      # the target's config.platform.php -- its lock is resolved for 8.4.1 and
-      # pulls in Symfony 8, which will not install on anything earlier.
+      # No matrix over PHP: this proves drupdater works against a real site, not that Drupal
+      # runs everywhere. 8.4 has to match the target's config.platform.php.
       - name: Build Docker image
         uses: docker/build-push-action@v7
         with:
@@ -192,9 +161,8 @@ jobs:
     needs: [plan, build]
     name: ${{ matrix.fixture }} / ${{ matrix.mode }}
     runs-on: ubuntu-latest
-    # Generous because the normal-mode legs run drupdater a second time to check
-    # the update is idempotent, and that second run installs the site again
-    # before it gets as far as composer update.
+    # Generous: the normal-mode legs run drupdater twice, and the second run reinstalls the
+    # site before it reaches composer update.
     timeout-minutes: 120
     strategy:
       # One fixture or mode failing must not hide the state of the others.
@@ -228,10 +196,8 @@ jobs:
         env:
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
         run: |
-          # A fixture's composer.lock is frozen, so the update branch name
-          # (update-<lock content-hash>) is stable across runs. Left behind, it
-          # makes the next real run abort with "branch already exists", which
-          # reports as no_changes and exit 0 -- a green run that tested nothing.
+          # A frozen lock makes the update branch name stable across runs. Left behind, the
+          # next run aborts with "branch already exists" -- green, and testing nothing.
           authed="$(echo "$TARGET_URL" | sed "s#https://#https://oauth2:$REPO_TOKEN@#")"
           git ls-remote --heads "$authed" 'refs/heads/update-*' \
             | awk '{print $2}' | sed 's#refs/heads/##' \
@@ -245,30 +211,23 @@ jobs:
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
           SHALLOW: ${{ matrix.shallow }}
         run: |
-          # ./run is the mount root, the project a level below it. drupdater
-          # writes <site>.sqlite and private/ into the checkout's PARENT
-          # (pkg/drupal/installer.go), so the parent has to be a real directory
-          # we control -- mounting the checkout itself at /workspace puts them
-          # in the container's /.
+          # drupdater writes <site>.sqlite and private/ into the checkout's PARENT, so the
+          # mount root is one level above the project rather than the checkout itself.
           mkdir -p ./run
-          # Normally no --depth: drupdater's preflight rejects a shallow checkout
-          # ("git history complete"), and a shallow clone cannot be pushed. The
-          # multisite-shallow fixture asks for one precisely to prove that
-          # rejection still happens -- it is the only leg that sets this.
+          # Normally no --depth: preflight rejects a shallow checkout. multisite-shallow asks
+          # for one precisely to prove that rejection still happens.
           depth=()
           if [ "$SHALLOW" = "true" ]; then
             depth=(--depth 1)
           fi
           git -c credential.helper='!f(){ echo username=oauth2; echo "password=$REPO_TOKEN"; };f' \
             clone "${depth[@]}" --branch "$TARGET_BRANCH" "$TARGET_URL" ./run/project
-          # Deliberately NO git identity configured here. A fresh clone has none,
-          # which is exactly the case drupdater has to handle on its own -- leaving
-          # it unset is what makes this job a regression test for that fallback.
+          # No git identity on purpose: a fresh clone has none, which is the case drupdater's
+          # own fallback has to handle.
 
       - name: Run drupdater
         env:
-          # No fallback token on purpose: a checkout-mode --dry-run is documented as
-          # needing none, so running it with an empty one keeps that promise tested.
+          # No fallback token: a checkout-mode --dry-run is documented as needing none.
           REPO_TOKEN: ${{ secrets.DRUPDATER_TEST_TOKEN }}
           DRUPALCODE_ACCESS_TOKEN: ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
           DRY_RUN: ${{ needs.plan.outputs.dry_run }}
@@ -281,10 +240,9 @@ jobs:
           [ "$MODE" = "security" ]   && args+=(--security)
           [ "$VERBOSE" = "true" ]    && args+=(--verbose)
 
-          # A fixture built to fail exits non-zero by design, and this step runs under bash -e:
-          # it would abort before the report is read, and the report is the actual verdict.
-          # Derived from the fixture's own status list rather than a second flag, which could
-          # disagree with it.
+          # A failure fixture exits non-zero by design, and bash -e would abort before the
+          # report -- the actual verdict -- is read. Derived from the fixture's status list
+          # rather than a second flag that could disagree with it.
           want_failure=$(jq -r 'if (.status | index("failed")) then "true" else "false" end' <<<"$EXPECT")
 
           rc=0
@@ -293,9 +251,8 @@ jobs:
             -v "$(pwd)/run:/workspace" \
             drupdater:test "$REPO_TOKEN" "${args[@]}" || rc=$?
 
-          # Both directions: a failure fixture that suddenly succeeds has stopped testing
-          # what it was built for, which no assertion on the report would catch -- the
-          # report of a successful run is perfectly consistent.
+          # Both directions: a failure fixture that suddenly succeeds has stopped testing what
+          # it was built for, and its report is perfectly consistent.
           if [ "$want_failure" = "true" ] && [ "$rc" -eq 0 ]; then
             echo "::error::the run was expected to fail, but exited 0"
             exit 1
@@ -305,34 +262,27 @@ jobs:
             exit "$rc"
           fi
 
-      # The report is written on every exit path, so this runs even when the
-      # container failed -- a failed run's report is the one worth reading.
+      # The report is written on every exit path, and a failed run's is the one worth reading.
       - name: Summarise and verify run report
         id: report
         if: always()
         env:
           EXPECT: ${{ matrix.expect }}
-          # Asserted to appear nowhere in the report. Redaction is a documented
-          # promise about a file that gets archived and attached to tickets, and
-          # this is the only place it is checked against a real run's errors and
-          # URLs rather than against strings a unit test made up.
+          # The only place redaction is checked against a real run's errors and URLs rather
+          # than strings a unit test made up.
           DRUPDATER_ASSERT_SECRETS: |
             ${{ secrets.DRUPDATER_TEST_TOKEN }}
             ${{ secrets.DRUPALCODE_ACCESS_TOKEN }}
         run: |
-          # pipefail is load-bearing here, not decoration. Without it this step's verdict was
-          # `jq -e ... | tee`, whose exit status is tee's -- always 0 -- so assert-report.jq
-          # could never fail a leg. Every run before this only ever proved the container
-          # exited 0, which is precisely what that script exists to stop being the standard.
+          # pipefail is load-bearing: without it the verdict is `jq -e ... | tee`, whose exit
+          # status is tee's -- always 0 -- so assert-report.jq could never fail a leg.
           set -euo pipefail
-          # The container runs as root and the report is written 0600, so both jq
-          # and upload-artifact get EACCES until the runner owns it back.
+          # Written 0600 by root, so jq and upload-artifact get EACCES until the runner owns it.
           sudo chown -R "$(id -u):$(id -g)" ./run || true
           test -f ./run/report.json || { echo "::error::no run report was written"; exit 1; }
           echo "### ${{ matrix.fixture }} / ${{ matrix.mode }}" >> "$GITHUB_STEP_SUMMARY"
-          # The // [] guards matter now that pipefail is on: a run that died before recording
-          # anything would otherwise fail this step on "Cannot iterate over null" and hide the
-          # real reason behind a jq error.
+          # The // [] guards matter under pipefail: a run that recorded nothing would fail
+          # here on "Cannot iterate over null" and hide the real reason.
           jq -r '
             "status=\(.status)  mode=\(.mode)  dry_run=\(.dry_run)",
             "failed_phase=\(.failed_phase // "-")  error=\(.error // "-")",
@@ -342,29 +292,23 @@ jobs:
             ((.addons // {}) | to_entries[]
              | "  \(.key): \(.value | tojson | if length > 400 then .[0:400] + " ..." else . end)")
           ' ./run/report.json | tee -a "$GITHUB_STEP_SUMMARY"
-          # The container exits 0 on an AbortError ("no changes", "branch already
-          # exists") and a run reports success even when an addon logged and
-          # swallowed its own failure, so neither exit status nor .status alone is
-          # a verdict. Assert what this fixture is actually meant to produce.
-          # Hand the outcome to the steps below: everything that inspects the
-          # working copy only makes sense for a run that produced one.
+          # The container exits 0 on an AbortError, and a run reports success even when an
+          # addon swallowed its own failure, so neither is a verdict on its own. The outcome
+          # goes to the steps below, which only make sense for a run that produced a working copy.
           {
             echo "status=$(jq -r '.status' ./run/report.json)"
             echo "update_branch=$(jq -r '.update_branch // ""' ./run/report.json)"
           } >> "$GITHUB_OUTPUT"
-          # Captured rather than piped into tee, which is what swallowed the exit status, and
-          # with stderr folded in: halt_error writes the "report assertions failed" list there,
-          # so the piped version reached the raw log but never the summary anyone opens.
+          # Captured, not piped into tee, which swallowed the exit status -- and with stderr
+          # folded in, since halt_error writes the failure list there.
           assert_status=0
           jq -e -r --argjson expect "$EXPECT" -f .github/assert-report.jq \
             ./run/report.json > /tmp/assert-report.out 2>&1 || assert_status=$?
           tee -a "$GITHUB_STEP_SUMMARY" < /tmp/assert-report.out
           exit "$assert_status"
 
-      # Everything above reads the report, which is drupdater's own account of
-      # the run. The steps below read the repository it left behind, which is
-      # what a reviewer would actually get -- the two disagreeing is the failure
-      # mode a report cannot catch on its own.
+      # Everything above reads drupdater's own account of the run; the steps below read the
+      # repository it left behind. The two disagreeing is what a report cannot catch itself.
       - name: Verify the working copy
         if: always() && steps.report.outputs.status == 'success'
         env:
@@ -374,16 +318,14 @@ jobs:
           cd ./run/project
           echo "### Working copy" >> "$GITHUB_STEP_SUMMARY"
 
-          # The run ends on the branch it created, and the report names it. A
-          # mismatch means the report is describing a branch that is not there.
+          # A mismatch means the report describes a branch that is not there.
           current="$(git rev-parse --abbrev-ref HEAD)"
           if [ "$current" != "$UPDATE_BRANCH" ]; then
             echo "::error::checkout is on $current, report says $UPDATE_BRANCH"
             exit 1
           fi
 
-          # The update has to be additive: the base branch is left where it was,
-          # and the update branch descends from it.
+          # Additive: the base branch stays put and the update branch descends from it.
           if ! git merge-base --is-ancestor "origin/$TARGET_BRANCH" HEAD; then
             echo "::error::$UPDATE_BRANCH does not descend from origin/$TARGET_BRANCH"
             exit 1
@@ -401,13 +343,9 @@ jobs:
           echo "$commits commits on \`$UPDATE_BRANCH\`:" >> "$GITHUB_STEP_SUMMARY"
           git log --oneline "origin/$TARGET_BRANCH..HEAD" >> "$GITHUB_STEP_SUMMARY"
 
-          # Addons commit as they go, so a finished run leaves nothing behind:
-          # an uncommitted change is work that would never reach the merge
-          # request. settings.php is the one exception -- ConfigureDatabase
-          # appends the test database to it on purpose, and it is gitignored in
-          # most projects anyway -- so it is excluded rather than tolerated
-          # wholesale. Untracked files are out of scope: vendor/ and the site's
-          # generated files legitimately sit in the checkout.
+          # Addons commit as they go, so an uncommitted change is work that would never reach
+          # the merge request. settings.php is excluded because ConfigureDatabase appends the
+          # test database to it; untracked files are out of scope, vendor/ lives here too.
           dirty="$(git status --porcelain --untracked-files=no \
                    | grep -v 'sites/[^/]*/settings\.php$' || true)"
           if [ -n "$dirty" ]; then
@@ -420,11 +358,8 @@ jobs:
         if: always() && steps.report.outputs.status == 'success'
         run: |
           set -euo pipefail
-          # The report's package list is parsed out of composer's console
-          # output. Diffing the lock the run committed against the one it
-          # started from is the independent check on that parsing -- and on
-          # everything built from it, the merge request's dependency table
-          # included.
+          # The report's package list is parsed out of composer's console output, and the
+          # committed lock is the independent check on that parsing.
           git -C ./run/project show "origin/$TARGET_BRANCH:composer.lock" > /tmp/base-composer.lock
           jq -n -e -r \
             --slurpfile before /tmp/base-composer.lock \
@@ -436,21 +371,12 @@ jobs:
         if: always() && steps.report.outputs.status == 'success'
         run: |
           set -euo pipefail
-          # A lock that does not match composer.json, or one that is internally
-          # inconsistent, makes the merge request useless however good the
-          # changelog looks. composer is in the image, so this runs against
-          # exactly the version the update itself used.
+          # A lock that does not match composer.json makes the merge request useless however
+          # good the changelog looks. Run with the image's composer, the one the update used.
           #
-          # --no-check-publish drops the rules about publishable packages
-          # (name, description, license); a site is not a library. The lock
-          # check is deliberately kept.
-          #
-          # --ignore-platform-reqs because drupdater passes it on every composer
-          # call it makes (pkg/composer/composer.go), so a lock it produced can
-          # legitimately require an extension this image does not carry --
-          # drupal/ai_provider_amazeeio wants ext-pgsql. Without the flag this
-          # step asserts a stronger property than drupdater ever promises, and
-          # fails on the runtime's extension set rather than on the update.
+          # --no-check-publish drops the publishable-package rules; a site is not a library.
+          # --ignore-platform-reqs because drupdater passes it on every composer call, so a
+          # lock it produced may require an extension this image does not carry.
           docker run --rm -v "$(pwd)/run:/workspace" -w /workspace/project \
             --entrypoint composer drupdater:test \
             validate --no-check-publish --no-interaction | tee -a "$GITHUB_STEP_SUMMARY"
@@ -459,15 +385,9 @@ jobs:
             install --dry-run --no-scripts --no-interaction --ignore-platform-reqs \
             | tail -20 | tee -a "$GITHUB_STEP_SUMMARY"
 
-      # Running drupdater on its own output must find nothing left to do. It is
-      # the one assertion that covers the addons that only ever write files:
-      # a normaliser, PHPCBF or Rector rule that rewrites the same code
-      # differently on every pass produces an endless stream of merge requests,
-      # and no single run can tell that it did.
-      #
-      # Only the normal-mode leg: the second run exercises the same code path in
-      # either mode, and it is not cheap -- it installs the site again before it
-      # can get as far as composer update.
+      # Running drupdater on its own output must find nothing to do. The only assertion that
+      # catches a normaliser or Rector rule rewriting the same code differently every pass,
+      # which no single run can tell. Normal mode only: the path is the same and it is not cheap.
       - name: Re-run to prove the update is idempotent
         if: steps.report.outputs.status == 'success' && matrix.mode == 'normal'
         env:
@@ -477,18 +397,15 @@ jobs:
           VERBOSE: ${{ needs.plan.outputs.verbose }}
         run: |
           set -euo pipefail
-          # Move the base branch onto the update, the way merging the request
-          # would, and run against that. Re-running on the update branch itself
-          # would abort with "branch already exists" and prove nothing.
+          # Move the base branch onto the update, as merging would. Re-running on the update
+          # branch itself aborts with "branch already exists" and proves nothing.
           git -C ./run/project checkout "$TARGET_BRANCH"
           git -C ./run/project merge --ff-only "$UPDATE_BRANCH"
 
           args=(--working-dir /workspace/project --report /workspace/report-second.json --dry-run)
           [ "$VERBOSE" = "true" ] && args+=(--verbose)
-          # The chown has to happen even when the run fails, so it is a trap rather than the
-          # next line: report-second.json is written on every exit path, owned by root and
-          # 0600, and set -e would otherwise skip straight past. The upload step then dies
-          # with EACCES on it and reports that instead of what actually went wrong.
+          # A trap, not the next line: the report is written on every exit path as root 0600,
+          # and set -e would skip the chown, leaving upload-artifact to die on EACCES instead.
           trap 'sudo chown -R "$(id -u):$(id -g)" ./run || true' EXIT
 
           docker run --rm \
@@ -498,9 +415,7 @@ jobs:
 
           sudo chown -R "$(id -u):$(id -g)" ./run || true
           echo "### Second run (idempotency)" >> "$GITHUB_STEP_SUMMARY"
-          # Anything other than no_changes means the first run left work behind:
-          # read .packages in the second report to see what moved the second
-          # time round.
+          # Anything but no_changes means the first run left work behind; .packages says what.
           jq -e -r --argjson expect '{"status": ["no_changes"]}' \
             -f .github/assert-report.jq ./run/report-second.json \
             | tee -a "$GITHUB_STEP_SUMMARY"
@@ -510,8 +425,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: drupdater-report-${{ matrix.fixture }}-${{ matrix.mode }}
-          # report-second.json only exists for the legs that run the idempotency
-          # check, so the pattern is a glob rather than two named files.
+          # A glob, since report-second.json only exists for the idempotency legs.
           path: ./run/report*.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,22 +1,13 @@
 name: Mutation Testing
 
-# Scores the whole module with mutation testing: every mutant that survives is a
-# line the tests execute but do not actually check.
+# Scores the whole module with mutation testing: a surviving mutant is a line the tests execute
+# but do not check. Informational only -- the blocking gate is go.yml's `mutation` job.
 #
-# Deliberately informational -- it never fails the build. The blocking gate is
-# the `mutation` job in go.yml, which scores only the lines a pull request
-# changes. This run exists to track the module-wide score over time and to
-# produce a worklist of surviving mutants in existing code.
+# One leg per package, not a single `./...` run: ~3000 mutants is over half an hour serially,
+# and `fail-fast: false` keeps one bad package from discarding the others.
 #
-# Split one leg per package rather than a single `./...` run: the whole module
-# is ~3000 mutants and over half an hour serially, where the matrix finishes in
-# the time of its slowest package. A leg that fails or times out can be re-run
-# on its own, and `fail-fast: false` keeps one bad package from discarding the
-# other thirteen results.
-#
-# The per-package `mutation-report-*` artifacts hold mutago-agentic.json: each
-# survivor with its diff, surrounding context and the test file that should have
-# caught it. Download them to pick off survivors package by package.
+# The `mutation-report-*` artifacts hold each survivor with its diff and the test that should
+# have caught it.
 
 on:
   schedule:
@@ -32,8 +23,7 @@ permissions:
   contents: read
 
 jobs:
-  # Discover the packages to score instead of hardcoding them, so adding a
-  # package to the module adds a leg here automatically. Packages without tests
+  # Discovered rather than hardcoded, so a new package adds its own leg. Untested packages
   # are skipped -- mutago has nothing to score there.
   plan:
     name: plan
@@ -75,8 +65,7 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # Artifact names cannot contain "/", and the aggregate job needs to know
-      # which package a summary came from.
+      # Artifact names cannot contain "/", and the aggregate job needs the package name.
       - name: Derive slug
         id: slug
         run: echo "slug=$(echo '${{ matrix.package }}' | sed 's|^\./||; s|/|_|g; s|^\.$|root|')" >> "$GITHUB_OUTPUT"
@@ -125,9 +114,8 @@ jobs:
           merge-multiple: true
           path: reports
 
-      # MSI is killed/total and covered-code MSI is killed/(total - notCovered),
-      # so both aggregate by summing counts. Averaging the per-package
-      # percentages would weight a 26-mutant package like a 424-mutant one.
+      # Summed, not averaged: averaging percentages weights a 26-mutant package like a
+      # 424-mutant one.
       - name: Module-wide score
         run: |
           shopt -s nullglob

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,37 @@ Where things live. For *how they work*, read `docs/explanation/` rather than dup
 
 ## Comments
 
-Keep comments short, simple and precise. One line where one line does. Say *why*, not what the code already says. No restating the signature, no commented-out code, no filler.
+**Default to no comment.** Readable code with a good name is the goal; a comment is what you fall
+back to when the *reason* for the code can't be expressed in the code itself.
+
+Hard rules:
+
+- **One line. Under ~100 characters.** If it doesn't fit, the comment is explaining too much — cut it
+  to the single non-obvious fact, or delete it. Multi-line blocks are reserved for doc comments on
+  exported API and for `internal/addon/report.go`'s published schema.
+- **Say *why*, never *what*.** The code already says what. `// lock the mutex`, `// returns an error
+  if the path is empty`, `// loop over the packages` — all deleted.
+- **No signature restating**, no `// Foo does X` on unexported helpers whose name already says X.
+- **No narration of the diff**: `// changed to handle the new case`, `// moved from workflow_base`,
+  `// see PR #123`. Git holds that.
+- **No commented-out code**, no TODO/FIXME without a concrete reason, no section banners
+  (`// --- helpers ---`), no filler.
+- **Tests**: name the test after what it asserts instead of commenting it. No `// arrange` /
+  `// act` / `// assert` scaffolding.
+
+The comments worth keeping are the ones a reader can't derive: a workaround for an upstream bug (name
+it), a non-obvious ordering or concurrency constraint, an event-priority dependency, a deliberate
+deviation from the obvious implementation. Everything else goes.
+
+```go
+// bad — three lines restating the code
+// getPackages collects the packages that need updating. It iterates over
+// the installed packages, filters out the ones in PackagesToKeep and
+// returns the remaining slice.
+
+// good — one line, states what the reader can't see
+// Composer resolves patches lazily, so the lock has to be re-read after `require`.
+```
 
 ## Configuration
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -24,8 +24,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// checkFull selects the --full tier: on top of the free checks it clones the repository and runs
-// composer install plus a real site install, proving each site installs from its exported config.
+// checkFull adds the expensive tier: clone, composer install and a real site install per site.
 var checkFull bool
 
 var checkCmd = &cobra.Command{
@@ -54,7 +53,7 @@ Exits non-zero if any check fails, so it can gate a pipeline.`,
 			return err
 		}
 
-		// A token is never required here: without one, the VCS authentication check is skipped.
+		// Optional: without a token the VCS authentication check is skipped.
 		token := checkToken(args)
 		redactor.Register(token)
 
@@ -87,17 +86,13 @@ Exits non-zero if any check fails, so it can gate a pipeline.`,
 	},
 }
 
-// cheapChecksComposer is the union of services.PlatformReqsChecker and
-// services.ComposerConfigGetter. Kept narrow so tests can supply a small fake; the real
-// *composer.CLI satisfies it as-is.
+// cheapChecksComposer is narrow so tests can supply a fake; *composer.CLI satisfies it as-is.
 type cheapChecksComposer interface {
 	services.PlatformReqsChecker
 	services.ComposerConfigGetter
 }
 
-// runCheapChecks runs every check that's free: no composer install, no site install, no network
-// beyond one optional read-only VCS call (see checkVCS). Split out of RunE so its branching can
-// be tested against fakes, without the composer/drush/git binaries CI doesn't install.
+// runCheapChecks runs the free checks: no install, no network beyond one optional VCS call.
 func runCheapChecks(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -120,9 +115,7 @@ func runCheapChecks(
 	return results
 }
 
-// writeCheckReport writes the preflight result to path, or nothing without --report. A preflight
-// has no phases, packages or branch, hence its own document shape. As with a run's report, a
-// write failure is logged and swallowed: the verdict matters more than the file describing it.
+// writeCheckReport writes the preflight result, or nothing without --report. Failures are logged.
 func writeCheckReport(logger *zap.Logger, redactor *logging.Redactor, path string, tools report.ToolVersions, results []services.CheckResult) {
 	if path == "" {
 		return
@@ -136,8 +129,7 @@ func writeCheckReport(logger *zap.Logger, redactor *logging.Redactor, path strin
 	logger.Info("check report written", zap.String("path", path))
 }
 
-// toReportCheckResults converts the services results into the report's own schema type, for the
-// same reason report.PackageChange mirrors composer.PackageChange.
+// toReportCheckResults converts to the report's own schema type — see report.PackageChange.
 func toReportCheckResults(results []services.CheckResult) []report.CheckResult {
 	out := make([]report.CheckResult, 0, len(results))
 	for _, r := range results {
@@ -147,8 +139,7 @@ func toReportCheckResults(results []services.CheckResult) []report.CheckResult {
 	return out
 }
 
-// checkToken resolves the token the way a real run does, but never errors when neither source is
-// set: check works without one, it just can't verify authentication.
+// checkToken resolves the token like a real run does, but check works without one.
 func checkToken(args []string) string {
 	if len(args) == 1 && args[0] != "" {
 		return args[0]
@@ -156,8 +147,7 @@ func checkToken(args []string) string {
 	return os.Getenv("DRUPDATER_TOKEN")
 }
 
-// checkConfigAndAddons validates .drupdater.yaml and, if it parses, the addon names it lists.
-// It also fills cfg.Sites (and the rest of the file config) for the checks that follow.
+// checkConfigAndAddons validates .drupdater.yaml and its addon names, and fills cfg for the rest.
 func checkConfigAndAddons(path string, cfg *internal.Config) []services.CheckResult {
 	if _, err := internal.LoadConfigFile(path, cfg); err != nil {
 		return []services.CheckResult{services.CheckFailed(".drupdater.yaml valid", err.Error())}
@@ -174,15 +164,13 @@ func checkConfigAndAddons(path string, cfg *internal.Config) []services.CheckRes
 	return append(results, services.CheckOK(addonsName))
 }
 
-// newVcsProvider resolves a repository URL and token to a VCS platform. A variable so the token
-// check can be tested without GetUser making a real network request.
+// newVcsProvider is a variable so the token check can be tested without a real GetUser request.
 var newVcsProvider = func(repositoryURL string, token string, logger *zap.Logger) (codehosting.Platform, error) {
 	return codehosting.NewDefaultVcsProviderFactory().Create(repositoryURL, token, logger)
 }
 
-// checkVCS reports whether the repository URL routes to a known provider and, with a token,
-// whether it authenticates. resolveErr comes from deriving the URL out of the checkout, and is
-// surfaced here because this is the only check it would otherwise silently fail.
+// checkVCS reports whether the URL routes to a known provider and, with a token, authenticates.
+// resolveErr is surfaced here because this is the only check it would otherwise silently fail.
 func checkVCS(ctx context.Context, logger *zap.Logger, repositoryURL string, token string, resolveErr error) []services.CheckResult {
 	const name = "repository host recognized (GitHub/GitLab)"
 
@@ -214,8 +202,7 @@ func checkVCS(ctx context.Context, logger *zap.Logger, repositoryURL string, tok
 	return append(results, services.CheckOK(tokenCheckName))
 }
 
-// fullCheckComposer is what the --full tier needs from composer: the install it performs, the
-// scratch-directory cleanup it owes, and the config lookup drupal.Installer makes.
+// fullCheckComposer is what the --full tier needs from composer.
 type fullCheckComposer interface {
 	drupal.Composer
 	Install(ctx context.Context, path string) error
@@ -227,18 +214,15 @@ type siteInstaller interface {
 	Install(ctx context.Context, dir string, site string) error
 }
 
-// fullCheckDeps are the external tools the --full tier drives. Constructors rather than values,
-// so the tier keeps its ordering: composer is built only once the clone succeeded, the installer
-// only once composer install did. Grouping them here makes the tier's control flow testable
-// without a real clone, install and site install.
+// fullCheckDeps holds constructors rather than values, so the tier keeps its build order:
+// composer only once the clone succeeded, the installer only once composer install did.
 type fullCheckDeps struct {
 	clone        func(repositoryURL string, branch string, token string) (string, error)
 	newComposer  func() fullCheckComposer
 	newInstaller func(fullCheckComposer) (siteInstaller, error)
 }
 
-// newFullCheckDeps builds the real services. It is a variable so tests can substitute doubles,
-// the same way execCommand is swapped in the pkg/* wrappers.
+// newFullCheckDeps builds the real services. A variable so tests can substitute doubles.
 var newFullCheckDeps = func(logger *zap.Logger) fullCheckDeps {
 	return fullCheckDeps{
 		clone: func(repositoryURL string, branch string, token string) (string, error) {
@@ -257,8 +241,7 @@ var newFullCheckDeps = func(logger *zap.Logger) fullCheckDeps {
 	}
 }
 
-// runFullChecks is the --full tier: it clones to a scratch directory, never the live working
-// copy, and proves each configured site installs from its exported configuration.
+// runFullChecks clones to a scratch directory, never the live working copy, and installs each site.
 func runFullChecks(ctx context.Context, logger *zap.Logger, cfg internal.Config, token string) []services.CheckResult {
 	if cfg.RepositoryURL == "" {
 		return []services.CheckResult{services.CheckFailed("sites install from configuration",
@@ -302,17 +285,14 @@ func runFullChecks(ctx context.Context, logger *zap.Logger, cfg internal.Config,
 	return results
 }
 
-// cleanupFullCheckArtifacts removes the clone and the SQLite databases/private files the site
-// installs wrote beside it, mirroring the real run's own clone-mode cleanup.
+// cleanupFullCheckArtifacts removes the clone and the SQLite/private files the installs wrote.
 func cleanupFullCheckArtifacts(path string, sites []string) {
 	defer os.RemoveAll(path)
 
 	services.CleanupSiteArtifacts(filepath.Dir(path), sites)
 }
 
-// printCheckResults writes results to w, redacting each detail first: a failed check's Detail
-// can carry raw subprocess output, which would otherwise leak a credential straight to stdout,
-// bypassing the logger's redaction entirely.
+// printCheckResults redacts each detail: a failure's Detail can carry raw subprocess output.
 func printCheckResults(w io.Writer, results []services.CheckResult, redactor *logging.Redactor) {
 	for _, r := range results {
 		mark := "✓"

--- a/cmd/check_cmd_test.go
+++ b/cmd/check_cmd_test.go
@@ -40,10 +40,8 @@ func runCheckCmd(t *testing.T, args ...string) (string, error) {
 }
 
 func TestCheckCommandReportsFailuresAndExitsNonZero(t *testing.T) {
-	// A bare git checkout with no Drupal project in it: the cheap tier can run end to end, and
-	// every check that depends on a real project fails. That is the shape of the command's
-	// unhappy path, and it is what proves RunE collects results, prints them, and turns a
-	// failure into a non-zero exit rather than reporting success.
+	// A bare checkout with no Drupal project: every project-dependent check fails, which is
+	// the command's unhappy path end to end.
 	dir := t.TempDir()
 	_, err := git.PlainInit(dir, false)
 	require.NoError(t, err)

--- a/cmd/check_full_test.go
+++ b/cmd/check_full_test.go
@@ -40,9 +40,8 @@ func (f *fakeInstaller) Install(_ context.Context, dir string, site string) erro
 	return f.failFor[site]
 }
 
-// stubFullCheckDeps swaps the real clone/composer/installer construction for doubles. The
-// production constructors reach for a real git remote, a real composer install and a real
-// drush site-install, so the tier's own control flow is otherwise untestable.
+// stubFullCheckDeps swaps in doubles for the real clone, composer install and site install,
+// without which the tier's control flow is untestable.
 func stubFullCheckDeps(t *testing.T, clonePath string, cloneErr error, composerDouble *fakeComposer, installer siteInstaller, installerErr error) *[]string {
 	t.Helper()
 

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -128,9 +128,7 @@ func TestPrintCheckResults(t *testing.T) {
 }
 
 func TestPrintCheckResultsRedactsDetail(t *testing.T) {
-	// A failed check's Detail can carry raw subprocess output (e.g. a Composer error after a
-	// failed authenticated fetch), which is exactly where a leaked credential would otherwise
-	// reach stdout unredacted.
+	// Detail can carry raw subprocess output, where a credential would reach stdout unredacted.
 	redactor := logging.NewRedactor()
 	redactor.Register("s3cr3t-token")
 
@@ -167,8 +165,7 @@ func TestCleanupFullCheckArtifacts(t *testing.T) {
 	assert.NoDirExists(t, filepath.Join(parent, "private"))
 }
 
-// fakeShallowCloneChecker and fakeCheapChecksComposer are minimal test doubles for the narrow
-// interfaces runCheapChecks depends on, so its branching can be exercised without the real
+// Doubles for the narrow interfaces runCheapChecks needs, so its branching runs without the
 // composer/drush/git binaries CI doesn't install.
 type fakeShallowCloneChecker struct {
 	shallow bool
@@ -236,9 +233,8 @@ func TestRunCheapChecks(t *testing.T) {
 	})
 
 	t.Run("one result per configured site", func(t *testing.T) {
-		// The sites list comes from the config file, not a pre-set cfg.Sites: runCheapChecks
-		// loads it via checkConfigAndAddons. Only "default" gets a settings.php; "extra" is
-		// missing.
+		// The sites come from the config file, not a pre-set cfg.Sites. Only "default" has
+		// a settings.php.
 		cfgPath := filepath.Join(t.TempDir(), ".drupdater.yaml")
 		require.NoError(t, os.WriteFile(cfgPath, []byte("sites: [default, extra]\n"), 0o600))
 
@@ -267,9 +263,8 @@ func TestRunFullChecksNoRepositoryURL(t *testing.T) {
 }
 
 func TestRunFullChecksDefaultsToMainBranch(t *testing.T) {
-	// With no branch configured the full check must still pick one; "main" is the default the
-	// clone is attempted with. The clone fails here (the URL is a bare directory), but the
-	// failure detail names the branch that was tried.
+	// With no branch configured the clone must still try one. It fails here, but the detail
+	// names the branch it tried.
 	cfg := internal.Config{RepositoryURL: t.TempDir()}
 
 	results := runFullChecks(t.Context(), zap.NewNop(), cfg, "")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,8 +60,7 @@ names you can set there. See the README for the full file format.`,
 		if config.Clone && config.RepositoryURL == "" {
 			return errors.New("--repository-url is required with --clone")
 		}
-		// Validated against what the provider factory accepts, not a stricter URL parser that
-		// would reject git@host:owner/repo.git even though clone and detection handle it.
+		// Validated against what the provider factory accepts, so git@host:owner/repo.git passes.
 		if config.RepositoryURL != "" {
 			if err := codehosting.ValidateRepositoryURL(config.RepositoryURL); err != nil {
 				return fmt.Errorf("invalid repository URL: %w", err)
@@ -77,19 +76,18 @@ names you can set there. See the README for the full file format.`,
 	},
 }
 
-// runUpdate is the body of the root command's RunE. Named rather than inline so a test can call
-// it directly: a closure assigned to RunE is invisible to `go tool cover -func`.
+// runUpdate is the body of the root command's RunE. Named rather than inline because a closure
+// assigned to RunE is invisible to `go tool cover -func`.
 func runUpdate(cmd *cobra.Command, args []string) error {
 
-	// Secrets are registered the moment each becomes known, so nothing is logged unredacted in
-	// between — subprocesses echo credentials back after a failed authenticated fetch.
+	// Registered as each becomes known, so nothing is logged unredacted in between.
 	redactor := logging.NewRedactor()
 	registerEnvSecrets(redactor)
 
-	// Initialize the logger first so config errors are reported (errors are silenced by Cobra).
+	// First, so config errors are reported at all — Cobra silences them.
 	logger, err := NewLogger(config, redactor)
 	if err != nil {
-		// No logger yet, so this one report has to go straight to stderr.
+		// No logger yet.
 		fmt.Fprintln(cmd.ErrOrStderr(), "failed to initialize logger:", err)
 		return err
 	}
@@ -119,21 +117,18 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	installer := drupal.NewInstaller(logger, drush, composer)
 	git := repo.NewGitRepositoryService(logger)
 
-	// In checkout mode the repository URL and target branch come from the checkout, so
-	// they don't have to be passed in. --branch only applies to --clone.
+	// In checkout mode the URL and target branch come from the checkout; --branch is --clone only.
 	if !config.Clone {
 		if err := resolveCheckoutSettings(git, &config); err != nil {
 			return err
 		}
 		logger.Info("using checkout", zap.String("url", config.RepositoryURL), zap.String("branch", config.Branch))
 
-		// CI mounts the checkout under a different user than the container runs as, so git
-		// refuses it as "dubious ownership" in every drush/composer subprocess.
+		// CI mounts the checkout under another user, so git calls it "dubious ownership".
 		ensureGitSafeDirectory(cmd.Context(), logger, config.WorkingDir)
 	}
 
-	// Built only for a run that uses it — cloning or publishing. A checkout-mode --dry-run does
-	// neither, so it needs no client and no token; see tokenRequired.
+	// Built only for a run that clones or publishes; see tokenRequired.
 	var platform codehosting.Platform
 	if tokenRequired(config) {
 		vcsProviderFactory := codehosting.NewDefaultVcsProviderFactory()
@@ -167,14 +162,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// updateWorkflow is all runUpdate needs from the workflow. Kept narrow so a test can drive
-// runUpdate to the end without a real repository, composer and drush.
+// updateWorkflow is narrow so a test can drive runUpdate without a real repository or subprocesses.
 type updateWorkflow interface {
 	StartUpdate(ctx context.Context, addons []internal.Addon) error
 }
 
-// newWorkflowService builds the update workflow. A variable purely as a test seam: everything
-// above it in runUpdate runs for real, and only the run itself is replaced.
+// newWorkflowService is a variable purely as a test seam: only the run itself gets replaced.
 var newWorkflowService = func(
 	logger *zap.Logger,
 	cfg internal.Config,
@@ -189,9 +182,8 @@ var newWorkflowService = func(
 	return services.NewWorkflowBaseService(logger, cfg, drushSvc, platform, gitSvc, installerSvc, composerSvc, dispatcher, opts...)
 }
 
-// reportSink returns the callback that writes the run report to path. A write failure is logged
-// and swallowed: the report describes the run, it is not the run, and on the failure path it
-// would mask the real error.
+// reportSink writes the run report to path. A write failure is logged, never returned: on the
+// failure path it would mask the real error.
 func reportSink(logger *zap.Logger, redactor *logging.Redactor, path string) func(report.Report) {
 	return func(rep report.Report) {
 		if err := report.Write(afero.NewOsFs(), path, rep, redactor.Redact); err != nil {
@@ -202,9 +194,7 @@ func reportSink(logger *zap.Logger, redactor *logging.Redactor, path string) fun
 	}
 }
 
-// resolveToken returns the access token: the positional argument, else DRUPDATER_TOKEN, which is
-// preferred because it stays out of the process list and shell history. Mandatory only when the
-// run will use it — see tokenRequired.
+// resolveToken takes the argument, else DRUPDATER_TOKEN. Mandatory only when the run will use it.
 func resolveToken(args []string, cfg internal.Config) (string, error) {
 	var token string
 	if len(args) == 1 && args[0] != "" {
@@ -218,25 +208,19 @@ func resolveToken(args []string, cfg internal.Config) (string, error) {
 	return token, nil
 }
 
-// tokenRequired reports whether this run needs VCS credentials: cloning (which may be
-// authenticated) or publishing. A checkout-mode --dry-run does neither.
+// tokenRequired reports whether this run clones or publishes. A checkout-mode --dry-run does neither.
 func tokenRequired(cfg internal.Config) bool {
 	return cfg.Clone || !cfg.DryRun
 }
 
-// registerEnvSecrets registers every credential-bearing environment value a subprocess might
-// echo back. Shared by the real run and "drupdater check", which drives the same subprocesses.
+// registerEnvSecrets registers every credential-bearing environment value a subprocess may echo.
 func registerEnvSecrets(redactor *logging.Redactor) {
 	redactor.Register(os.Getenv("DRUPALCODE_ACCESS_TOKEN"))
 	registerComposerAuth(redactor, os.Getenv("COMPOSER_AUTH"))
 }
 
-// registerComposerAuth registers the credentials inside a COMPOSER_AUTH value.
-//
-// Composer echoes the individual password or token, not the JSON blob, so every string leaf is
-// registered separately. "username" values are skipped: the documented http-basic form commonly
-// sets it to the literal word "token", which must not be redacted from unrelated output. The raw
-// value is registered too, as a fallback when it does not parse as JSON.
+// registerComposerAuth registers the credentials inside a COMPOSER_AUTH value. Composer echoes the
+// individual leaf, not the JSON blob. The raw value goes in too, for when it does not parse.
 func registerComposerAuth(redactor *logging.Redactor, composerAuth string) {
 	redactor.Register(composerAuth)
 
@@ -247,11 +231,11 @@ func registerComposerAuth(redactor *logging.Redactor, composerAuth string) {
 	redactor.Register(composerAuthSecretLeaves(parsed, "")...)
 }
 
-// composerAuthSecretLeaves returns every string value in a decoded COMPOSER_AUTH structure,
-// except those reached through a "username" key (see registerComposerAuth).
+// composerAuthSecretLeaves returns every string value in a decoded COMPOSER_AUTH structure.
 func composerAuthSecretLeaves(v any, key string) []string {
 	switch t := v.(type) {
 	case string:
+		// http-basic commonly sets username to the literal "token", which must stay readable.
 		if key == "username" {
 			return nil
 		}
@@ -273,8 +257,7 @@ func composerAuthSecretLeaves(v any, key string) []string {
 	}
 }
 
-// configFilePath returns the .drupdater.yaml to read: --config when set, otherwise the one in
-// the working directory.
+// configFilePath returns --config when set, otherwise the working directory's .drupdater.yaml.
 func configFilePath(explicit string, workingDir string) string {
 	if explicit != "" {
 		return explicit
@@ -282,8 +265,7 @@ func configFilePath(explicit string, workingDir string) string {
 	return filepath.Join(workingDir, ".drupdater.yaml")
 }
 
-// loadProjectConfig layers the project's .drupdater.yaml onto cfg and validates the addon
-// names it lists. A missing file is not an error — the built-in defaults apply.
+// loadProjectConfig layers .drupdater.yaml onto cfg. A missing file is not an error.
 func loadProjectConfig(logger *zap.Logger, path string, cfg *internal.Config) error {
 	found, err := internal.LoadConfigFile(path, cfg)
 	if err != nil {
@@ -307,8 +289,7 @@ func loadProjectConfig(logger *zap.Logger, path string, cfg *internal.Config) er
 	return nil
 }
 
-// resolveCheckoutSettings fills in the repository URL and target branch from the checkout.
-// --branch only applies to --clone, so it is overwritten here.
+// resolveCheckoutSettings fills the URL and target branch from the checkout, overwriting --branch.
 func resolveCheckoutSettings(git *repo.GitRepositoryService, cfg *internal.Config) error {
 	if cfg.RepositoryURL == "" {
 		remoteURL, err := git.GetRemoteURL(cfg.WorkingDir)
@@ -326,9 +307,7 @@ func resolveCheckoutSettings(git *repo.GitRepositoryService, cfg *internal.Confi
 	return nil
 }
 
-// resolveCheckoutBranch determines the MR target branch for checkout mode: the checkout's
-// current branch, or — when it's in detached HEAD (the usual CI state) — the branch reported
-// by the CI environment.
+// resolveCheckoutBranch returns the checkout's branch, or the CI variable when in detached HEAD.
 func resolveCheckoutBranch(git *repo.GitRepositoryService, workingDir string) (string, error) {
 	branch, err := git.GetCurrentBranch(workingDir)
 	if err != nil {
@@ -343,8 +322,8 @@ func resolveCheckoutBranch(git *repo.GitRepositoryService, workingDir string) (s
 	return branch, nil
 }
 
-// ensureGitSafeDirectory adds dir to git's global safe.directory list unless it (or "*") is
-// already trusted, so repeated runs don't append duplicates to the user's global gitconfig.
+// ensureGitSafeDirectory trusts dir globally, skipping it when already listed so repeated runs
+// don't append duplicates to the user's gitconfig.
 func ensureGitSafeDirectory(ctx context.Context, logger *zap.Logger, dir string) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
@@ -372,8 +351,7 @@ type addonDeps struct {
 	composer  addon.Composer
 	drupalOrg addon.DrupalOrg
 	git       addon.Repository
-	// security marks a --security run. Only composer_audit reads it, to tell the run whose
-	// scope it dictates from the one it merely describes.
+	// security marks a --security run. Only composer_audit reads it.
 	security bool
 }
 
@@ -399,11 +377,8 @@ var addonRegistry = map[string]func(addonDeps) internal.Addon{
 	"unsupported_modules": func(d addonDeps) internal.Addon { return addon.NewUnsupportedModules(d.logger, d.drush) },
 }
 
-// mandatoryAddons always run, regardless of the .drupdater.yaml addon lists.
-//
-// composer_audit and unsupported_modules are here for the same reason: between them they answer
-// "what is no longer getting fixes?" — Packagist's view and Drupal.org's. Either alone covers
-// half a project, and they render one shared list, which needs both on every update.
+// mandatoryAddons always run, regardless of the .drupdater.yaml addon lists. composer_audit and
+// unsupported_modules render one shared end-of-life list, so both are needed on every update.
 var mandatoryAddons = []string{
 	"composer_allow_plugins",
 	"composer_patches",
@@ -413,8 +388,7 @@ var mandatoryAddons = []string{
 	"unsupported_modules",
 }
 
-// createAddons builds the addons to run: the mandatory ones plus the configurable ones listed
-// for the active mode (security or regular) in the config. An unknown addon name is an error.
+// createAddons builds the mandatory addons plus the ones the active run type lists.
 func createAddons(
 	logger *zap.Logger,
 	config internal.Config,
@@ -456,8 +430,7 @@ func createAddons(
 	return addons, nil
 }
 
-// validateAddons checks both run types, so a typo under run_types.security is caught on a normal
-// run too.
+// validateAddons checks both run types, so a typo under run_types.security fails a normal run too.
 func validateAddons(config internal.Config) error {
 	for _, name := range append(append([]string{}, config.RunTypes.Normal.Addons...), config.RunTypes.Security.Addons...) {
 		if _, ok := addonRegistry[name]; !ok {
@@ -467,8 +440,7 @@ func validateAddons(config internal.Config) error {
 	return nil
 }
 
-// configurableAddons returns the sorted addon names settable in .drupdater.yaml: every
-// registered addon except the mandatory ones.
+// configurableAddons returns the sorted registered addon names, minus the mandatory ones.
 func configurableAddons() []string {
 	names := slices.Sorted(maps.Keys(addonRegistry))
 	return slices.DeleteFunc(names, func(n string) bool { return slices.Contains(mandatoryAddons, n) })
@@ -521,8 +493,7 @@ func init() {
 	rootCmd.AddCommand(addonsCmd)
 }
 
-// osExit is os.Exit, as a variable so a test can observe the exit code instead of ending the
-// test binary. Nothing else may replace it.
+// osExit is a variable so a test can observe the exit code instead of ending the test binary.
 var osExit = os.Exit
 
 func Execute() {

--- a/cmd/root_extra_test.go
+++ b/cmd/root_extra_test.go
@@ -97,10 +97,7 @@ func TestTokenRequired(t *testing.T) {
 }
 
 func TestRegisterEnvSecrets(t *testing.T) {
-	// registerEnvSecrets is what wires DRUPALCODE_ACCESS_TOKEN and COMPOSER_AUTH into the
-	// redactor for both a real run (cmd/root.go) and "drupdater check" (cmd/check.go), which
-	// shells out to the same subprocesses and must redact the same secrets from anything it
-	// prints.
+	// One wiring for both a real run and "drupdater check": same subprocesses, same secrets.
 	t.Setenv("DRUPALCODE_ACCESS_TOKEN", "drupalcode-secret")
 	t.Setenv("COMPOSER_AUTH", `{"bearer":{"example.com":"bearer-secret"}}`)
 
@@ -113,9 +110,8 @@ func TestRegisterEnvSecrets(t *testing.T) {
 }
 
 func TestRegisterComposerAuth(t *testing.T) {
-	// registerComposerAuth must register the individual credentials inside COMPOSER_AUTH, not
-	// just the raw JSON blob: Composer echoes the username/password/token itself (typically
-	// embedded in a URL after a failed authenticated fetch), never the blob verbatim.
+	// The individual credentials, not just the raw blob: Composer echoes the leaf, never the
+	// JSON verbatim.
 	redact := func(t *testing.T, redactor *logging.Redactor, msg string) string {
 		t.Helper()
 		core, logs := observer.New(zap.DebugLevel)
@@ -159,9 +155,8 @@ func TestComposerAuthSecretLeaves(t *testing.T) {
 }
 
 func TestComposerAuthSecretLeavesSkipsUsername(t *testing.T) {
-	// Packagist.com's documented http-basic form sets username to the literal word "token" and
-	// the real secret in password; the username leaf must not be registered as a secret, or every
-	// occurrence of the word "token" in unrelated log output gets redacted too.
+	// http-basic sets username to the literal word "token", which must stay out of the secret
+	// set or every unrelated "token" in the log is redacted too.
 	leaves := composerAuthSecretLeaves(map[string]any{
 		"http-basic": map[string]any{
 			"repo.packagist.com": map[string]any{

--- a/cmd/root_property_test.go
+++ b/cmd/root_property_test.go
@@ -12,24 +12,20 @@ import (
 	"pgregory.net/rapid"
 )
 
-// COMPOSER_AUTH is a JSON blob of credentials whose shape Composer defines and extends, so the
-// walk that finds the secrets in it has to hold for structures nobody here wrote down. The
-// properties end where it matters: the value that reaches the log.
+// COMPOSER_AUTH's shape is Composer's to extend, so the walk that finds its secrets has to hold
+// for structures nobody here wrote down.
 
 // authLeafGen generates one credential value.
 func authLeafGen() *rapid.Generator[string] {
 	return rapid.StringMatching(`[a-zA-Z0-9_-]{8,24}`)
 }
 
-// authTreeGen builds a COMPOSER_AUTH-shaped JSON tree and reports, alongside it, exactly which
-// of its string leaves are secrets. key is the object key the value was reached through.
+// authTreeGen builds a COMPOSER_AUTH-shaped tree and reports which of its leaves are secrets.
 //
 // The bookkeeping states the documented rule rather than mirroring the walk: a string is a
-// secret unless it was reached through a "username" key — Composer's http-basic form commonly
-// sets that to the literal word "token", and redacting it would black out unrelated log output.
-// An array inherits the key it sits under, an object gives each of its values its own, and
-// numbers and booleans are never secrets. Encoding the rule here is what lets the property
-// generate nesting nobody wrote down and still know the right answer.
+// secret unless reached through a "username" key, arrays inherit the key they sit under, and
+// numbers are never secrets. That is what lets the property generate unwritten nesting and
+// still know the right answer.
 func authTreeGen(depth int, key string) *rapid.Generator[authTree] {
 	leafGen := func(t *rapid.T) authTree {
 		leaf := authLeafGen().Draw(t, "leaf")
@@ -97,10 +93,8 @@ func TestPropertyComposerAuthSecretLeavesIgnoresNesting(t *testing.T) {
 		tree := authTreeGen(2, "").Draw(t, "tree")
 		wraps := rapid.IntRange(1, 4).Draw(t, "wraps")
 
-		// An array propagates the key it was reached through, so wrapping a value in any number
-		// of arrays must not change which of its leaves count as secrets. Composer nests its
-		// per-host blocks differently between auth types, and the walk has to be indifferent
-		// to how deep a credential sits.
+		// Composer nests per-host blocks differently per auth type, so the walk must be
+		// indifferent to how deep a credential sits.
 		wrapped := tree.value
 		for range wraps {
 			wrapped = []any{wrapped}
@@ -146,9 +140,8 @@ func TestPropertyConfigurableAddonsMatchesTheRegistry(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		names := configurableAddons()
 
-		// The list `drupdater addons` prints is what a user may write in .drupdater.yaml, so it
-		// has to be exactly the registry minus the addons that always run. Adding a registry
-		// entry without touching this function would leave the command silent about it.
+		// What `drupdater addons` prints is what a user may write, so a new registry entry
+		// must not be able to go unlisted.
 		want := make([]string, 0, len(addonRegistry))
 		for name := range addonRegistry {
 			if name != "composer_audit" && !slices.Contains(mandatoryAddons, name) {
@@ -187,9 +180,7 @@ func TestPropertyValidateAddonsRejectsUnknownNamesInEitherRunType(t *testing.T) 
 			config.RunTypes.Normal.Addons = append(slices.Clone(known), unknown)
 		}
 
-		// Symmetric on purpose: a typo under run_types.security is caught on a normal run and
-		// the other way round, so the mistake surfaces the first time the tool runs at all
-		// rather than the first time a security update happens to be due.
+		// Symmetric on purpose, so a typo surfaces the first time the tool runs at all.
 		err := validateAddons(config)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), unknown)

--- a/cmd/root_run_test.go
+++ b/cmd/root_run_test.go
@@ -45,9 +45,7 @@ func runUpdateWith(t *testing.T, args ...string) error {
 }
 
 func TestRunUpdateRequiresATokenWhenItWillPublish(t *testing.T) {
-	// A publishing run (no --dry-run) pushes a branch and opens a merge request, so it cannot
-	// start without credentials. Failing here rather than midway is the point: the alternative
-	// is a run that does all the work and then cannot deliver it.
+	// A publishing run must fail up front, not after doing all the work it cannot deliver.
 	t.Setenv("DRUPDATER_TOKEN", "")
 	withRootCmdState(t, internal.Config{WorkingDir: t.TempDir()}, "")
 
@@ -153,9 +151,7 @@ func checkoutWithOrigin(t *testing.T) string {
 }
 
 func TestRunUpdateWiresUpAndStartsTheWorkflow(t *testing.T) {
-	// Everything up to the workflow runs for real here: the service constructors, checkout
-	// resolution, the addon registry and the dispatcher. Only the run itself is replaced, so
-	// this covers the wiring that a unit test otherwise cannot reach at all.
+	// Everything up to the workflow runs for real; only the run itself is replaced.
 	fake := &fakeWorkflow{}
 	withFakeWorkflow(t, fake)
 
@@ -190,9 +186,7 @@ func TestRunUpdateReportsAWorkflowFailure(t *testing.T) {
 }
 
 func TestRunUpdateWritesTheRunReport(t *testing.T) {
-	// --report registers a sink on the workflow. The file itself is written by the workflow,
-	// which is faked here, so what this pins is that requesting a report does not break the
-	// wiring -- the option path is otherwise never exercised.
+	// The workflow writes the file and is faked here, so this pins only the option wiring.
 	fake := &fakeWorkflow{}
 	withFakeWorkflow(t, fake)
 
@@ -259,14 +253,11 @@ func TestExecuteDoesNotExitOnSuccess(t *testing.T) {
 }
 
 func TestCreateAddonsPassesEveryDependency(t *testing.T) {
-	// createAddons builds one dependency struct and hands it to every addon factory. Nothing
-	// downstream reports a missing field, so a dependency dropped here would only surface as a
-	// nil-pointer panic in the middle of a real run.
+	// Nothing downstream reports a missing dependency: it surfaces as a nil-pointer panic
+	// mid-run.
 	var got addonDeps
 	oldRegistry, oldMandatory := addonRegistry, mandatoryAddons
-	// The probes delegate to a real factory, so an actual addon is constructed from the
-	// captured dependencies rather than a stand-in. Two of them, so the test also shows the
-	// same struct reaches every addon rather than only the first.
+	// Real factories, and two of them, so the same struct is shown to reach every addon.
 	var second addonDeps
 	realFactory := oldRegistry["composer_diff"]
 	require.NotNil(t, realFactory)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -55,10 +55,8 @@ func TestNewLogger(t *testing.T) {
 }
 
 func TestPersistentFlagDefaults(t *testing.T) {
-	// The defaults are the behaviour of an invocation that passes no flags, and several of them
-	// are safety-critical: --security defaulting to true would silently change every run into a
-	// security-only one, and --clone defaulting to true would make drupdater clone instead of
-	// updating the checkout it was pointed at.
+	// Safety-critical: --security defaulting to true makes every run security-only, --clone
+	// makes drupdater clone instead of updating the checkout it was pointed at.
 	tests := []struct {
 		flag string
 		want string
@@ -170,9 +168,7 @@ func TestCreateAddons(t *testing.T) {
 	})
 
 	t.Run("composer_audit and unsupported_modules run on a normal update", func(t *testing.T) {
-		// Both are mandatory in either mode: between them they are the project's "no longer
-		// maintained" report, and they render it as one list. A mode that ran only one of them
-		// would publish half a list.
+		// Both are mandatory: they render one list, so either alone publishes half of it.
 		config := internal.Config{RunTypes: internal.RunTypesConfig{Normal: internal.RunTypeConfig{}}}
 		addons, err := createAddons(logger, config, nil, nil, nil, nil)
 		require.NoError(t, err)
@@ -181,9 +177,8 @@ func TestCreateAddons(t *testing.T) {
 		assert.Contains(t, mandatoryAddons, "unsupported_modules")
 	})
 
-	// composer_audit now runs in both modes, so --security has to reach it some other way than
-	// by its mere presence. These two pin that wiring on the one difference visible from here:
-	// only a security run relabels the merge request.
+	// composer_audit runs in both modes, so --security must reach it some other way. Pinned on
+	// the one difference visible here: only a security run relabels the merge request.
 	t.Run("security mode lets composer_audit relabel the merge request", func(t *testing.T) {
 		config := internal.Config{Security: true, RunTypes: internal.RunTypesConfig{Security: internal.RunTypeConfig{}}}
 		addons, err := createAddons(logger, config, nil, nil, nil, nil)
@@ -311,9 +306,7 @@ func TestResolveCheckoutBranch(t *testing.T) {
 	})
 
 	t.Run("falls back to the GitLab CI variable", func(t *testing.T) {
-		// Both CI variables are consulted. With only the GitHub one covered, dropping the GitLab
-		// operand would go unnoticed and every detached GitLab CI run would fail to find its
-		// branch.
+		// Both CI variables: covering only GitHub would let the GitLab operand be dropped.
 		t.Setenv("GITHUB_REF_NAME", "")
 		t.Setenv("CI_COMMIT_REF_NAME", "release-2")
 		branch, err := resolveCheckoutBranch(svc, initRepo(t, true))

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,33 +1,26 @@
-# Codecov has been receiving this module's coverage since the Go workflow was written, with no
-# configuration at all: no target, no threshold, nothing ignored. The ">= 90% for a changed
-# package" rule lives in .claude/rules/coverage.md, CONTRIBUTING.md and two documentation pages,
-# and until now was enforced by nothing -- the local pre-commit hook prints the numbers and ends
-# in `; true`.
+# Enforces the ">= 90% for a changed package" rule documented in .claude/rules/coverage.md and
+# CONTRIBUTING.md, which the local pre-commit hook only ever printed.
 #
-# This does not replace the mutation gate in .github/workflows/go.yml. Line coverage says a line
-# ran; mutation says a test fails when it is wrong, and the module scored 67% MSI at 90%+ line
-# coverage. Coverage is the floor, not the bar.
+# Not a replacement for go.yml's mutation gate: the module scored 67% MSI at 90%+ line coverage.
+# Coverage is the floor, not the bar.
 
 coverage:
   status:
-    # The module sits around 95%. The target is the documented 90% rather than "never drop",
-    # so an honest refactor that trades a few covered lines for less code is not a failure.
+    # The documented 90%, not "never drop", so a refactor trading covered lines for less code
+    # is not a failure.
     project:
       default:
         target: 90%
         threshold: 1%
-    # New and changed lines are held to the same 90%. This is the one that matters day to day:
-    # it is the automated half of the rule contributors are already asked to follow.
+    # New and changed lines held to the same 90% -- the half that matters day to day.
     patch:
       default:
         target: 90%
 
-# main.go is `cmd.Execute()` and nothing else. It cannot be covered without executing the binary,
-# and a single permanently-uncovered statement drags the project number for no signal.
+# main.go is `cmd.Execute()` and nothing else, uncoverable without executing the binary.
 #
-# Deliberately NOT listed here: the generated mocks_test.go files. `go test -coverprofile` does
-# not instrument _test.go files at all, so they never reach the report and ignoring them would
-# be a no-op that reads like it does something.
+# The generated mocks_test.go files are deliberately absent: -coverprofile does not instrument
+# _test.go at all, so ignoring them would be a no-op that reads like it does something.
 ignore:
   - "main.go"
 

--- a/internal/addon.go
+++ b/internal/addon.go
@@ -11,8 +11,7 @@ import (
 	"github.com/gookit/event"
 )
 
-// cellReplacer escapes values interpolated into markdown table cells so a
-// literal "|" or newline can't break the table layout.
+// cellReplacer stops a literal "|" or newline in a value from breaking a markdown table.
 var cellReplacer = strings.NewReplacer("|", "\\|", "\n", " ", "\r", "")
 
 //go:embed addon/templates
@@ -28,8 +27,7 @@ type Addon interface {
 type BasicAddon struct {
 }
 
-// addonTemplates parses the embedded section templates once. The FS is compiled in, so the
-// result — success or failure — is the same on every call.
+// addonTemplates parses the embedded templates once: the FS is compiled in, so the result is fixed.
 var addonTemplates = sync.OnceValues(func() (*template.Template, error) {
 	return template.New("").Funcs(template.FuncMap{
 		"cell": cellReplacer.Replace,

--- a/internal/addon/addons_extra_test.go
+++ b/internal/addon/addons_extra_test.go
@@ -290,11 +290,6 @@ func countOccurrences(haystack string, needle string) int {
 	return count
 }
 
-// anyCtx matches any non-nil context.Context in a mock expectation.
-//
-// Addons receive the context on the event payload and hand it to every service call. Matching
-// it with mock.Anything let a call site drop it entirely without a test noticing, which would
-// silently disable cancellation and the run timeout for everything below that point. The exact
-// value cannot always be pinned -- the workflow derives per-site contexts -- but requiring
-// non-nil catches the failure that matters.
+// anyCtx matches any non-nil context.Context in a mock expectation. mock.Anything would let a
+// call site drop the context entirely, silently disabling cancellation and the run timeout.
 var anyCtx = mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })

--- a/internal/addon/code_beautifier.go
+++ b/internal/addon/code_beautifier.go
@@ -23,8 +23,7 @@ type CodeBeautifier struct {
 	phpcs    PHPCS
 	composer Composer
 
-	// What the run fixed, for the report. Written once from the single post-code-update
-	// event, read after the run.
+	// For the report. Written once from the single post-code-update event, read after the run.
 	fixedFiles []string
 	fixable    int
 }
@@ -50,9 +49,8 @@ func (cb *CodeBeautifier) RenderTemplate() (string, error) {
 	return "", nil
 }
 
-// phpcsConfigPath returns the project's phpcs config file. found is true when a candidate is
-// present — or when stat failed for a reason other than absence, which is not this function's
-// call to interpret: a config that exists but cannot be read must not read as "no config".
+// phpcsConfigPath returns the project's phpcs config file. An unreadable config counts as found:
+// only absence means "no config".
 func phpcsConfigPath(path string) (configPath string, found bool) {
 	for _, name := range []string{"phpcs.xml", "phpcs.xml.dist"} {
 		candidate := filepath.Join(path, name)
@@ -122,10 +120,8 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) (err error) { //n
 		if err := cb.InstallCoder(event.Context(), event.Path(), event.Worktree()); err != nil {
 			return err
 		}
-		// Deferred rather than called at the end: every path below returns early -- nothing
-		// fixable, nothing staged, phpcs failing -- and a coder left behind is a dev dependency
-		// the project never asked for, committed into the update branch and absent from the run
-		// report's package list, which is exactly what the lock-versus-report check catches.
+		// Deferred, not called at the end: every path below returns early, and a coder left
+		// behind is committed into the update branch as a dependency nobody asked for.
 		defer func() {
 			if removeErr := cb.removeCoder(event.Context(), event.Path(), event.Worktree()); removeErr != nil && err == nil {
 				err = removeErr
@@ -163,9 +159,8 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) (err error) { //n
 		addedFiles = append(addedFiles, relativePath)
 	}
 
-	// phpcbf may have changed nothing — not every "fixable" issue is, and RunCBF errors are
-	// only logged — which would make an empty commit go-git rejects. Checked against just this
-	// handler's own paths, so another listener's dangling change is never swept in.
+	// phpcbf may have changed nothing, which would make an empty commit go-git rejects. Only
+	// this handler's own paths, so another listener's dangling change is never swept in.
 	staged, err := stagedAnyOf(event.Worktree(), addedFiles)
 	if err != nil {
 		return fmt.Errorf("failed to check worktree status: %w", err)
@@ -185,8 +180,7 @@ func (cb *CodeBeautifier) postCodeUpdateHandler(e event.Event) (err error) { //n
 	return nil
 }
 
-// stagedAnyOf reports whether any of paths has a staged (non-Unmodified) change in worktree. An
-// empty paths list is "nothing to check" and short-circuits without querying git status.
+// stagedAnyOf reports whether any of paths has a staged change in worktree.
 func stagedAnyOf(worktree Worktree, paths []string) (bool, error) {
 	if len(paths) == 0 {
 		return false, nil
@@ -245,8 +239,8 @@ func (cb *CodeBeautifier) CreatePHPCSConfig(ctx context.Context, path string, wo
 		return false, nil
 	}
 
-	// Render before touching the filesystem: an early return above would otherwise leave an
-	// empty phpcs.xml behind, and the next run fails parsing it for <file> definitions.
+	// Render before touching the filesystem, or a template failure leaves an empty phpcs.xml
+	// behind that the next run fails to parse.
 	var rendered bytes.Buffer
 	if err := tmpl.Execute(&rendered, data); err != nil {
 		return false, fmt.Errorf("failed to execute phpcs template: %w", err)
@@ -291,13 +285,11 @@ func (cb *CodeBeautifier) InstallCoder(ctx context.Context, path string, worktre
 	return nil
 }
 
-// removeCoder undoes InstallCoder. Removing it rarely restores composer.lock byte-for-byte, so
-// the remainder is committed here rather than left for another listener's AddGlob("composer.*")
-// to sweep into its own commit.
+// removeCoder undoes InstallCoder. Removing it rarely restores composer.lock byte-for-byte, so the
+// remainder is committed here rather than swept into another listener's AddGlob("composer.*").
 func (cb *CodeBeautifier) removeCoder(ctx context.Context, path string, worktree Worktree) error {
 	cb.logger.Debug("removing drupal/coder")
-	// --dev because InstallCoder required it there. Without the flag composer refuses with
-	// "could not be found in require but it is present in require-dev" and fails the run.
+	// --dev because InstallCoder required it there; without the flag composer refuses.
 	if _, err := cb.composer.Remove(ctx, path, "--dev", "drupal/coder"); err != nil {
 		return err
 	}

--- a/internal/addon/code_beautifier_test.go
+++ b/internal/addon/code_beautifier_test.go
@@ -458,9 +458,8 @@ func TestCodingStyles(t *testing.T) {
 		composer := NewMockComposer(t)
 		composer.EXPECT().IsPackageInstalled(anyCtx, "/tmp", "drupal/coder").Return(false, nil)
 		composer.EXPECT().Require(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
-		// Coder was installed only to run phpcs, so it has to go again -- even on this path,
-		// where there was nothing to fix. Left behind, it reaches the merge request as a dev
-		// dependency the project never asked for and that no report mentions.
+		// Coder has to go even on this path, or it reaches the merge request as a dependency
+		// nobody asked for.
 		composer.EXPECT().Remove(anyCtx, "/tmp", []string{"--dev", "drupal/coder"}).Return("", nil)
 
 		worktree.EXPECT().AddGlob("composer.*").Return(nil)
@@ -771,9 +770,7 @@ func TestRemoveCoder(t *testing.T) {
 }
 
 func TestCoderRemovalErrorDoesNotMaskTheRealFailure(t *testing.T) {
-	// The deferred cleanup reports its own failure only when the handler was otherwise fine.
-	// Letting it overwrite a live error would replace "phpcs blew up" with "could not uninstall
-	// coder", and the run report would name the wrong cause.
+	// The deferred cleanup must not overwrite a live error, or the report names the wrong cause.
 	logger := zap.NewNop()
 
 	fileExists = func(_ string) bool { return true }
@@ -834,13 +831,9 @@ func TestCoderRemovalFailureSurfacesOnAnOtherwiseCleanRun(t *testing.T) {
 }
 
 func TestCoderIsRemovedFromTheSectionItWasInstalledInto(t *testing.T) {
-	// Install and removal must name the same dependency section. composer rejects the mismatch
-	// outright -- "drupal/coder could not be found in require but it is present in require-dev"
-	// -- and the whole run fails in post-code-update.
-	//
-	// Asserting the two calls against each other rather than against a hard-coded flag: a mock
-	// that simply echoes back whatever the code passes will happily agree with a wrong flag, and
-	// did, until an integration run caught it.
+	// Install and removal must name the same dependency section, or composer rejects the
+	// mismatch and the run fails. Asserted against each other, not a hard-coded flag: a mock
+	// agrees with whatever the code passes, and did, until an integration run caught it.
 	logger := zap.NewNop()
 
 	fileExists = func(_ string) bool { return true }

--- a/internal/addon/composer_audit.go
+++ b/internal/addon/composer_audit.go
@@ -21,15 +21,8 @@ type SecurityReport struct {
 	AfterUpdateAdvisories []composer.Advisory
 }
 
-// ComposerAudit handles security auditing for Drupal sites.
-//
-// It runs on every update because `composer audit` answers two questions and only one is
-// specific to --security: which packages must be updated *now*, and what the resulting code's
-// security posture is. A monthly update that happens to close a CVE should say so, and the
-// abandoned-package list comes from the same audit.
-//
-// The security flag separates the two: only a security run lets the audit dictate the update's
-// scope, abort when there is nothing to fix, and relabel the merge request.
+// ComposerAudit runs on every update: a routine update that closes a CVE should say so. Only a
+// security run lets the audit dictate the update's scope, abort, and relabel the merge request.
 type ComposerAudit struct {
 	internal.BasicAddon
 	logger   *zap.Logger
@@ -41,8 +34,7 @@ type ComposerAudit struct {
 	afterAudit  composer.Audit
 }
 
-// NewComposerAudit creates a new security auditor instance. security marks a `--security` run,
-// in which the audit drives the update rather than only describing it.
+// NewComposerAudit creates a security auditor. security marks a `--security` run.
 func NewComposerAudit(logger *zap.Logger, composer Composer, security bool) *ComposerAudit {
 	return &ComposerAudit{
 		logger:   logger,
@@ -58,8 +50,7 @@ func (ca *ComposerAudit) SubscribedEvents() map[string]any {
 			Priority: event.Max,
 			Listener: event.ListenerFunc(ca.preComposerUpdateHandler),
 		},
-		// Below Normal: this reports the final code's security posture, so it must run after
-		// code_beautifier and deprecations_remover rather than interleaving with them.
+		// BelowNormal: audits the final code, so it must run after the addons that rewrite it.
 		"post-code-update": event.ListenerItem{
 			Priority: event.BelowNormal,
 			Listener: event.ListenerFunc(ca.postCodeUpdateHandler),
@@ -71,13 +62,8 @@ func (ca *ComposerAudit) SubscribedEvents() map[string]any {
 	}
 }
 
-// RenderTemplate returns the rendered template for this addon.
-//
-// A run with no advisories at all renders nothing — the common case on a normal run, where a
-// "🛡️ Security Report" section saying nothing would appear in every routine merge request.
-//
-// The abandoned packages go to unsupported_modules via pre-merge-request-create instead, which
-// renders both as one list: to a reviewer they are the same finding.
+// RenderTemplate renders nothing when there are no advisories at all, so a routine merge request
+// carries no empty security section. Abandoned packages go to unsupported_modules instead.
 func (ca *ComposerAudit) RenderTemplate() (string, error) {
 	fixed := ca.GetFixedAdvisories()
 	if len(fixed) == 0 && len(ca.afterAudit.Advisories) == 0 {
@@ -90,10 +76,8 @@ func (ca *ComposerAudit) RenderTemplate() (string, error) {
 	})
 }
 
-// preComposerUpdateHandler audits the code as it stands before the update.
-//
-// On a security run it narrows the update to the affected packages and aborts when there are
-// none. On a normal run it only records the audit: the scope is the user's to decide.
+// preComposerUpdateHandler audits the pre-update code. A security run narrows the update to the
+// affected packages and aborts when there are none; a normal run only records the audit.
 func (ca *ComposerAudit) preComposerUpdateHandler(e event.Event) error {
 	evt := e.(*services.PreComposerUpdateEvent)
 	var err error
@@ -107,8 +91,7 @@ func (ca *ComposerAudit) preComposerUpdateHandler(e event.Event) error {
 		return nil
 	}
 
-	// Deduplicated in first-seen order: several advisories often name one package, and the list
-	// becomes composer update's package arguments.
+	// Deduplicated: several advisories often name one package, and this becomes composer's args.
 	packagesToUpdate := make([]string, 0)
 	seen := make(map[string]bool, len(ca.beforeAudit.Advisories))
 	for _, advisory := range ca.beforeAudit.Advisories {
@@ -152,12 +135,8 @@ func (ca *ComposerAudit) postCodeUpdateHandler(e event.Event) error {
 	return nil
 }
 
-// GetAbandonedPackages returns the abandoned packages from the post-update audit, so the list
-// describes the code the merge request actually contains. Unlike an advisory, one that is no
-// longer abandoned is simply absent — there is nothing for the update to take credit for.
-//
-// drupal/* is left out: unsupported_modules already reports those from drupal.org's own release
-// data, and listing them twice would read as two separate findings.
+// GetAbandonedPackages returns the post-update audit's abandoned packages, minus drupal/*:
+// unsupported_modules reports those from drupal.org's release data, and twice reads as two findings.
 func (ca *ComposerAudit) GetAbandonedPackages() []composer.AbandonedPackage {
 	abandoned := make([]composer.AbandonedPackage, 0, len(ca.afterAudit.Abandoned))
 	for _, pkg := range ca.afterAudit.Abandoned {
@@ -169,9 +148,7 @@ func (ca *ComposerAudit) GetAbandonedPackages() []composer.AbandonedPackage {
 	return abandoned
 }
 
-// GetFixedAdvisories returns the advisories present before the update but not after. Identified
-// by CVE, falling back to advisory ID and then package+title, so the CVE-less ones don't all
-// collide on the empty string.
+// GetFixedAdvisories returns the advisories present before the update but not after.
 func (ca *ComposerAudit) GetFixedAdvisories() []composer.Advisory {
 	afterKeys := make(map[string]bool, len(ca.afterAudit.Advisories))
 	for _, afterAdvisory := range ca.afterAudit.Advisories {
@@ -187,11 +164,9 @@ func (ca *ComposerAudit) GetFixedAdvisories() []composer.Advisory {
 	return fixed
 }
 
-// advisoryKey returns a stable identity that does not collapse distinct advisories lacking a CVE.
-//
-// The last fallback quotes both halves instead of joining on a separator: a title is free text
-// and may contain one. Two advisories colliding here means one is reported as fixed while it is
-// still open, in a security update.
+// advisoryKey identifies an advisory without collapsing the CVE-less ones onto one key: a
+// collision reports an advisory as fixed while it is still open. The last fallback quotes both
+// halves rather than joining on a separator, because a title is free text.
 func advisoryKey(a composer.Advisory) string {
 	if a.CVE != "" {
 		return "cve:" + a.CVE
@@ -202,11 +177,8 @@ func advisoryKey(a composer.Advisory) string {
 	return "pkg:" + strconv.Quote(a.PackageName) + strconv.Quote(a.Title)
 }
 
-// preMergeRequestCreateHandler publishes the abandoned packages for unsupported_modules to
-// render, and — on a security run only — relabels the merge request.
-//
-// Priority is load-bearing: this runs at Normal and unsupported_modules at BelowNormal, so the
-// list is on the event before the addon that renders it reads it.
+// preMergeRequestCreateHandler publishes the abandoned packages for unsupported_modules and, on a
+// security run, relabels the merge request. Runs at Normal, above the BelowNormal consumer.
 func (ca *ComposerAudit) preMergeRequestCreateHandler(e event.Event) error {
 	evt := e.(*services.PreMergeRequestCreateEvent)
 

--- a/internal/addon/composer_audit_property_test.go
+++ b/internal/addon/composer_audit_property_test.go
@@ -9,14 +9,11 @@ import (
 	"pgregory.net/rapid"
 )
 
-// GetFixedAdvisories is a set difference, and it decides what a security merge request claims to
-// have fixed. Getting it wrong in the generous direction — reporting an advisory as fixed while
-// it is still open — is the failure that matters, so the laws of set difference are asserted
-// here rather than sampled.
+// GetFixedAdvisories decides what a security merge request claims to have fixed, so the laws of
+// set difference are asserted rather than sampled.
 
-// advisoryGen generates an advisory in one of the three states the key function distinguishes:
-// with a CVE, with only an advisory ID, and with neither. Free-text fields draw separators on
-// purpose, because that is where a hand-rolled composite key breaks.
+// advisoryGen covers the three states advisoryKey distinguishes. Free-text fields draw
+// separators on purpose: that is where a composite key breaks.
 func advisoryGen() *rapid.Generator[composer.Advisory] {
 	text := rapid.StringMatching(`[a-zA-Z0-9 |:"\\-]{0,12}`)
 	return rapid.Custom(func(t *rapid.T) composer.Advisory {
@@ -92,9 +89,8 @@ func TestPropertyAdvisoryKeyTellsDistinctAdvisoriesApart(t *testing.T) {
 		a := advisoryGen().Draw(t, "a")
 		b := advisoryGen().Draw(t, "b")
 
-		// Two advisories may share a key only when they are the same advisory. Titles are free
-		// text and routinely contain the punctuation a composite key is built from, so this is
-		// where an ambiguous separator shows up.
+		// A shared key must mean the same advisory. Titles routinely carry the punctuation a
+		// composite key is built from.
 		sameIdentity := (a.CVE != "" && a.CVE == b.CVE) ||
 			(a.CVE == "" && b.CVE == "" && a.AdvisoryID != "" && a.AdvisoryID == b.AdvisoryID) ||
 			(a.CVE == "" && b.CVE == "" && a.AdvisoryID == "" && b.AdvisoryID == "" &&
@@ -112,11 +108,9 @@ func TestPropertyAdvisoryKeySurvivesSeparatorsInFreeText(t *testing.T) {
 		right := rapid.StringMatching(`[a-z]{1,6}`).Draw(t, "right")
 		separator := rapid.SampledFrom([]string{"|", ":", `"`, `\`, "/"}).Draw(t, "separator")
 
-		// Two genuinely different advisories, split at different points around the same
-		// character. Any key that joins the fields on a fixed separator maps both onto one
-		// string, and the second advisory is then reported as fixed while it is still open.
-		// Drawing the two halves independently, as the property above does, would essentially
-		// never line them up like this — the ambiguity has to be constructed to be found.
+		// Two different advisories split around the same character: a fixed separator maps
+		// both onto one key, reporting the second as fixed while it is still open. The
+		// property above would essentially never line them up — this has to be constructed.
 		a := composer.Advisory{PackageName: left + separator + middle, Title: right}
 		b := composer.Advisory{PackageName: left, Title: middle + separator + right}
 

--- a/internal/addon/composer_audit_test.go
+++ b/internal/addon/composer_audit_test.go
@@ -151,9 +151,8 @@ func TestAdvisoryKey(t *testing.T) {
 	assert.Equal(t, `pkg:"drupal/foo""Title"`, advisoryKey(composer.Advisory{PackageName: "drupal/foo", Title: "Title"}))
 }
 
-// TestAdvisoryKey_SeparatorInTitle covers the fallback's ambiguity. An advisory title is free
-// text, so joining package and title on a separator lets two different advisories share a key —
-// and a shared key means the second one is reported as fixed while it is still open.
+// A title is free text, so joining package and title on a separator lets two advisories share
+// a key — and the second is then reported as fixed while it is still open.
 func TestAdvisoryKey_SeparatorInTitle(t *testing.T) {
 	split := composer.Advisory{PackageName: "drupal/foo|Access", Title: "bypass"}
 	other := composer.Advisory{PackageName: "drupal/foo", Title: "Access|bypass"}
@@ -286,9 +285,7 @@ func TestComposerAudit_RenderTemplate_EscapesPipes(t *testing.T) {
 	assert.NotContains(t, result, "a|b")
 }
 
-// TestComposerAudit_GetAbandonedPackages_FiltersDrupalPackages checks that drupal/* packages
-// are left to unsupported_modules, which reports them from drupal.org's own release data, so
-// one end-of-life module is not reported twice in the same merge request.
+// drupal/* is left to unsupported_modules, so one module is not reported twice.
 func TestComposerAudit_GetAbandonedPackages_FiltersDrupalPackages(t *testing.T) {
 	audit := NewComposerAudit(zap.NewNop(), NewMockComposer(t), true)
 	audit.afterAudit = composer.Audit{
@@ -321,10 +318,8 @@ func TestComposerAudit_GetAbandonedPackages_UsesTheAuditAfterTheUpdate(t *testin
 	assert.Equal(t, []composer.AbandonedPackage{{PackageName: "still/here"}}, audit.GetAbandonedPackages())
 }
 
-// TestComposerAudit_PreComposerUpdateHandler_NormalMode checks that a normal run audits without
-// taking over the update. The scope of a maintenance update is the user's to decide, and an
-// update with no advisories to fix still has everything else to do — narrowing or aborting here
-// would turn every normal run into a security run.
+// A normal run audits without taking over: narrowing or aborting here would turn every normal
+// run into a security run.
 func TestComposerAudit_PreComposerUpdateHandler_NormalMode(t *testing.T) {
 	mockComposer := NewMockComposer(t)
 	audit := NewComposerAudit(zap.NewNop(), mockComposer, false)
@@ -399,9 +394,8 @@ func TestComposerAudit_PreMergeRequestCreateHandler_PublishesAbandonedPackages(t
 	assert.Equal(t, []services.AbandonedPackage{{Name: "patchwork/jsqueeze"}}, mockEvent.AbandonedPackages)
 }
 
-// TestComposerAudit_RenderTemplate_NothingToReport checks a run that found no advisories at all
-// contributes no section. Otherwise every routine merge request would carry a security report
-// whose only content is that there was nothing to report.
+// No advisories at all contributes no section, or every routine merge request carries an empty
+// security report.
 func TestComposerAudit_RenderTemplate_NothingToReport(t *testing.T) {
 	audit := NewComposerAudit(zap.NewNop(), NewMockComposer(t), false)
 
@@ -410,9 +404,7 @@ func TestComposerAudit_RenderTemplate_NothingToReport(t *testing.T) {
 	assert.Empty(t, result)
 }
 
-// TestComposerAudit_RenderTemplate_OmitsAbandonedPackages checks the abandoned packages are not
-// rendered here: they go to unsupported_modules, and rendering them in both places would show
-// the same finding twice.
+// Abandoned packages go to unsupported_modules; rendering them here too shows one finding twice.
 func TestComposerAudit_RenderTemplate_OmitsAbandonedPackages(t *testing.T) {
 	audit := NewComposerAudit(zap.NewNop(), NewMockComposer(t), true)
 	audit.afterAudit = composer.Audit{
@@ -425,9 +417,7 @@ func TestComposerAudit_RenderTemplate_OmitsAbandonedPackages(t *testing.T) {
 	assert.NotContains(t, result, "patchwork/jsqueeze")
 }
 
-// TestComposerAudit_RenderTemplate_FixedOnly covers the other half of the "nothing to report"
-// guard: a run that closed every advisory it found still has something to say, and must not be
-// silenced along with the run that found none.
+// The other half of the guard: a run that closed every advisory still has something to say.
 func TestComposerAudit_RenderTemplate_FixedOnly(t *testing.T) {
 	audit := NewComposerAudit(zap.NewNop(), NewMockComposer(t), true)
 	audit.beforeAudit = composer.Audit{
@@ -440,11 +430,8 @@ func TestComposerAudit_RenderTemplate_FixedOnly(t *testing.T) {
 	assert.Contains(t, result, "All security issues have been resolved.")
 }
 
-// TestComposerAudit_AuditFailures covers the two points where composer audit itself fails.
-//
-// Both matter more than a usual error path: composer_audit runs at Max priority on
-// pre-composer-update, so a swallowed failure here would let a security run continue with an
-// empty advisory list -- updating nothing and reporting that everything is fine.
+// A swallowed audit failure would let a security run continue with an empty advisory list,
+// updating nothing and reporting that everything is fine.
 func TestComposerAudit_AuditFailures(t *testing.T) {
 	path := "/test/path"
 
@@ -476,9 +463,7 @@ func TestComposerAudit_AuditFailures(t *testing.T) {
 	})
 }
 
-// TestComposerAudit_PreComposerUpdateHandler_DeduplicatesPackages pins the behaviour the handler's
-// own comment describes: several advisories usually name the same package, and this list becomes
-// composer update's arguments. Passing a package twice is what the dedup exists to prevent.
+// The list becomes composer update's arguments, which must not name a package twice.
 func TestComposerAudit_PreComposerUpdateHandler_DeduplicatesPackages(t *testing.T) {
 	mockComposer := NewMockComposer(t)
 	audit := NewComposerAudit(zap.NewNop(), mockComposer, true)

--- a/internal/addon/composer_diff.go
+++ b/internal/addon/composer_diff.go
@@ -33,8 +33,7 @@ func (cd *ComposerDiff) SubscribedEvents() map[string]any {
 	}
 }
 
-// RenderTemplate returns "" when there is no dependency diff to show, so the section is omitted
-// rather than emitted as an empty header — as every other addon does.
+// RenderTemplate returns "" with no diff, so the section is omitted rather than left empty.
 func (cd *ComposerDiff) RenderTemplate() (string, error) {
 	if cd.table == "" {
 		return "", nil
@@ -51,8 +50,7 @@ func (cd *ComposerDiff) postComposerUpdateHandler(e event.Event) error {
 	}
 	cd.table = table
 
-	// The log gets the link-free table — markdown URLs are unreadable in a terminal. A failure
-	// here costs only a log line, so it must not fail the run.
+	// The log gets the link-free table: markdown URLs are unreadable in a terminal.
 	plain, err := cd.composer.Diff(evt.Context(), evt.Path(), false)
 	if err != nil {
 		cd.logger.Warn("failed to render the dependency diff for the log", zap.Error(err))

--- a/internal/addon/composer_patches_1.go
+++ b/internal/addon/composer_patches_1.go
@@ -31,8 +31,7 @@ func (pu PatchUpdates) Changes() bool {
 	return len(pu.Removed) > 0 || len(pu.Updated) > 0 || len(pu.Conflicts) > 0
 }
 
-// The json tags on these three types are part of the --report schema (see report.go in this
-// package); rename a field only alongside a report.SchemaVersion bump.
+// The json tags below are published --report schema; renaming one needs a SchemaVersion bump.
 
 type RemovedPatch struct {
 	Package          string `json:"package"`
@@ -176,8 +175,8 @@ func (h *ComposerPatches1) updatePatches(ctx context.Context, path string, workt
 	for _, op := range operations {
 		switch op.Action {
 		case "Upgrade", "Downgrade":
-			// processSinglePatch mutates patches[op.Package], so snapshot first: a key it
-			// inserts must not be visited again in the same pass.
+			// processSinglePatch mutates patches[op.Package]; a key it inserts must not be
+			// visited again in the same pass.
 			for _, e := range snapshotPatches(patches[op.Package]) {
 				h.processSinglePatch(ctx, path, worktree, op, e.description, e.patchPath, patches, &updates)
 			}
@@ -198,8 +197,7 @@ type patchEntry struct {
 	patchPath   string
 }
 
-// snapshotPatches copies a package's description→path map into a stable slice so callers can
-// iterate while mutating the underlying map.
+// snapshotPatches copies a patch map so callers can iterate while mutating the underlying map.
 func snapshotPatches(m map[string]string) []patchEntry {
 	entries := make([]patchEntry, 0, len(m))
 	for description, patchPath := range m {
@@ -208,19 +206,14 @@ func snapshotPatches(m map[string]string) []patchEntry {
 	return entries
 }
 
-// isRemotePatch reports whether a patch reference is an http/https URL. The scheme is checked
-// explicitly because url.ParseRequestURI also accepts a local path like "/patches/x.diff".
+// isRemotePatch checks the scheme explicitly: url.ParseRequestURI also accepts "/patches/x.diff".
 func isRemotePatch(patchPath string) bool {
 	u, err := url.Parse(patchPath)
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
 }
 
-// resolvePatchPath makes a patch reference absolute for the patch-test project, which runs from
-// a temp directory where a project-relative path points nowhere. A remote patch is already
-// absolute.
-//
-// Must go through isRemotePatch: url.ParseRequestURI accepts "/patches/x.diff", which would pass
-// through unprefixed, fail to resolve, and pin the package on a conflict that never happened.
+// resolvePatchPath makes a patch reference absolute for the patch-test project, which runs from a
+// temp directory where a project-relative path points nowhere.
 func resolvePatchPath(projectDir string, patchPath string) string {
 	if isRemotePatch(patchPath) {
 		return patchPath
@@ -239,9 +232,8 @@ func conflict(op composer.PackageChange, patchPath string, description string) C
 	}
 }
 
-// dropPatchFile removes a patch's file from the worktree. A remote patch has no file, which is
-// not an error. Every removal goes through here so a URL never reaches worktree.Remove, which
-// would fail and read as "the patch could not be dropped".
+// dropPatchFile removes a patch's file. Every removal goes through here so a remote patch's URL
+// never reaches worktree.Remove, which would fail and read as "the patch could not be dropped".
 func (h *ComposerPatches1) dropPatchFile(worktree Worktree, patchPath string) error {
 	if isRemotePatch(patchPath) {
 		return nil
@@ -250,10 +242,8 @@ func (h *ComposerPatches1) dropPatchFile(worktree Worktree, patchPath string) er
 	return err
 }
 
-// removeDependencyProvidedPatches drops root patches an installed dependency already applies to
-// the same package: composer-patches would otherwise apply the same file twice, and the second
-// fails. Only remote patches count — a local path is package-relative, so matching strings in
-// two packages are not the same file.
+// removeDependencyProvidedPatches drops root patches a dependency already applies, which
+// composer-patches would apply twice. Remote only: a local path is package-relative.
 func (h *ComposerPatches1) removeDependencyProvidedPatches(ctx context.Context, path string, patches map[string]map[string]string) []RemovedPatch {
 	depPatches, err := h.composer.GetDependencyPatches(ctx, path)
 	if err != nil {
@@ -343,8 +333,8 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 			} else if len(commits) != 0 {
 				h.logger.Debug("issue is fixed", zap.String("issue", issue.ID))
 				if err := h.dropPatchFile(worktree, patchPath); err != nil {
-					// Restore the entry deleted above: a patch whose file could not be removed
-					// must stay declared rather than vanish from composer.json unreported.
+					// Restore the entry deleted above: a patch whose file survived must stay
+					// declared rather than vanish from composer.json unreported.
 					h.logger.Error("failed to remove patch", zap.String("patch", patchPath), zap.Error(err))
 					patches[op.Package][description] = patchPath
 					return
@@ -364,9 +354,8 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 
 	ok, err := h.composer.CheckIfPatchApplies(ctx, path, op.Package, op.To, resolvePatchPath(path, patchPath))
 	if err != nil {
-		// The check could not run at all, usually because the package was unobtainable. An
-		// unverifiable patch is not a stale one: pinning here would hold the package back on
-		// every run and blame a conflict that never happened.
+		// An unverifiable patch is not a stale one: pinning here would hold the package back
+		// on every run and blame a conflict that never happened.
 		h.logger.Warn("could not check whether the patch still applies, leaving the package unpinned",
 			zap.String("package", op.Package), zap.String("patch", patchPath), zap.Error(err))
 		return
@@ -384,8 +373,7 @@ func (h *ComposerPatches1) processSinglePatch(ctx context.Context, path string, 
 		return
 	}
 
-	// Locating a newer patch from the issue fork needs the drupalcode GitLab client, which is
-	// only configured when DRUPALCODE_ACCESS_TOKEN is set. Without it, keep the current version.
+	// Finding a newer patch needs the drupalcode client, configured only with DRUPALCODE_ACCESS_TOKEN.
 	if h.gitlab == nil {
 		h.logger.Info("patch does not apply and no drupalcode client is configured, keeping current package version", zap.String("package", op.Package), zap.String("version", op.From), zap.String("patch", patchPath))
 		updates.Conflicts = append(updates.Conflicts, conflict(op, patchPath, description))
@@ -465,8 +453,8 @@ func (h *ComposerPatches1) validateCombinedPatches(ctx context.Context, path str
 	}
 }
 
-// fetchForkMergeRequests returns open MRs in projectMachineName that originate from forkProjectID.
-// ponytail: raw request because gitlab.ListMergeRequests doesn't support source_project_id filtering
+// fetchForkMergeRequests returns open MRs in projectMachineName originating from forkProjectID.
+// Raw request: gitlab.ListMergeRequests cannot filter on source_project_id.
 func (h *ComposerPatches1) fetchForkMergeRequests(projectMachineName string, forkProjectID int64) ([]*gitlab.BasicMergeRequest, error) {
 	opt := struct {
 		gitlab.ListProjectMergeRequestsOptions
@@ -490,8 +478,7 @@ func (h *ComposerPatches1) fetchForkMergeRequests(projectMachineName string, for
 
 var unsafeFileNameChars = regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
 
-// cleanURLString turns an issue title into a safe file name component: lower-cased, spaces to
-// underscores, everything outside [a-z0-9-_.] stripped, so it can hold no path separator.
+// cleanURLString turns an issue title into a file name component that holds no path separator.
 func (h *ComposerPatches1) cleanURLString(s string) string {
 	s = strings.ToLower(s)
 	s = strings.ReplaceAll(s, " ", "_")

--- a/internal/addon/composer_patches_1_property_test.go
+++ b/internal/addon/composer_patches_1_property_test.go
@@ -12,10 +12,8 @@ import (
 	"pgregory.net/rapid"
 )
 
-// Both helpers below turn untrusted input into a decision about the filesystem: cleanURLString
-// builds a file name out of a drupal.org issue title, and isRemotePatch decides whether a patch
-// reference names a file to remove at all. Titles are written by whoever opened the issue, so
-// "for every input" is the only useful scope for their promises.
+// Both helpers below turn untrusted input into a filesystem decision, and the input is written
+// by whoever opened the drupal.org issue — so "for every input" is the only useful scope.
 
 // safeFileNameChars is the character set cleanURLString promises to stay inside — no separator
 // and nothing else that would break os.Create.
@@ -27,15 +25,12 @@ func TestPropertyCleanURLStringProducesASafeFileName(t *testing.T) {
 
 		cleaned := (&ComposerPatches1{}).cleanURLString(title)
 
-		// The result is concatenated into a path and handed to os.Create. Any title at all —
-		// including one containing "../", a NUL byte or a full URL — has to come out as
-		// something that cannot leave the patch directory.
+		// The result is concatenated into a path and handed to os.Create, so no title may
+		// produce a name that leaves the patch directory.
 		assert.Regexp(t, safeFileNameChars, cleaned, "cleaned %q", title)
 
-		// Stated on the name the caller actually builds rather than on the fragment. A run of
-		// dots survives cleaning, and that is fine: with no separator in the character set it
-		// cannot form a traversal, and the fragment is always embedded between an issue ID and
-		// the ".diff" suffix, so the name can never be "." or ".." either.
+		// Stated on the whole name, not the fragment: a run of dots survives cleaning, which
+		// is harmless once embedded between an issue ID and ".diff".
 		const patchDir = "patches/drupal"
 		name := fmt.Sprintf("%s-%s-%s.diff", "3456789", "0ff1ce", cleaned)
 		assert.Equal(t, name, filepath.Base(name), "%q is not a single path element", name)
@@ -64,9 +59,8 @@ func TestPropertyIsRemotePatchRejectsEveryFilesystemPath(t *testing.T) {
 			path = "/" + path
 		}
 
-		// A local patch has a file in the worktree that has to be removed when the patch is
-		// dropped. Classifying it as remote makes the removal a silent no-op, so the patch file
-		// stays behind and composer-patches keeps applying it.
+		// Misclassifying a local patch as remote makes its removal a silent no-op, and
+		// composer-patches keeps applying the file left behind.
 		assert.False(t, isRemotePatch(path), "for %q", path)
 	})
 }
@@ -94,9 +88,8 @@ func TestPropertyDropPatchFileTouchesTheWorktreeOnlyForLocalPatches(t *testing.T
 			worktree.EXPECT().Remove(patchPath).Return(plumbing.Hash{}, nil).Once()
 		}
 
-		// A remote patch has no file in the repository, so handing its URL to worktree.Remove
-		// would fail and leave the caller believing the patch could not be dropped. The two
-		// have to agree for every reference, not just for the ones someone listed.
+		// A URL handed to worktree.Remove fails, and reads as "the patch could not be
+		// dropped". The two have to agree for every reference, not just the listed ones.
 		assert.NoError(t, (&ComposerPatches1{}).dropPatchFile(worktree, patchPath))
 	})
 }

--- a/internal/addon/composer_patches_1_removal_test.go
+++ b/internal/addon/composer_patches_1_removal_test.go
@@ -60,9 +60,8 @@ func upgradeCore() []composer.PackageChange {
 }
 
 func TestUpdatePatchesRemovesRemotePatchForFixedIssue(t *testing.T) {
-	// A remote patch has no file in the repository, so there is nothing to remove from the
-	// worktree — passing its URL to worktree.Remove would fail, and the patch used to be
-	// dropped from composer.json without ever being reported in the merge request.
+	// A remote patch has no file to remove. Passing its URL to worktree.Remove used to fail,
+	// dropping the patch from composer.json unreported.
 	const patchURL = "https://www.drupal.org/files/issues/123456-1.patch"
 
 	composerService := NewMockComposer(t)
@@ -155,9 +154,8 @@ func TestDropPatchFile(t *testing.T) {
 }
 
 func TestValidateCombinedPatchesResolvesAbsoluteLocalPaths(t *testing.T) {
-	// An absolute local path is not a remote patch. url.ParseRequestURI accepts it, so the
-	// previous check passed it through unprefixed, composer could not find it, and the package
-	// was pinned on a patch conflict that did not exist.
+	// url.ParseRequestURI accepts an absolute local path, which once passed through unprefixed
+	// and pinned the package on a conflict that did not exist.
 	composerService := NewMockComposer(t)
 	composerService.EXPECT().
 		CheckIfPatchesApply(mock.Anything, mock.Anything, "drupal/core", "8.8.0", mock.Anything).
@@ -187,13 +185,9 @@ func TestValidateCombinedPatchesResolvesAbsoluteLocalPaths(t *testing.T) {
 }
 
 func TestUpdatePatchesRecognisesEveryFixedIssueStatus(t *testing.T) {
-	// drupal.org has three statuses that mean "the fix has landed": 2 (Fixed), 7 (Closed
-	// (fixed)) and 15 (Patch (to be ported)). Each is checked separately in the guard, so each
-	// needs its own case -- otherwise two of the three could be deleted and patches for issues
-	// closed under those statuses would be carried forward forever.
-	//
-	// The negative case matters just as much: an issue still open must keep its patch, or a
-	// live fix would be dropped from composer.json.
+	// Three drupal.org statuses mean "the fix has landed" -- 2, 7 and 15 -- each checked
+	// separately in the guard, so each needs its own case. The negative matters as much: an
+	// open issue must keep its patch, or a live fix is dropped from composer.json.
 	tests := []struct {
 		name        string
 		status      string

--- a/internal/addon/composer_patches_1_test.go
+++ b/internal/addon/composer_patches_1_test.go
@@ -77,10 +77,8 @@ func TestComposerPatches1_RenderTemplate_NoChanges(t *testing.T) {
 }
 
 func TestComposerPatches1_RenderTemplate_AnyChangeRenders(t *testing.T) {
-	// The empty check has three independent clauses, and each one alone must be enough to
-	// produce a section. Testing only "all empty" and "everything populated" would let any two
-	// of the three be deleted without a failure -- and the addon would then stay silent about a
-	// patch it had removed, updated or found conflicting.
+	// Each of the three clauses alone must produce a section, or two could be deleted and the
+	// addon would stay silent about a patch it removed, updated or found conflicting.
 	tests := []struct {
 		name    string
 		updates PatchUpdates
@@ -267,9 +265,7 @@ func TestUpdatePatches(t *testing.T) {
 
 		report, newPatches := updater.updatePatches(t.Context(), "/tmp", worktree, operations, patches)
 		assert.Empty(t, newPatches["drupal/core"], "patch provided by a dependency should be removed from root")
-		// Assert the whole record, not just the path. Every field ends up in the merge request:
-		// the package and description identify which patch was dropped, and the reason is the
-		// only explanation the reviewer gets for why it disappeared.
+		// The whole record, not just the path: every field ends up in the merge request.
 		require.Len(t, report.Removed, 1)
 		assert.Equal(t, RemovedPatch{
 			Package:          "drupal/core",

--- a/internal/addon/composer_patches_1_unverifiable_test.go
+++ b/internal/addon/composer_patches_1_unverifiable_test.go
@@ -16,10 +16,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// A patch check that could not be carried out is not the same as a patch that was checked and
-// rejected. Only the second is a conflict; the first must leave the package alone, or a package
-// whose registry is unreachable gets pinned on every run and the merge request blames a patch
-// conflict that never happened.
+// A check that could not run is not a rejected patch. Only the second is a conflict: pinning on
+// the first blames a conflict that never happened, on every run.
 func TestUpdatePatchesLeavesUnverifiablePatchesUnpinned(t *testing.T) {
 	logger := zap.NewNop()
 	unverifiable := errors.New("could not obtain drupal/core 8.8.0 to test its patches (not available from any configured repository)")

--- a/internal/addon/deprecations_remover.go
+++ b/internal/addon/deprecations_remover.go
@@ -17,8 +17,7 @@ type DeprecationsRemover struct {
 	rector   Rector
 	composer Composer
 
-	// Which rules rewrote which files, for the report. Written once from the single
-	// post-code-update event, read after the run.
+	// For the report. Written once from the single post-code-update event, read after the run.
 	fixes []DeprecationFix
 }
 
@@ -32,9 +31,8 @@ func NewDeprecationsRemover(logger *zap.Logger, rector Rector, composer Composer
 
 func (dr *DeprecationsRemover) SubscribedEvents() map[string]any {
 	return map[string]any{
-		// Above Normal: this handler temporarily requires palantirnet/drupal-rector, and
-		// code_beautifier (Normal) may commit composer.* via AddGlob. Running in between would
-		// sweep this handler's half-finished composer diff into that commit.
+		// AboveNormal: this temporarily requires drupal-rector, and code_beautifier (Normal)
+		// commits composer.* via AddGlob — interleaving sweeps a half-finished diff into it.
 		"post-code-update": event.ListenerItem{
 			Priority: event.AboveNormal,
 			Listener: event.ListenerFunc(dr.postCodeUpdateHandler),
@@ -74,8 +72,8 @@ func (dr *DeprecationsRemover) postCodeUpdateHandler(e event.Event) error {
 		if _, err := dr.composer.Remove(evt.Context(), evt.Path(), "palantirnet/drupal-rector"); err != nil {
 			return err
 		}
-		// Removing rector rarely restores composer.lock byte-for-byte. Commit the remainder here
-		// so no other listener's AddGlob("composer.*") sweeps this diff into its own commit.
+		// Removing rector rarely restores composer.lock byte-for-byte; commit the remainder
+		// here so no other listener's AddGlob("composer.*") sweeps it up.
 		if err := dr.commitTemporaryRectorCleanup(evt.Worktree()); err != nil {
 			return err
 		}
@@ -100,8 +98,7 @@ func (dr *DeprecationsRemover) postCodeUpdateHandler(e event.Event) error {
 	return err
 }
 
-// commitTemporaryRectorCleanup commits any composer.json/composer.lock diff left over from
-// temporarily requiring palantirnet/drupal-rector, or does nothing if removing it left no trace.
+// commitTemporaryRectorCleanup commits whatever composer.* diff removing drupal-rector left behind.
 func (dr *DeprecationsRemover) commitTemporaryRectorCleanup(worktree Worktree) error {
 	if err := worktree.AddGlob("composer.*"); err != nil {
 		return err
@@ -117,8 +114,7 @@ func (dr *DeprecationsRemover) commitTemporaryRectorCleanup(worktree Worktree) e
 	return err
 }
 
-// recordFixes captures which rules fired on which files, so the report says more than "some
-// deprecations were removed".
+// recordFixes captures which rules fired on which files, for the report.
 func (dr *DeprecationsRemover) recordFixes(result rector.ReturnOutput) {
 	rectorsByFile := make(map[string][]string, len(result.FileDiffs))
 	for _, diff := range result.FileDiffs {
@@ -127,8 +123,7 @@ func (dr *DeprecationsRemover) recordFixes(result rector.ReturnOutput) {
 
 	fixes := make([]DeprecationFix, 0, len(result.ChangedFiles))
 	for _, file := range result.ChangedFiles {
-		// Cloned before sorting: in place would reorder the caller's rector.ReturnOutput, and a
-		// file listed twice would leave two fixes sharing one backing array.
+		// Cloned: sorting in place would reorder the caller's rector.ReturnOutput.
 		applied := slices.Clone(rectorsByFile[file])
 		slices.Sort(applied)
 		fixes = append(fixes, DeprecationFix{File: file, AppliedRectors: applied})

--- a/internal/addon/deprecations_remover_property_test.go
+++ b/internal/addon/deprecations_remover_property_test.go
@@ -9,10 +9,8 @@ import (
 	"pgregory.net/rapid"
 )
 
-// recordFixes turns rector's output into a report section, and the section is supposed to be
-// byte-identical for two runs over unchanged code. Rector's output order is not something this
-// code controls, so "the same input in a different order gives the same section" is exactly the
-// promise — and a permutation is what states it.
+// recordFixes must produce a byte-identical section for two runs over unchanged code, and
+// rector's output order is not this code's to control — hence a permutation property.
 
 func rectorOutputGen() *rapid.Generator[rector.ReturnOutput] {
 	fileGen := rapid.StringMatching(`(web|modules)/[a-z0-9_]{1,8}/[a-z0-9_]{1,8}\.php`)
@@ -65,9 +63,7 @@ func TestPropertyRecordFixesCoversEveryChangedFile(t *testing.T) {
 		remover := &DeprecationsRemover{}
 		remover.recordFixes(output)
 
-		// Every changed file is accounted for, each carries exactly the rules rector recorded
-		// for it, and both levels come out ordered — that ordering is the whole reason the
-		// section is stable across runs.
+		// Every file accounted for, with its own rules, and both levels ordered.
 		assert.Len(t, remover.fixes, len(output.ChangedFiles))
 		for i, fix := range remover.fixes {
 			assert.ElementsMatch(t, rulesFor(output, fix.File), fix.AppliedRectors, "rules for %q", fix.File)
@@ -94,18 +90,16 @@ func TestPropertyRecordFixesLeavesRectorsOutputAlone(t *testing.T) {
 
 		(&DeprecationsRemover{}).recordFixes(output)
 
-		// The caller still owns this value — the post-code-update handler passes rector's own
-		// output and goes on using it. Sorting a slice out of it in place reaches back into
-		// data this function was only given to read.
+		// The caller still owns this value, so sorting in place reaches into data recordFixes
+		// was only given to read.
 		for i, diff := range output.FileDiffs {
 			assert.Equal(t, before[i], diff.AppliedRectors, "AppliedRectors of %q was rewritten", diff.File)
 		}
 	})
 }
 
-// rulesFor returns the rules the output records for file, unsorted, or nil when the file has no
-// diff entry. Deliberately not a second implementation of recordFixes: it only looks the entry
-// up, and the property compares the two as sets and checks the ordering separately.
+// rulesFor looks up a file's recorded rules, unsorted. Deliberately not a second implementation
+// of recordFixes: the property compares the two as sets and checks ordering separately.
 func rulesFor(output rector.ReturnOutput, file string) []string {
 	for _, diff := range output.FileDiffs {
 		if diff.File == file {

--- a/internal/addon/deprecations_remover_test.go
+++ b/internal/addon/deprecations_remover_test.go
@@ -16,10 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestRecordFixes_DoesNotSortRectorsOutputInPlace pins that recordFixes only reads the value it
-// is handed. It sorts each file's rules, and doing that on the slice inside rector's own output
-// would reorder data the caller still owns — and hand two fixes for the same file one shared
-// backing array.
+// recordFixes sorts each file's rules, which in place would reorder data the caller still owns.
 func TestRecordFixes_DoesNotSortRectorsOutputInPlace(t *testing.T) {
 	output := rector.ReturnOutput{
 		ChangedFiles: []string{"web/modules/custom/a.php"},

--- a/internal/addon/report.go
+++ b/internal/addon/report.go
@@ -9,33 +9,19 @@ import (
 	"github.com/drupdater/drupdater/pkg/drush"
 )
 
-// This file holds every addon's contribution to the machine-readable run report (--report).
+// Every addon's contribution to the --report document, together in one file because these
+// methods are a published contract and a rename spread over eight files is easy to miss.
 //
-// Together these methods are the report's addons schema, a published contract. Scattered across
-// eight files it is easy to rename a field without noticing a consumer depends on it.
+// Addons satisfy report.Reporter structurally, so none of them imports the report package. Keys
+// match .drupdater.yaml's addon names.
 //
-// Each addon satisfies report.Reporter structurally, so none of them imports the report package.
-// The keys match .drupdater.yaml's addon names, so a report reads the way the project is
-// configured.
-//
-// Two addons deliberately contribute nothing:
-//
-//   - composer_diff renders a markdown table of what the top-level "packages" field already
-//     carries in structured form.
-//   - composer_normalizer only reorders composer.json, which the diff shows.
-//
-// Everything else reports, even addons whose work is "only" a code change: most log and swallow
-// their own failures, so one that silently did nothing is otherwise indistinguishable from one
-// with nothing to do.
+// composer_diff and composer_normalizer contribute nothing: the top-level "packages" field
+// already carries what they do.
 
 // --- composer_audit ---
 
-// SecurityAdvisories is the composer_audit section: which advisories the update resolved and
-// which are still open. Remaining is the more actionable half — a fleet-wide exposure view is
-// built from it.
-//
-// Abandoned is not an advisory but the same shape of finding as an unsupported module, on the
-// non-Drupal packages unsupported_modules cannot see.
+// SecurityAdvisories is the composer_audit section. Abandoned is not an advisory but the same
+// kind of finding, on the non-Drupal packages unsupported_modules cannot see.
 type SecurityAdvisories struct {
 	Fixed     []composer.Advisory         `json:"fixed"`
 	Remaining []composer.Advisory         `json:"remaining"`
@@ -45,8 +31,7 @@ type SecurityAdvisories struct {
 // ReportKey implements report.Reporter.
 func (ca *ComposerAudit) ReportKey() string { return "composer_audit" }
 
-// ReportData implements report.Reporter. The abandoned packages are already sorted by name
-// when composer's output is parsed, so this section stays byte-stable across runs.
+// ReportData implements report.Reporter. Abandoned packages arrive sorted, so this stays stable.
 func (ca *ComposerAudit) ReportData() any {
 	fixed := ca.GetFixedAdvisories()
 	remaining := ca.afterAudit.Advisories
@@ -73,8 +58,7 @@ func (uh *UpdateHooks) ReportData() any {
 		return nil
 	}
 
-	// Copy: the caller has no way to know this map is mutex-guarded state. Deep, because the
-	// per-site maps are guarded too.
+	// Deep copy: the caller has no way to know these maps are mutex-guarded state.
 	out := make(map[string]map[string]drush.UpdateHook, len(uh.hooks))
 	for site, hooks := range uh.hooks {
 		out[site] = maps.Clone(hooks)
@@ -88,8 +72,7 @@ func (uh *UpdateHooks) ReportData() any {
 // ReportKey implements report.Reporter.
 func (um *UnsupportedModules) ReportKey() string { return "unsupported_modules" }
 
-// ReportData implements report.Reporter. Sorted by name so two runs over an unchanged site
-// produce byte-identical sections a consumer can diff directly.
+// ReportData implements report.Reporter. Sorted so an unchanged site reports byte-identically.
 func (um *UnsupportedModules) ReportData() any {
 	um.mu.Lock()
 	defer um.mu.Unlock()
@@ -106,8 +89,7 @@ func (um *UnsupportedModules) ReportData() any {
 
 // --- composer_patches ---
 
-// Patches is the composer_patches section. Conflicts are the ones that need a human: a patch
-// that no longer applies to the updated package and could not be replaced automatically.
+// Patches is the composer_patches section. Conflicts are the ones that need a human.
 type Patches struct {
 	Removed   []RemovedPatch  `json:"removed"`
 	Updated   []UpdatedPatch  `json:"updated"`
@@ -132,9 +114,8 @@ func (h *ComposerPatches1) ReportData() any {
 
 // --- code_beautifier ---
 
-// CodingStyleFixes is the code_beautifier section: which files PHPCBF fixed and committed, and
-// how many violations PHPCS called fixable beforehand. The two differ when PHPCBF cannot fix a
-// violation it reported as fixable.
+// CodingStyleFixes is the code_beautifier section. Files and Fixable differ when PHPCBF cannot
+// fix a violation PHPCS reported as fixable.
 type CodingStyleFixes struct {
 	Files   []string `json:"files"`
 	Fixable int      `json:"fixable"`
@@ -153,8 +134,8 @@ func (cb *CodeBeautifier) ReportData() any {
 
 // --- deprecations_remover ---
 
-// DeprecationFix is one file Rector rewrote, and the rules that fired on it. The rule names are
-// the actionable part: they say which deprecation was removed, which "the file changed" does not.
+// DeprecationFix is one file Rector rewrote, and the rules that fired — which name the
+// deprecation removed, where "the file changed" does not.
 type DeprecationFix struct {
 	File           string   `json:"file"`
 	AppliedRectors []string `json:"applied_rectors,omitempty"`
@@ -173,9 +154,8 @@ func (dr *DeprecationsRemover) ReportData() any {
 
 // --- translations_updater ---
 
-// TranslationResult is one site's outcome. Skipped is set when the addon bailed out by design --
-// no locale_deploy, or an unresolvable translation path -- which a report that simply omitted
-// the site would render indistinguishable from "ran and found nothing".
+// TranslationResult is one site's outcome. Skipped records a deliberate bail-out, which omitting
+// the site would make indistinguishable from "ran and found nothing".
 type TranslationResult struct {
 	Path    string `json:"path,omitempty"`
 	Updated bool   `json:"updated"`
@@ -185,8 +165,7 @@ type TranslationResult struct {
 // ReportKey implements report.Reporter.
 func (tu *TranslationsUpdater) ReportKey() string { return "translations_updater" }
 
-// ReportData implements report.Reporter. Keyed by site: in a multisite run each site has its own
-// translation directory and can succeed or skip independently.
+// ReportData implements report.Reporter. Keyed by site: each has its own translation directory.
 func (tu *TranslationsUpdater) ReportData() any {
 	tu.mu.Lock()
 	defer tu.mu.Unlock()

--- a/internal/addon/report_test.go
+++ b/internal/addon/report_test.go
@@ -49,9 +49,8 @@ func TestComposerAuditReportData(t *testing.T) {
 	}, data.Abandoned)
 }
 
-// TestComposerAuditReportDataOnAbandonedAlone covers the case where the update resolved every
-// advisory it found: the section is still worth emitting, because the abandoned packages in it
-// are a standing finding that no update is going to clear.
+// An update that resolved every advisory still emits the section: abandoned packages are a
+// standing finding no update clears.
 func TestComposerAuditReportDataOnAbandonedAlone(t *testing.T) {
 	ca := &ComposerAudit{
 		afterAudit: composer.Audit{
@@ -67,9 +66,8 @@ func TestComposerAuditReportDataOnAbandonedAlone(t *testing.T) {
 	assert.Equal(t, "patchwork/jsqueeze", data.Abandoned[0].PackageName)
 }
 
-// TestComposerAuditReportDataNilWhenOnlyDrupalPackagesAreAbandoned checks the drupal/* filter
-// applies before the "nothing to report" decision, so a run whose only finding belongs to
-// unsupported_modules does not add an empty composer_audit section.
+// The drupal/* filter applies before the "nothing to report" check, so a finding that belongs
+// to unsupported_modules adds no empty composer_audit section.
 func TestComposerAuditReportDataNilWhenOnlyDrupalPackagesAreAbandoned(t *testing.T) {
 	ca := &ComposerAudit{
 		afterAudit: composer.Audit{

--- a/internal/addon/translations_updater_test.go
+++ b/internal/addon/translations_updater_test.go
@@ -90,9 +90,8 @@ func TestUpdateTranslationsEventHandlerWithLocaleDeploy(t *testing.T) {
 }
 
 func TestUpdateTranslationsEventHandlerSkipsWhenTranslationPathUnavailable(t *testing.T) {
-	// A GetTranslationPath failure (e.g. locale.settings.translation.path unset) must be a soft
-	// skip, not a fatal error: nothing must be staged or committed on this path, since an empty
-	// path handed to Worktree.Add would stage the entire working tree instead of nothing.
+	// A soft skip, not a fatal error — and nothing staged: an empty path handed to
+	// Worktree.Add stages the entire working tree.
 	mockDrush := NewMockDrush(t)
 	mockRepository := NewMockRepository(t)
 	logger := zap.NewNop()
@@ -123,9 +122,7 @@ func TestUpdateTranslationsEventHandlerSkipsWhenTranslationPathUnavailable(t *te
 }
 
 func TestUpdateTranslationsEventHandlerRecordsNothingToCommit(t *testing.T) {
-	// Translations were localized but produced no change. The site must still appear in the
-	// report with its path -- and explicitly not as updated, which is what tells a reviewer the
-	// merge request contains no translation commit.
+	// Localized but unchanged: the site still appears in the report, explicitly not updated.
 	mockDrush := NewMockDrush(t)
 	mockRepository := NewMockRepository(t)
 	handler := NewTranslationsUpdater(zap.NewNop(), mockDrush, mockRepository)

--- a/internal/addon/unsupported_modules.go
+++ b/internal/addon/unsupported_modules.go
@@ -13,42 +13,35 @@ import (
 	"go.uber.org/zap"
 )
 
-// UnsupportedModules detects installed modules that have reached end-of-life according to
-// Drupal's update status service (status NOT_SUPPORTED): they have no supported upgrade path,
-// which is a different risk category than a security vulnerability caught by composer_audit.
-//
-// It also renders the abandoned packages composer_audit hands it on pre-merge-request-create.
-// Those come from Packagist and cover the non-Drupal libraries this addon cannot see, but they
-// tell a reviewer the same thing — no further fixes are coming — so they share one list.
+// UnsupportedModules detects modules Drupal's update status service reports as NOT_SUPPORTED, and
+// renders them together with the abandoned packages composer_audit hands it: one finding to a
+// reviewer, so one list.
 type UnsupportedModules struct {
 	internal.BasicAddon
 	logger *zap.Logger
 	drush  Drush
 
-	// mu guards modules: preSiteUpdateHandler runs concurrently for each site. Keyed by module
-	// name so results are deduplicated across sites in multisite runs.
+	// mu guards modules: preSiteUpdateHandler runs concurrently for each site. Keyed by name,
+	// so multisite results are deduplicated.
 	mu      sync.Mutex
 	modules map[string]drush.UnsupportedModule
 
-	// Written once from pre-merge-request-create, which fires after every site's goroutine has
-	// finished, so unlike modules it needs no lock.
+	// Written once from pre-merge-request-create, after every site's goroutine — no lock needed.
 	abandoned []services.AbandonedPackage
 }
 
-// EndOfLifeEntry is one row of the merged "unsupported or abandoned" table. Status names the
-// source, rather than pretending a module version and a replacement package are one column.
+// EndOfLifeEntry is one row of the merged "unsupported or abandoned" table.
 type EndOfLifeEntry struct {
 	Name string
 	// Status is "Unsupported module" or "Abandoned package".
 	Status string
-	// InstalledVersion is empty for an abandoned package: `composer audit` does not report one,
-	// and the dependency table already carries every installed version.
+	// InstalledVersion is empty for an abandoned package: `composer audit` reports none.
 	InstalledVersion string
 	// Recommendation is what to do about it, already phrased for the reader.
 	Recommendation string
 }
 
-// NewUnsupportedModules creates a new unsupported modules detector instance.
+// NewUnsupportedModules creates an unsupported modules detector.
 func NewUnsupportedModules(logger *zap.Logger, drushClient Drush) *UnsupportedModules {
 	return &UnsupportedModules{
 		logger:  logger,
@@ -63,9 +56,8 @@ func (um *UnsupportedModules) SubscribedEvents() map[string]any {
 			Priority: event.Normal,
 			Listener: event.ListenerFunc(um.preSiteUpdateHandler),
 		},
-		// Below Normal: composer_audit puts the abandoned packages on this event at Normal. At
-		// equal priority the dispatcher decides the order, and the list would sometimes be read
-		// before it is written.
+		// BelowNormal: composer_audit writes the abandoned packages at Normal. At equal
+		// priority the list would sometimes be read before it is written.
 		"pre-merge-request-create": event.ListenerItem{
 			Priority: event.BelowNormal,
 			Listener: event.ListenerFunc(um.preMergeRequestCreateHandler),
@@ -73,8 +65,7 @@ func (um *UnsupportedModules) SubscribedEvents() map[string]any {
 	}
 }
 
-// RenderTemplate returns the rendered template for this addon: the unsupported modules and the
-// abandoned packages as one table, or nothing at all when there is neither.
+// RenderTemplate renders modules and abandoned packages as one table, or nothing when empty.
 func (um *UnsupportedModules) RenderTemplate() (string, error) {
 	entries := um.endOfLifeEntries()
 	if len(entries) == 0 {
@@ -84,16 +75,12 @@ func (um *UnsupportedModules) RenderTemplate() (string, error) {
 	return um.Render("unsupported_modules.go.tmpl", entries)
 }
 
-// endOfLifeEntries returns the merged table rows, sorted by name. One list rather than two
-// groups: the Status column already says which kind each row is, and a reviewer should not have
-// to know which addon found a package. Sorting also makes the section byte-stable — both halves
-// come from maps, whose iteration order is random.
+// endOfLifeEntries returns the merged table rows. Sorted because both halves come from maps.
 func (um *UnsupportedModules) endOfLifeEntries() []EndOfLifeEntry {
 	entries := make([]EndOfLifeEntry, 0, len(um.modules)+len(um.abandoned))
 
 	for _, module := range um.collectModules() {
-		// drush reports the literal string "None" when there is no supported release at all,
-		// which is a status rather than a version to move to.
+		// drush reports "None" when there is no supported release — a status, not a version.
 		recommendation := "Update to " + module.RecommendedVersion
 		if module.RecommendedVersion == "" || module.RecommendedVersion == "None" {
 			recommendation = "No supported release — replace it"
@@ -125,9 +112,8 @@ func (um *UnsupportedModules) endOfLifeEntries() []EndOfLifeEntry {
 	return entries
 }
 
-// collectModules returns the modules gathered so far. The lock is not needed today —
-// errgroup.Wait already orders every site's goroutine before rendering — but that is the
-// caller's invariant, not this type's.
+// collectModules locks even though errgroup.Wait already orders every site's goroutine before
+// rendering: that ordering is the caller's invariant, not this type's.
 func (um *UnsupportedModules) collectModules() []drush.UnsupportedModule {
 	um.mu.Lock()
 	defer um.mu.Unlock()
@@ -135,8 +121,7 @@ func (um *UnsupportedModules) collectModules() []drush.UnsupportedModule {
 	return slices.Collect(maps.Values(um.modules))
 }
 
-// preMergeRequestCreateHandler takes composer_audit's abandoned packages so they render
-// alongside the unsupported modules. Not logged here — composer_audit already logged the count.
+// preMergeRequestCreateHandler takes composer_audit's abandoned packages, to render alongside.
 func (um *UnsupportedModules) preMergeRequestCreateHandler(e event.Event) error {
 	evt := e.(*services.PreMergeRequestCreateEvent)
 
@@ -145,8 +130,7 @@ func (um *UnsupportedModules) preMergeRequestCreateHandler(e event.Event) error 
 	return nil
 }
 
-// preSiteUpdateHandler checks a site for unsupported modules. Best-effort: an unreachable update
-// status service is logged and swallowed, since an unsupported module is reported, not an error.
+// preSiteUpdateHandler checks a site. Best-effort: an unreachable status service is not an error.
 func (um *UnsupportedModules) preSiteUpdateHandler(e event.Event) error {
 	evt := e.(*services.PreSiteUpdateEvent)
 

--- a/internal/addon/unsupported_modules_test.go
+++ b/internal/addon/unsupported_modules_test.go
@@ -36,9 +36,8 @@ func TestUnsupportedModules_SubscribedEvents(t *testing.T) {
 	assert.Contains(t, events, "pre-site-update")
 	assert.IsType(t, event.ListenerItem{}, events["pre-site-update"])
 
-	// Below Normal on pre-merge-request-create, strictly below the Normal that composer_audit
-	// publishes the abandoned packages at. Equal priorities would leave the order to the
-	// dispatcher and the list would sometimes be read before it is written.
+	// Strictly below the Normal composer_audit publishes at: at equal priority the list would
+	// sometimes be read before it is written.
 	assert.Contains(t, events, "pre-merge-request-create")
 	preMerge := events["pre-merge-request-create"].(event.ListenerItem)
 	assert.Equal(t, event.BelowNormal, preMerge.Priority)
@@ -180,10 +179,8 @@ func TestUnsupportedModules_PreMergeRequestCreateHandler(t *testing.T) {
 	assert.Equal(t, evt.AbandonedPackages, um.abandoned)
 }
 
-// TestUnsupportedModules_RenderTemplate_AbandonedOnly checks a project with no unsupported
-// module but an abandoned package still gets the section. Before the two were merged this was
-// the case that fell through the gap: nothing on Drupal.org's side to report, and no other
-// section to put a Packagist finding in.
+// An abandoned package with no unsupported module still gets the section — the case that fell
+// through the gap before the two lists were merged.
 func TestUnsupportedModules_RenderTemplate_AbandonedOnly(t *testing.T) {
 	um := NewUnsupportedModules(zap.NewNop(), NewMockDrush(t))
 	um.abandoned = []services.AbandonedPackage{{Name: "patchwork/jsqueeze"}}
@@ -193,9 +190,8 @@ func TestUnsupportedModules_RenderTemplate_AbandonedOnly(t *testing.T) {
 	assert.Contains(t, result, "| patchwork/jsqueeze | Abandoned package | — | No replacement suggested |")
 }
 
-// TestUnsupportedModules_EndOfLifeEntries_Ordering pins the row order: one list sorted by
-// name, with the two sources interleaved rather than grouped. Both halves originate from maps,
-// so without the sort two runs over an unchanged project would produce different descriptions.
+// One list sorted by name, sources interleaved. Both halves come from maps, so without the sort
+// two runs over an unchanged project produce different descriptions.
 func TestUnsupportedModules_EndOfLifeEntries_Ordering(t *testing.T) {
 	um := NewUnsupportedModules(zap.NewNop(), NewMockDrush(t))
 	um.modules = map[string]drush.UnsupportedModule{
@@ -214,9 +210,7 @@ func TestUnsupportedModules_EndOfLifeEntries_Ordering(t *testing.T) {
 	assert.Equal(t, []string{"acme/pkg", "alpha", "zebra", "zeta/pkg"}, names)
 }
 
-// TestUnsupportedModules_EndOfLifeEntries_Recommendations covers the four ways a row's
-// recommendation is phrased, including drush's literal "None" for a module with no supported
-// release at all — which is a status, not a version to update to.
+// The four phrasings, including drush's literal "None" — a status, not a version to update to.
 func TestUnsupportedModules_EndOfLifeEntries_Recommendations(t *testing.T) {
 	um := NewUnsupportedModules(zap.NewNop(), NewMockDrush(t))
 	um.modules = map[string]drush.UnsupportedModule{
@@ -242,10 +236,8 @@ func TestUnsupportedModules_EndOfLifeEntries_Recommendations(t *testing.T) {
 	}, got)
 }
 
-// TestUnsupportedModules_AbandonedHandoff runs the whole handoff through a real dispatcher:
-// composer_audit publishes on pre-merge-request-create and unsupported_modules renders. It is
-// the only test that covers the wiring rather than the two halves — the subscription itself,
-// and the priority that puts the write before the read.
+// The whole handoff through a real dispatcher — the only test covering the wiring itself: the
+// subscription, and the priority that puts the write before the read.
 func TestUnsupportedModules_AbandonedHandoff(t *testing.T) {
 	audit := NewComposerAudit(zap.NewNop(), NewMockComposer(t), false)
 	audit.afterAudit = composer.Audit{

--- a/internal/addon/update_hooks.go
+++ b/internal/addon/update_hooks.go
@@ -40,8 +40,7 @@ func (uh *UpdateHooks) SubscribedEvents() map[string]any {
 	}
 }
 
-// RenderTemplate locks even though errgroup.Wait already orders every site's goroutine before
-// this call: that ordering is the caller's invariant, not this type's.
+// RenderTemplate locks because the goroutine ordering is the caller's invariant, not this type's.
 func (uh *UpdateHooks) RenderTemplate() (string, error) {
 	uh.mu.Lock()
 	defer uh.mu.Unlock()

--- a/internal/codehosting/factory.go
+++ b/internal/codehosting/factory.go
@@ -53,8 +53,8 @@ func (vpf *DefaultVcsProviderFactory) Create(repositoryURL string, token string,
 	}
 }
 
-// providerFromEnv reads the provider from CI environment variables, which are authoritative and
-// work for self-hosted instances whose hostname does not name the provider. "" when not in CI.
+// providerFromEnv reads the provider from CI, which also covers self-hosted instances whose
+// hostname does not name it. "" when not in CI.
 func providerFromEnv() string {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		return "github"
@@ -65,8 +65,7 @@ func providerFromEnv() string {
 	return ""
 }
 
-// providerFromHost matches on the host, not the whole URL, so github.com/foo/gitlab-migration
-// is not misrouted to GitLab.
+// providerFromHost matches the host, not the URL: github.com/foo/gitlab-migration is not GitLab.
 func providerFromHost(host string) string {
 	host = strings.ToLower(host)
 	switch {
@@ -79,15 +78,13 @@ func providerFromHost(host string) string {
 	}
 }
 
-// ValidateRepositoryURL reports whether raw is a URL this tool can route to a provider, so
-// callers validate against what Create accepts — including scheme-less SCP-style git URLs.
+// ValidateRepositoryURL validates against exactly what Create accepts, SCP-style URLs included.
 func ValidateRepositoryURL(raw string) error {
 	_, _, err := parseGitURL(raw)
 	return err
 }
 
-// parseGitURL extracts the host and "owner/repo" from either an HTTP(S) URL or an SCP-style git
-// URL (git@host:owner/repo.git), stripping any trailing ".git".
+// parseGitURL extracts host and "owner/repo" from an HTTP(S) or SCP-style (git@host:owner/repo) URL.
 func parseGitURL(raw string) (host string, path string, err error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/internal/codehosting/factory_property_test.go
+++ b/internal/codehosting/factory_property_test.go
@@ -10,14 +10,11 @@ import (
 	"pgregory.net/rapid"
 )
 
-// Repository URLs arrive from a CI variable or a flag, in whichever of the two shapes git
-// itself accepts. The example-based tests cover the shapes someone wrote down; these state what
-// has to hold for every URL of either shape, and that the parser is total — it is called on
-// unvalidated user input, so "never panics" is part of the contract.
+// Repository URLs arrive from a CI variable or a flag, in either shape git accepts. The parser
+// is called on unvalidated input, so "never panics" is part of the contract.
 
-// hostGen generates a repository host: labels of the kind a real forge uses. No port — the SCP
-// form has no slot for one, since the colon after the host already introduces the path, so a
-// port belongs only to the URL form and is covered separately.
+// hostGen generates a forge-shaped host. No port: the SCP form has no slot for one, so ports
+// belong to the URL form and are covered separately.
 func hostGen() *rapid.Generator[string] {
 	return rapid.StringMatching(`[a-z][a-z0-9-]{0,10}(\.[a-z][a-z0-9-]{0,10}){1,2}`)
 }
@@ -34,9 +31,8 @@ func TestPropertyParseGitURLRoundTripsBothURLShapes(t *testing.T) {
 		repo := segmentGen().Draw(t, "repo")
 		wantPath := owner + "/" + repo
 
-		// Both forms name the same repository, so both have to parse back to the same pair.
-		// The SCP form is the one url.ParseRequestURI rejects outright, which is why
-		// ValidateRepositoryURL exists.
+		// Both forms name one repository, so both must parse to the same pair. The SCP form
+		// is the one url.ParseRequestURI rejects outright.
 		for _, raw := range []string{
 			"https://" + host + "/" + wantPath + ".git",
 			"https://" + host + "/" + wantPath,
@@ -58,8 +54,7 @@ func TestPropertyParseGitURLKeepsThePort(t *testing.T) {
 		owner := segmentGen().Draw(t, "owner")
 		repo := segmentGen().Draw(t, "repo")
 
-		// A self-hosted GitLab is routinely reached on a non-default port, and the port is part
-		// of the host the gitlab client is constructed with — dropping it would send every API
+		// A self-hosted GitLab runs on a non-default port, and dropping it sends every API
 		// call somewhere else.
 		hostPort := fmt.Sprintf("%s:%d", host, port)
 		gotHost, gotPath, err := parseGitURL("https://" + hostPort + "/" + owner + "/" + repo + ".git")
@@ -93,9 +88,8 @@ func TestPropertyValidateRepositoryURLAgreesWithParseGitURL(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		raw := rapid.String().Draw(t, "raw")
 
-		// The whole point of ValidateRepositoryURL is that a preflight check accepts exactly
-		// what a run will later accept. If the two ever diverged, a check would pass and the
-		// run would then fail on the same URL.
+		// A preflight check must accept exactly what a run will, or a check passes and the
+		// run fails on the same URL.
 		_, _, parseErr := parseGitURL(raw)
 		assert.Equal(t, parseErr == nil, ValidateRepositoryURL(raw) == nil, "for %q", raw)
 	})
@@ -127,9 +121,7 @@ func TestPropertyProviderFromHostPrefersGitlab(t *testing.T) {
 		middle := rapid.StringMatching(`[a-z.-]{0,8}`).Draw(t, "middle")
 		suffix := rapid.StringMatching(`[a-z.-]{0,8}`).Draw(t, "suffix")
 
-		// A host naming both is ambiguous and the precedence is load-bearing: gitlab wins,
-		// whichever order the two appear in. Create falls through to gitlab for "" as well, so
-		// the only host that reaches the github client is one that says github and not gitlab.
+		// A host naming both is ambiguous, and gitlab wins whichever order they appear in.
 		gitlabFirst := prefix + "gitlab" + middle + "github" + suffix
 		githubFirst := prefix + "github" + middle + "gitlab" + suffix
 

--- a/internal/codehosting/github.go
+++ b/internal/codehosting/github.go
@@ -17,8 +17,7 @@ type Github struct {
 	logger *zap.Logger
 }
 
-// newGithub builds a GitHub platform from an "owner/repo" path, erroring rather than panicking
-// when a segment is missing.
+// newGithub builds a GitHub platform from an "owner/repo" path.
 func newGithub(path string, token string, logger *zap.Logger) (*Github, error) {
 	owner, repo, found := strings.Cut(strings.Trim(path, "/"), "/")
 	if !found || owner == "" || repo == "" {
@@ -59,11 +58,8 @@ func (g *Github) DeleteBranch(ctx context.Context, branch string) error {
 	return nil
 }
 
-// GetUser returns the authenticated user's name and email.
-//
-// A GITHUB_TOKEN (Actions bot) gets 403 "Resource not accessible by integration" from GET /user;
-// that case falls back to the github-actions[bot] identity, so commits are attributed correctly
-// without a PAT. Any other error yields empty strings so callers can detect the failure.
+// GetUser returns the authenticated user's name and email, empty on failure. An Actions token
+// cannot read /user, so it falls back to the github-actions[bot] identity rather than need a PAT.
 func (g *Github) GetUser(ctx context.Context) (name string, email string) {
 	user, resp, err := g.client.Users.Get(ctx, "")
 	if err != nil {
@@ -83,11 +79,8 @@ func (g *Github) GetUser(ctx context.Context) (name string, email string) {
 	return user.GetName(), email
 }
 
-// EnableAutoMerge merges the PR once every required status check passes.
-//
-// The endpoint: go-github's base URL is the REST root, so "graphql" resolves correctly for
-// github.com. Enterprise serves GraphQL at /api/graphql, outside the /api/v3/ prefix, so this
-// path needs adjusting if newGithub ever gains enterprise support.
+// EnableAutoMerge merges the PR once every required status check passes. The "graphql" path
+// resolves only for github.com; Enterprise serves it outside the /api/v3/ prefix.
 func (g *Github) EnableAutoMerge(ctx context.Context, mr MergeRequest) error {
 	pr, _, err := g.client.PullRequests.Get(ctx, g.owner, g.repo, int(mr.ID))
 	if err != nil {
@@ -133,11 +126,7 @@ func (g *Github) EnableAutoMerge(ctx context.Context, mr MergeRequest) error {
 }
 
 // mergeMethodFor picks a method the repository permits: requesting a disallowed one fails the
-// mutation, and many repositories allow only squash or only rebase. With no flags set at all it
-// falls back to MERGE, whose rejection at least names the problem.
-//
-// Unlike GitLab there is no per-request "delete source branch" option; that is the repository's
-// delete_branch_on_merge setting.
+// mutation. With no flags set it falls back to MERGE, whose rejection at least names the problem.
 func mergeMethodFor(repo *github.Repository) string {
 	switch {
 	case repo.GetAllowMergeCommit():
@@ -151,9 +140,8 @@ func mergeMethodFor(repo *github.Repository) string {
 	}
 }
 
-// isGitHubActionsToken403 matches only the 403 an Actions token gets from /user, identified by
-// its "Resource not accessible by integration" message. Bad credentials and an under-scoped PAT
-// also give 403, with a different message, and must not be suppressed.
+// isGitHubActionsToken403 matches on the message, not the status: bad credentials and an
+// under-scoped PAT also give 403, and those must not be suppressed.
 func isGitHubActionsToken403(resp *github.Response, err error) bool {
 	var ghErr *github.ErrorResponse
 	if !errors.As(err, &ghErr) {

--- a/internal/codehosting/github_test.go
+++ b/internal/codehosting/github_test.go
@@ -246,10 +246,8 @@ func TestGithub_DeleteBranch_HonorsContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-// newAutoMergePRServer serves the PR endpoint with the given base repo JSON (the merge-method
-// flags) and a successful GraphQL mutation, capturing the mergeMethod variable that was sent.
-// Note the GraphQL path: WithEnterpriseURLs puts the REST root at /api/v3/, so "graphql"
-// resolves under it. Real GHES serves GraphQL at /api/graphql instead — see EnableAutoMerge.
+// newAutoMergePRServer serves the PR endpoint and a successful GraphQL mutation, capturing the
+// mergeMethod that was sent. WithEnterpriseURLs puts "graphql" under /api/v3/, unlike real GHES.
 func newAutoMergePRServer(t *testing.T, baseRepoJSON string, gotMethod *string) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/codehosting/gitlab.go
+++ b/internal/codehosting/gitlab.go
@@ -62,27 +62,17 @@ func (g *Gitlab) DeleteBranch(ctx context.Context, branch string) error {
 	return nil
 }
 
-// Attempt budgets for EnableAutoMerge. GitLab computes mergeability asynchronously, so the
-// status right after MR creation is usually pending and the accept call can lose the race and
-// answer 405. Bounded so a run can't hang: (maxMergeStatusChecks + maxAcceptAttempts - 2) *
-// retryInterval.
+// Attempt budgets for EnableAutoMerge. GitLab computes mergeability asynchronously, so the status
+// right after MR creation is usually pending. Bounded so a run can't hang on it.
 const (
 	maxMergeStatusChecks = 7
 	maxAcceptAttempts    = 4
 )
 
-// pendingMergeStatuses are the detailed_merge_status values that mean GitLab has not finished
-// working out whether the MR can merge. These are the only four of the documented values whose
-// meaning is "still computing" (see the merge status section of the merge requests API docs):
-//
-//	preparing          merge request diff is being created
-//	checking           Git is testing if a valid merge is possible
-//	unchecked          Git has not yet tested if a valid merge is possible
-//	approvals_syncing  the merge request's approvals are syncing
-//
-// Every other value is settled and safe to act on, including ci_must_pass and ci_still_running
-// — the states auto-merge exists for. Waiting for "mergeable" would defeat the feature: a
-// pipeline-gated MR only reports it once it could already be merged outright.
+// pendingMergeStatuses are the only detailed_merge_status values meaning "still computing".
+// Every other value is safe to act on, ci_must_pass and ci_still_running included — waiting for
+// "mergeable" would defeat auto-merge, which a pipeline-gated MR only reaches once it could
+// already be merged outright.
 var pendingMergeStatuses = map[string]bool{
 	"preparing":         true,
 	"checking":          true,
@@ -90,8 +80,8 @@ var pendingMergeStatuses = map[string]bool{
 	"approvals_syncing": true,
 }
 
-// EnableAutoMerge waits for GitLab to settle the merge status, then accepts with auto_merge.
-// GitLab decides from there whether to queue the merge, so an MR with no pipeline merges now.
+// EnableAutoMerge waits for the merge status to settle, then accepts with auto_merge. GitLab
+// decides from there whether to queue it, so an MR with no pipeline merges now.
 func (g *Gitlab) EnableAutoMerge(ctx context.Context, mr MergeRequest) error {
 	status, err := g.waitForSettledMergeStatus(ctx, mr.ID)
 	if err != nil {
@@ -100,8 +90,8 @@ func (g *Gitlab) EnableAutoMerge(ctx context.Context, mr MergeRequest) error {
 	return g.acceptWithAutoMerge(ctx, mr.ID, status)
 }
 
-// waitForSettledMergeStatus polls until detailed_merge_status is no longer pending, and returns
-// it. Deliberately does not require a mergeable status: see pendingMergeStatuses.
+// waitForSettledMergeStatus polls until detailed_merge_status is no longer pending. It does not
+// require a mergeable one — see pendingMergeStatuses.
 func (g *Gitlab) waitForSettledMergeStatus(ctx context.Context, iid int64) (string, error) {
 	for i := 0; i < maxMergeStatusChecks; i++ {
 		if i > 0 {
@@ -122,9 +112,8 @@ func (g *Gitlab) waitForSettledMergeStatus(ctx context.Context, iid int64) (stri
 	return "", fmt.Errorf("could not set auto merge for MR %d: merge status was still pending after %d checks", iid, maxMergeStatusChecks)
 }
 
-// acceptWithAutoMerge accepts the MR with auto_merge set. GitLab's 405 here means "cannot
-// merge" — a draft, a conflict, missing approvals — but also appears briefly just after the
-// status settles, hence the retries. status is reported on failure: it names the real blocker.
+// acceptWithAutoMerge accepts the MR with auto_merge set. GitLab's 405 means "cannot merge", but
+// also appears briefly just after the status settles — hence the retries. status names the blocker.
 func (g *Gitlab) acceptWithAutoMerge(ctx context.Context, iid int64, status string) error {
 	autoMerge := true
 	removeSourceBranch := true

--- a/internal/codehosting/gitlab_test.go
+++ b/internal/codehosting/gitlab_test.go
@@ -78,9 +78,7 @@ func TestCreateMergeRequest(t *testing.T) {
 
 		jsonString := make([]byte, 0)
 		if r.URL.Path == "/api/v4/projects/test_project/merge_requests" {
-			// Capture what was actually sent. Asserting only on the response would let any of
-			// the request fields be dropped unnoticed -- a merge request with no title or no
-			// source branch is the tool failing at its one job.
+			// Asserting only on the response would let a request field be dropped unnoticed.
 			assert.NoError(t, json.NewDecoder(r.Body).Decode(&sent))
 			jsonString = []byte(`{"iid": 1, "web_url": "http://example.com"}`)
 			w.WriteHeader(http.StatusOK)
@@ -175,9 +173,8 @@ func TestGitlab_GetUser_HonorsContext(t *testing.T) {
 	assert.Empty(t, email)
 }
 
-// newAutoMergeServer serves the GetMergeRequest endpoint with the given sequence of
-// detailed_merge_status values (the last one repeats once exhausted) and accepts the merge.
-// It returns the server plus counters for the GET and PUT calls.
+// newAutoMergeServer replays a sequence of detailed_merge_status values, repeating the last,
+// and returns call counters alongside the server.
 func newAutoMergeServer(t *testing.T, statuses ...string) (*httptest.Server, *int, *int) {
 	t.Helper()
 	var getCount, putCount int
@@ -214,10 +211,8 @@ func TestGitlab_EnableAutoMerge_WaitsOutPendingStatus(t *testing.T) {
 	assert.Equal(t, 1, *putCount)
 }
 
-// TestGitlab_EnableAutoMerge_AcceptsWhileCIRunning is the regression test for the feature's
-// central case: a pipeline-gated MR never reports "mergeable" before the pipeline finishes, so
-// waiting for that status would make auto-merge unusable on exactly the projects that want it.
-// A CI status is a settled answer and must be accepted straight away.
+// A pipeline-gated MR never reports "mergeable" before the pipeline finishes, so waiting for
+// that status makes auto-merge unusable on the projects that want it.
 func TestGitlab_EnableAutoMerge_AcceptsWhileCIRunning(t *testing.T) {
 	for _, status := range []string{"ci_still_running", "ci_must_pass"} {
 		t.Run(status, func(t *testing.T) {

--- a/internal/config.go
+++ b/internal/config.go
@@ -3,7 +3,6 @@ package internal
 import "time"
 
 // Version is set at build time via -ldflags, and stays "dev" for builds that skip the Makefile.
-// It is recorded in the run report so a consumer can tell which version produced a result.
 var Version = "dev"
 
 type Config struct {
@@ -18,17 +17,15 @@ type Config struct {
 	Verbose       bool
 	Timeout       time.Duration
 	RunTypes      RunTypesConfig
-	// Concurrency bounds how many sites are installed/updated at once; <= 0 means GOMAXPROCS(0).
-	// A CLI flag, not a config key: it describes the machine, not the project.
+	// Concurrency bounds how many sites run at once; <= 0 means GOMAXPROCS(0). A CLI flag, not
+	// a config key: it describes the machine, not the project.
 	Concurrency int
-	// ReportPath is where the run report is written; empty disables it. A CLI flag for the same
-	// reason as Concurrency.
+	// ReportPath is where the run report is written; empty disables it.
 	ReportPath string
 }
 
-// RunTypesConfig groups the settings that differ between a normal and a security run. Keyed on
-// the run type, not the setting, so configuring one mode means reading one stanza instead of
-// picking a `security` field out of every setting in the file.
+// RunTypesConfig is keyed on the run type, not the setting, so configuring one mode means
+// reading one stanza rather than a `security` field in every setting.
 type RunTypesConfig struct {
 	Normal   RunTypeConfig `yaml:"normal"`
 	Security RunTypeConfig `yaml:"security"`
@@ -36,16 +33,14 @@ type RunTypesConfig struct {
 
 // RunTypeConfig is what a single run type configures.
 type RunTypeConfig struct {
-	// Addons lists the configurable addons to run. The mandatory ones always run and are not
-	// listed here.
+	// Addons lists the configurable addons. The mandatory ones are not listed here.
 	Addons []string `yaml:"addons"`
 
 	// AutoMerge asks the platform to merge the MR/PR once its pipeline passes.
 	AutoMerge bool `yaml:"auto_merge"`
 }
 
-// ActiveRunType returns the selected run type's settings. Every consumer goes through here, so
-// the mapping from --security to a config block is stated once.
+// ActiveRunType is where --security maps to a config block — the only place that mapping lives.
 func (c Config) ActiveRunType() RunTypeConfig {
 	if c.Security {
 		return c.RunTypes.Security

--- a/internal/configfile.go
+++ b/internal/configfile.go
@@ -12,10 +12,7 @@ import (
 )
 
 // defaultNormalAddons is the configurable addon set for a normal update. Security mode defaults
-// to none of these — it should be a minimal, focused fix with only the mandatory addons.
-//
-// unsupported_modules is absent because it is mandatory now: end-of-life modules are worth
-// knowing on a security run too, and it renders composer_audit's abandoned packages with them.
+// to none of these: it should be a minimal, focused fix.
 var defaultNormalAddons = []string{
 	"code_beautifier",
 	"deprecations_remover",
@@ -23,9 +20,8 @@ var defaultNormalAddons = []string{
 	"composer_normalizer",
 }
 
-// flexTimeout captures the `timeout` key as a raw scalar so both "30m" and a bare 0 decode;
-// it is parsed as a duration later. Without it `timeout: 0`, the documented way to disable the
-// timeout, fails to decode into a string field.
+// flexTimeout takes `timeout` as a raw scalar so both "30m" and a bare 0 decode; a string field
+// would reject `timeout: 0`, the documented way to disable it.
 type flexTimeout string
 
 func (t *flexTimeout) UnmarshalYAML(node *yaml.Node) error {
@@ -33,43 +29,36 @@ func (t *flexTimeout) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-// fileConfig mirrors the YAML-settable keys of .drupdater.yaml. Timeout is a raw scalar because
-// yaml.v3 cannot decode "30m" into a time.Duration.
-//
-// Keys are split by scope: sites and timeout describe the whole run, anything that differs
-// between a normal and a security update lives under run_types, where it cannot collide with a
-// future global key.
+// fileConfig mirrors the YAML-settable keys of .drupdater.yaml. Split by scope: sites and timeout
+// describe the whole run, per-mode settings live under run_types where they cannot collide.
 type fileConfig struct {
 	Sites    []string       `yaml:"sites"`
 	Timeout  flexTimeout    `yaml:"timeout"`
 	RunTypes RunTypesConfig `yaml:"run_types"`
 }
 
-// legacyProbe detects the pre-run_types layout, where addons and auto_merge were top-level keys
-// split by mode. Strict decoding rejects those already, but with a message that says nothing
-// about what to write instead.
+// legacyProbe detects the pre-run_types layout. Strict decoding rejects it already, but says
+// nothing about what to write instead.
 type legacyProbe struct {
 	Addons    *struct{} `yaml:"addons"`
 	AutoMerge *struct{} `yaml:"auto_merge"`
 }
 
-// defaultFileConfig returns a fileConfig pre-populated with defaults. Unmarshaling over it
-// overwrites only the keys present, so a partial file still resolves to a complete config.
+// defaultFileConfig is the base to unmarshal over, so a partial file still resolves completely.
 func defaultFileConfig() fileConfig {
 	return fileConfig{
 		Sites:   []string{"default"},
 		Timeout: "30m",
 		RunTypes: RunTypesConfig{
 			Normal: RunTypeConfig{Addons: defaultNormalAddons},
-			// A security update should be a minimal, focused fix: mandatory addons only.
+			// Mandatory addons only, so a security update stays a focused fix.
 			Security: RunTypeConfig{},
 		},
 	}
 }
 
-// LoadConfigFile layers the .drupdater.yaml at path over the built-in defaults and applies the
-// result to c. A missing file is not an error: defaults apply and found is false. Unknown keys
-// are rejected so typos fail loudly.
+// LoadConfigFile layers path's .drupdater.yaml over the defaults and applies it to c. A missing
+// file is not an error. Unknown keys are rejected so typos fail loudly.
 func LoadConfigFile(path string, c *Config) (found bool, err error) {
 	fc := defaultFileConfig()
 
@@ -87,8 +76,7 @@ func LoadConfigFile(path string, c *Config) (found bool, err error) {
 
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
-	// An empty or comment-only file has no YAML document, which Decode reports as io.EOF. Same
-	// intent as an absent file: no keys set, so the defaults apply.
+	// A comment-only file has no YAML document, reported as io.EOF. Same intent as no file.
 	if err := dec.Decode(&fc); err != nil && !errors.Is(err, io.EOF) {
 		return true, fmt.Errorf("parsing %s: %w", path, err)
 	}
@@ -100,11 +88,9 @@ func LoadConfigFile(path string, c *Config) (found bool, err error) {
 }
 
 // checkLegacyLayout reports a config still in the pre-run_types layout, naming the replacement.
-// The strict decode's own message is accurate but leaves the reader to guess the new shape.
 func checkLegacyLayout(data []byte) error {
 	var probe legacyProbe
-	// Deliberately lenient: this only asks whether the legacy keys are present. A malformed
-	// document is the strict decode's business, and it reports that with proper context.
+	// Lenient on purpose: a malformed document is the strict decode's business to report.
 	parsed := yaml.Unmarshal(data, &probe) == nil
 	if !parsed || (probe.Addons == nil && probe.AutoMerge == nil) {
 		return nil
@@ -131,8 +117,7 @@ func applyFileConfig(fc fileConfig, c *Config) error {
 	if err != nil {
 		return fmt.Errorf("invalid timeout %q (use a Go duration like \"30m\" or \"2h\", or 0 to disable): %w", string(fc.Timeout), err)
 	}
-	// Every per-site phase iterates this list, so an empty one silently skips all of them and
-	// still opens a merge request for an update no site ever validated.
+	// An empty list silently skips every per-site phase, then opens the merge request anyway.
 	if len(fc.Sites) == 0 {
 		return errors.New(`no sites configured: "sites" must list at least one Drupal site name`)
 	}

--- a/internal/configfile_property_test.go
+++ b/internal/configfile_property_test.go
@@ -14,10 +14,8 @@ import (
 	"pgregory.net/rapid"
 )
 
-// .drupdater.yaml is written by hand, in a repository this tool has no other contact with, and
-// it is decoded strictly — so every key present has to land where the documentation says, and
-// every key absent has to fall back to the documented default. Those two claims are about all
-// files, not about the fixtures someone happened to write.
+// .drupdater.yaml is hand-written and decoded strictly, so every key present must land where
+// the docs say and every key absent must take the documented default — for all files.
 
 // fileConfigGen generates a config with every key set, so a round-trip covers each of them
 // rather than the ones an example filled in.
@@ -42,9 +40,8 @@ func fileConfigGen() *rapid.Generator[fileConfig] {
 	})
 }
 
-// writePropertyConfig writes body to a .drupdater.yaml in dir and returns its path. Separate
-// from writeConfig in configfile_test.go because that one takes a *testing.T and makes its own
-// temporary directory per call, and a property makes hundreds of calls under a *rapid.T.
+// writePropertyConfig exists because writeConfig takes a *testing.T and a fresh temp directory
+// per call, and a property makes hundreds of calls under a *rapid.T.
 func writePropertyConfig(t require.TestingT, dir string, body string) string {
 	path := filepath.Join(dir, ".drupdater.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
@@ -86,9 +83,8 @@ func TestPropertyLoadConfigFileFillsInEveryAbsentKey(t *testing.T) {
 		withTimeout := rapid.Bool().Draw(t, "withTimeout")
 		withRunTypes := rapid.Bool().Draw(t, "withRunTypes")
 
-		// A partial file is the normal case — most projects set `sites` and nothing else — and
-		// it has to resolve to a complete config, with the keys it does not mention taking the
-		// documented default rather than a zero value.
+		// A partial file is the normal case, and must resolve to a complete config — defaults
+		// for the unmentioned keys, not zero values.
 		var body strings.Builder
 		if withSites {
 			fmt.Fprintf(&body, "sites: [%s]\n", strings.Join(full.Sites, ", "))
@@ -119,9 +115,8 @@ func TestPropertyLoadConfigFileFillsInEveryAbsentKey(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, parsed, got.Timeout)
 
-		// Layering is per-key all the way down, not per-block: the generated run_types names
-		// only auto_merge, so the addon lists inside the same block still come from the
-		// defaults. A project that turns auto-merge on does not thereby switch every addon off.
+		// Layering is per-key, not per-block: turning auto-merge on must not switch every
+		// addon in the same block off.
 		if withRunTypes {
 			assert.Equal(t, full.RunTypes.Normal.AutoMerge, got.RunTypes.Normal.AutoMerge)
 			assert.Equal(t, full.RunTypes.Security.AutoMerge, got.RunTypes.Security.AutoMerge)
@@ -165,9 +160,7 @@ func TestPropertyFlexTimeoutAcceptsAnyGoDuration(t *testing.T) {
 		seconds := rapid.IntRange(0, 59).Draw(t, "seconds")
 		raw := fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds)
 
-		// Quoted and bare have to mean the same thing. flexTimeout exists because `timeout: 0`,
-		// the documented way to disable the timeout, decodes as an int and would not fit a
-		// string field.
+		// Quoted and bare must mean the same thing: `timeout: 0` decodes as an int.
 		var quoted, bare Config
 		_, err := LoadConfigFile(writePropertyConfig(t, dir, fmt.Sprintf("sites: [default]\ntimeout: %q\n", raw)), &quoted)
 		require.NoError(t, err)
@@ -188,9 +181,7 @@ func TestPropertyLoadConfigFileRejectsAnEmptySiteList(t *testing.T) {
 		empty := rapid.SampledFrom([]string{"sites: []", "sites:", "sites: ~", "sites: null"}).Draw(t, "sites")
 		timeout := rapid.SampledFrom([]string{"", "\ntimeout: 30m", "\ntimeout: 0"}).Draw(t, "timeout")
 
-		// Every per-site phase iterates this list, so an empty one would skip installing the
-		// database, running update hooks and exporting configuration, and still open a merge
-		// request for an update nothing validated.
+		// An empty list skips every per-site phase and still opens the merge request.
 		var got Config
 		_, err := LoadConfigFile(writePropertyConfig(t, dir, empty+timeout+"\n"), &got)
 		require.Error(t, err, "for %q", empty+timeout)
@@ -226,9 +217,8 @@ func TestPropertyCheckLegacyLayoutStaysOutOfTheWayOfMalformedYAML(t *testing.T) 
 			"{{{\n",
 		}).Draw(t, "body")
 
-		// A document that does not parse is the strict decode's business, which reports it with
-		// the file name and the parser's own message. Guessing at a legacy layout here would
-		// replace that with advice about a key the file may not even contain.
+		// An unparsable document is the strict decode's business: guessing at a legacy layout
+		// here replaces its message with advice about a key the file may not contain.
 		assert.NoError(t, checkLegacyLayout([]byte(body)))
 	})
 }

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -1,6 +1,5 @@
 // Package logging wraps a zapcore.Core to redact known secret values before they reach any sink.
-// Subprocesses echo credentials back in their own output, most often in a URL after a failed
-// authenticated fetch; wrapping the logger covers every call site at once.
+// Subprocesses echo credentials back in their own output; wrapping the logger covers every call site.
 package logging
 
 import (
@@ -17,27 +16,22 @@ import (
 // placeholder replaces every registered secret value wherever it appears in log output.
 const placeholder = "***"
 
-// Redactor holds the exact secret values that must never appear in log output. Value-based, not
-// pattern-based: matching "things that look like a token" both misses unusual formats and mangles
-// innocent output, and the real values are known at startup. Safe for concurrent use.
+// Redactor holds the exact secret values to hide. Value-based, not pattern-based: the real values
+// are known at startup, and "looks like a token" both misses formats and mangles innocent output.
 type Redactor struct {
 	mu       sync.RWMutex
 	secrets  map[string]struct{}
 	replacer *strings.Replacer
 }
 
-// NewRedactor returns an empty Redactor. Register secret values as soon as they are known so
-// nothing is logged unredacted in between.
+// NewRedactor returns an empty Redactor. Register values as soon as they are known.
 func NewRedactor() *Redactor {
 	return &Redactor{secrets: map[string]struct{}{}}
 }
 
 // Register adds values to redact from all later log output. Empty strings are ignored: redacting
-// "" would replace every character in every line.
-//
-// Each value's URL-encoded forms are registered too, because a token in a URL may appear encoded,
-// and both query and path escaping are used — a space is '+' in one and "%20" in the other, so
-// one form alone leaves the value readable. The map collapses duplicates.
+// "" would replace every character in every line. Both URL escapings go in too — query and path
+// escaping differ on a space, so one form alone leaves the value readable.
 func (r *Redactor) Register(values ...string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -62,9 +56,8 @@ func (r *Redactor) Register(values ...string) {
 	}
 }
 
-// Redact replaces every registered secret value in s with the placeholder. The exported
-// counterpart of redact, for output that bypasses the logger — a preflight check's results, or
-// the run report — and must be filtered all the same.
+// Redact is the exported counterpart of redact, for output that bypasses the logger: a preflight
+// check's results, or the run report.
 func (r *Redactor) Redact(s string) string {
 	return r.redact(s)
 }
@@ -108,15 +101,13 @@ func (r *Redactor) currentReplacer() *strings.Replacer {
 	return r.replacer
 }
 
-// core rewrites the message and any string/error field through the Redactor before handing the
-// entry on. It never logs the secret set itself.
+// core rewrites the message and any string/error field before handing the entry on.
 type core struct {
 	zapcore.Core
 	redactor *Redactor
 }
 
-// WrapCore returns a constructor for zap.WrapCore, so every entry the logger emits — at every
-// level, Debug included — is filtered before it reaches its sink.
+// WrapCore returns a constructor for zap.WrapCore, so every entry is filtered, Debug included.
 func WrapCore(r *Redactor) func(zapcore.Core) zapcore.Core {
 	return func(c zapcore.Core) zapcore.Core {
 		return &core{Core: c, redactor: r}
@@ -151,8 +142,7 @@ func (c *core) redactFields(fields []zapcore.Field) []zapcore.Field {
 				f.Interface = errors.New(c.redactor.redact(err.Error()))
 			}
 		default:
-			// Numbers, durations, zap.Any and friends pass through: no call site puts
-			// subprocess output into those.
+			// Numbers and durations pass through: no call site puts subprocess output there.
 		}
 		out[i] = f
 	}

--- a/internal/logging/redact_property_test.go
+++ b/internal/logging/redact_property_test.go
@@ -13,18 +13,14 @@ import (
 	"pgregory.net/rapid"
 )
 
-// The example-based tests in redact_test.go pin the cases someone thought of. The redactor is
-// the one component where a case nobody thought of means a credential in a log, so its promises
-// are stated here as properties over generated input instead.
+// A case nobody thought of means a credential in a log, so the redactor's promises are stated
+// as properties over generated input.
 
-// secretGen generates a plausible credential value: the alphabet is the one real tokens are
-// drawn from, plus the separators that show up around them in basic-auth URLs and query
-// strings, so the generated values actually exercise the URL-encoded registration.
+// secretGen draws from the alphabet real tokens use, plus the separators found around them in
+// URLs, so the values exercise the URL-encoded registration.
 //
-// '*' is deliberately excluded. The placeholder is "***", so a secret consisting only of
-// asterisks is a substring of the very thing that replaces it and would reappear in the output
-// by construction. A credential of one to three asterisks is not a credential; stating the
-// no-leak property for secrets distinguishable from the placeholder is the useful reading.
+// '*' is excluded: the placeholder is "***", so an all-asterisk secret is a substring of the
+// thing that replaces it and would reappear by construction.
 func secretGen() *rapid.Generator[string] {
 	return rapid.StringMatching(`[a-zA-Z0-9_.:/+= @-]{1,20}`)
 }
@@ -35,9 +31,8 @@ func secretsGen() *rapid.Generator[[]string] {
 	return rapid.SliceOfNDistinct(secretGen(), 1, 4, rapid.ID)
 }
 
-// logLineGen builds a line out of the given secrets and arbitrary filler. Drawing a wholly
-// random string instead would exercise redaction only by accident: a generated secret would
-// almost never appear in it, and the property would pass without ever replacing anything.
+// logLineGen plants the secrets in the line. A wholly random string would almost never contain
+// one, and the property would pass without ever replacing anything.
 func logLineGen(secrets []string) *rapid.Generator[string] {
 	parts := make([]*rapid.Generator[string], 0, len(secrets)+1)
 	parts = append(parts, rapid.String())
@@ -90,10 +85,8 @@ func TestPropertyRedactCoversURLEncodedForms(t *testing.T) {
 		redactor := NewRedactor()
 		redactor.Register(secret)
 
-		// A subprocess that echoes a token inside a URL emits it percent-encoded, and which
-		// encoding it is depends on where in the URL it landed: the query escaping turns a
-		// space into '+', the path escaping into "%20". Both have to be registered, or the
-		// value survives in the log in the form that is still perfectly usable.
+		// Which escaping a subprocess emits depends on where in the URL the token landed, and
+		// either form is still a usable credential — so both must be registered.
 		assert.Equal(t, placeholder, redactor.Redact(secret))
 		assert.Equal(t, placeholder, redactor.Redact(url.QueryEscape(secret)))
 		assert.Equal(t, placeholder, redactor.Redact(url.PathEscape(secret)))
@@ -102,10 +95,8 @@ func TestPropertyRedactCoversURLEncodedForms(t *testing.T) {
 
 func TestPropertyRedactLeavesSecretFreeTextAlone(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		// Disjoint alphabets: the filler is drawn from characters no secret can contain, so
-		// "this text holds no secret" holds by construction rather than by luck. Neither
-		// URL-encoded form can bridge the two either, since encoding a lower-case secret
-		// introduces only '%' and hex digits.
+		// Disjoint alphabets, so "this filler holds no secret" is true by construction rather
+		// than by luck — encoding introduces only '%' and hex digits, which bridge nothing.
 		secrets := rapid.SliceOfNDistinct(rapid.StringMatching(`[a-z0-9]{1,12}`), 1, 4, rapid.ID).Draw(t, "secrets")
 		text := rapid.StringMatching(`[ ,.!?()\[\]]{0,40}`).Draw(t, "text")
 
@@ -163,10 +154,8 @@ func TestPropertyWrappedLoggerNeverWritesASecret(t *testing.T) {
 		redactor.Register(secrets...)
 		newTestLogger(&buf, redactor).Info(message, zap.String("detail", field))
 
-		// Asserted on the decoded entry rather than on the raw line, because the raw line also
-		// carries zap's own envelope. A one-character secret like "8" occurs in the timestamp
-		// of roughly every entry, and no redactor can or should do anything about that — the
-		// promise is about what the call site passed in.
+		// On the decoded entry, not the raw line: a one-character secret like "8" occurs in
+		// zap's own timestamp, which is not what the promise is about.
 		var entry struct {
 			Message string `json:"msg"`
 			Detail  string `json:"detail"`

--- a/internal/logging/redact_test.go
+++ b/internal/logging/redact_test.go
@@ -54,10 +54,8 @@ func TestRedactorRedactsPercentEncodedForm(t *testing.T) {
 	assert.NotContains(t, out, encoded)
 }
 
-// TestRedactorRedactsPathEncodedForm covers the other escaping. Which one a tool emits depends
-// on where the value sat in the URL, not on the value: the same token is "a+b" after a query
-// component is escaped and "a%20b" after a path segment is. Registering only the query form
-// left the path form — still a perfectly usable credential — readable in the log.
+// The same token is "a+b" after query escaping and "a%20b" after path escaping. Registering
+// only the query form left the other — still a usable credential — readable in the log.
 func TestRedactorRedactsPathEncodedForm(t *testing.T) {
 	const token = "a b c"
 
@@ -154,9 +152,7 @@ func TestRedactorLongestSecretWinsOverSubstring(t *testing.T) {
 	logger.Info("value: secret-extended")
 
 	out := buf.String()
-	// Assert the whole result, not just that the secrets are absent. Replacing shortest-first
-	// yields "***-extended", which still contains neither "secret" nor "secret-extended" --
-	// absence checks alone cannot tell the correct ordering from the broken one.
+	// The whole result: shortest-first yields "***-extended", which an absence check passes.
 	assert.Contains(t, out, `"msg":"value: ***"`)
 	assert.NotContains(t, out, "-extended")
 }
@@ -184,9 +180,8 @@ func TestRedactorKeepsReplacerWhenNothingChanged(t *testing.T) {
 	redactor.Register("token") // already known
 	redactor.Register("")      // ignored
 
-	// Re-registering known or empty values must not throw the built replacer away: Register is
-	// called repeatedly as credentials are resolved, and rebuilding on every call would make
-	// redaction cost grow with the number of calls rather than the number of secrets.
+	// Register is called repeatedly as credentials resolve, so rebuilding on every call would
+	// grow redaction's cost with the call count rather than the number of secrets.
 	assert.Same(t, built, redactor.currentReplacer())
 }
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,9 +1,5 @@
-// Package report defines the machine-readable run report drupdater writes with --report.
-//
-// A run's outcome is otherwise only expressed for humans, and the merge request description only
-// exists for runs that get far enough to open one. The report is written on every exit path,
-// including failures, and records which phase failed and why -- what anything automating
-// drupdater across many repositories needs and the log makes expensive to obtain.
+// Package report defines the machine-readable run report drupdater writes with --report. It is
+// written on every exit path, failures included, so automation never has to parse the log.
 package report
 
 import (
@@ -19,9 +15,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-// SchemaVersion is the version of the report format. It is part of the report's public contract:
-// new fields may be added without bumping it (consumers must ignore unknown fields), while
-// removing or renaming a field requires an increment.
+// SchemaVersion is bumped when a field is removed or renamed. Adding one does not need it —
+// consumers must ignore unknown fields.
 const SchemaVersion = 1
 
 // Status is the overall outcome of a run.
@@ -46,9 +41,8 @@ const (
 	ModeSecurity Mode = "security"
 )
 
-// ToolVersions records the versions of the tools whose behaviour the outcome depends on. Without
-// them, a fleet of repositories failing the same phase after an upstream composer release is
-// unattributable. Embedded in both documents so the two cannot drift on field names.
+// ToolVersions attributes a fleet-wide failure to an upstream release. Embedded in both documents
+// so the two cannot drift on field names.
 type ToolVersions struct {
 	ComposerVersion string `json:"composer_version,omitempty"`
 	PHPVersion      string `json:"php_version,omitempty"`
@@ -103,16 +97,12 @@ type Report struct {
 // MergeRequest identifies the merge/pull request a successful run opened.
 type MergeRequest struct {
 	URL string `json:"url"`
-	// AutoMerge is nil when the active run type did not ask for auto-merge, so a consumer can
-	// tell "not requested" apart from "requested and failed".
+	// AutoMerge is nil when not requested, so that reads differently from "requested and failed".
 	AutoMerge *AutoMerge `json:"auto_merge,omitempty"`
 }
 
-// AutoMerge is the outcome of asking the platform to merge the MR/PR once its pipeline passes.
-//
-// Reported because enabling auto-merge is best-effort: a failure is logged and the run still
-// succeeds, so without this a consumer would see a clean success and never learn the MR it is
-// waiting on will not merge itself.
+// AutoMerge is the outcome of the auto-merge request. Reported because it is best-effort: without
+// it a consumer sees a clean success and never learns the MR will not merge itself.
 type AutoMerge struct {
 	// Enabled is true when the platform accepted the request.
 	Enabled bool `json:"enabled"`
@@ -120,8 +110,8 @@ type AutoMerge struct {
 	Error string `json:"error,omitempty"`
 }
 
-// PackageChange mirrors composer.PackageChange rather than reusing it: this type is published
-// schema, so a refactor in the composer package must not be able to rename a field here.
+// PackageChange mirrors composer.PackageChange: published schema, so an internal refactor must
+// not be able to rename a field here.
 type PackageChange struct {
 	// Action is one of Install, Upgrade, Downgrade, Remove.
 	Action  string `json:"action"`
@@ -149,8 +139,8 @@ type Reporter interface {
 	ReportData() any
 }
 
-// Recorder accumulates a report over a run. Safe for concurrent use: sites update concurrently,
-// so addons may record from several goroutines even though the phases are sequential.
+// Recorder accumulates a report over a run. Concurrency-safe: sites update in parallel, so an
+// addon may record from several goroutines.
 type Recorder struct {
 	mu     sync.Mutex
 	report Report
@@ -163,8 +153,7 @@ func NewRecorder(version string, mode Mode, dryRun bool, repositoryURL string, b
 			SchemaVersion:    SchemaVersion,
 			DrupdaterVersion: version,
 			StartedAt:        time.Now(),
-			// A failing phase overwrites this, so a run cut short without an error is not
-			// reported as having failed a phase it never entered.
+			// A failing phase overwrites this. A run cut short without an error failed nothing.
 			Status:     StatusSuccess,
 			Mode:       mode,
 			DryRun:     dryRun,
@@ -175,9 +164,8 @@ func NewRecorder(version string, mode Mode, dryRun bool, repositoryURL string, b
 	}
 }
 
-// Run executes fn as a named phase, recording its duration and outcome, and returns fn's error
-// unchanged. Only the first failure sets the top-level status: later bookkeeping is not what
-// went wrong.
+// Run records fn as a named phase and returns its error unchanged. Only the first failure sets
+// the top-level status: later bookkeeping is not what went wrong.
 func (r *Recorder) Run(name string, fn func() error) error {
 	start := time.Now()
 	err := fn()
@@ -204,11 +192,8 @@ func (r *Recorder) Run(name string, fn func() error) error {
 	return err
 }
 
-// SetNoChanges records that the run found nothing to update.
-//
-// The workflow signals this by aborting a phase, so that phase stays on record as failed in
-// Phases. The top-level status is reset, or every consumer would treat a healthy repository as
-// one needing attention.
+// SetNoChanges records that the run found nothing to update. The aborted phase stays on record as
+// failed, but the top-level status resets — a healthy repository must not read as needing attention.
 func (r *Recorder) SetNoChanges() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -218,8 +203,7 @@ func (r *Recorder) SetNoChanges() {
 	r.report.Error = ""
 }
 
-// SetToolVersions records the versions of the tools driving the run. A setter because reading
-// them costs a subprocess the recorder must already exist to outlive.
+// SetToolVersions is a setter because reading the versions costs a subprocess the recorder outlives.
 func (r *Recorder) SetToolVersions(versions ToolVersions) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -247,9 +231,8 @@ func (r *Recorder) SetMergeRequest(url string) {
 	r.report.MergeRequest = &MergeRequest{URL: SanitizeURL(url)}
 }
 
-// SetMergeRequestContent records the assembled title and description. Independent of
-// SetMergeRequest: the content exists once rendered, which is before -- and under --dry-run
-// without -- any merge request.
+// SetMergeRequestContent is independent of SetMergeRequest: the content exists once rendered,
+// which is before — and under --dry-run without — any merge request.
 func (r *Recorder) SetMergeRequestContent(title, description string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -257,8 +240,7 @@ func (r *Recorder) SetMergeRequestContent(title, description string) {
 	r.report.MergeRequestDescription = description
 }
 
-// SetAutoMerge records the outcome of the auto-merge request; err is nil when the platform
-// accepted it. A no-op when no merge request was recorded.
+// SetAutoMerge records the auto-merge outcome. A no-op when no merge request was recorded.
 func (r *Recorder) SetAutoMerge(err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -272,8 +254,7 @@ func (r *Recorder) SetAutoMerge(err error) {
 	r.report.MergeRequest.AutoMerge = am
 }
 
-// AddAddons collects a section from every addon implementing Reporter. A nil ReportData is
-// skipped too, so an addon with nothing to say does not add an empty key.
+// AddAddons collects a section per Reporter, skipping nil data so nothing adds an empty key.
 func (r *Recorder) AddAddons(addons []internal.Addon) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -294,8 +275,7 @@ func (r *Recorder) AddAddons(addons []internal.Addon) {
 	}
 }
 
-// Finish closes the report and returns it. The caller may call it more than once; each call
-// refreshes the end timestamp.
+// Finish closes the report. Safe to call repeatedly; each call refreshes the end timestamp.
 func (r *Recorder) Finish() Report {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -306,8 +286,8 @@ func (r *Recorder) Finish() Report {
 	return r.report
 }
 
-// Check is the document "drupdater check --report" writes. A distinct shape from Report: a
-// preflight has no phases, packages or branch, only prerequisites and whether each holds.
+// Check is the document "drupdater check --report" writes. Its own shape, because a preflight has
+// no phases, packages or branch.
 type Check struct {
 	SchemaVersion    int    `json:"schema_version"`
 	DrupdaterVersion string `json:"drupdater_version"`
@@ -338,20 +318,14 @@ func NewCheck(version string, tools ToolVersions, results []CheckResult) Check {
 	}
 }
 
-// WriteCheck serialises a preflight result to path, with the same atomicity and redaction
-// guarantees as Write.
+// WriteCheck serialises a preflight result, with the same guarantees as Write.
 func WriteCheck(fs afero.Fs, path string, check Check, redact func(string) string) error {
 	return writeJSON(fs, path, check, redact)
 }
 
-// Write serialises rep to path.
-//
-// redact runs over the whole marshalled document, not per field, so a credential reaching it
-// through a field nobody thought about -- an error string quoting an authenticated URL -- is
-// caught anyway. Pass logging.Redactor.Redact; nil writes unfiltered and suits only tests.
-//
-// The write is atomic (temp file plus rename), so a reader polling for the report never sees a
-// partial one.
+// Write serialises rep to path atomically, so a polling reader never sees a partial document.
+// redact runs over the whole marshalled document, catching a credential in a field nobody thought
+// about. Pass logging.Redactor.Redact; nil writes unfiltered and suits only tests.
 func Write(fs afero.Fs, path string, rep Report, redact func(string) string) error {
 	return writeJSON(fs, path, rep, redact)
 }
@@ -396,8 +370,8 @@ func writeJSON(fs afero.Fs, path string, doc any, redact func(string) string) er
 	return nil
 }
 
-// SanitizeURL strips a URL's userinfo, so https://user:token@host/repo.git cannot carry a
-// secret into the report. Values that do not parse as a URL are returned unchanged.
+// SanitizeURL strips userinfo, so https://user:token@host/repo.git cannot carry a secret into
+// the report. Values that do not parse as a URL are returned unchanged.
 func SanitizeURL(raw string) string {
 	if raw == "" {
 		return ""

--- a/internal/report/report_property_test.go
+++ b/internal/report/report_property_test.go
@@ -16,9 +16,8 @@ import (
 	"pgregory.net/rapid"
 )
 
-// This file is the report's published schema, so the promises worth stating over the whole input
-// space are the ones a consumer relies on: what is written parses back, no credential reaches
-// the file whichever field carried it, and a reader polling the path never sees a partial write.
+// The promises a consumer of the published schema relies on: what is written parses back, no
+// credential reaches the file, and a polling reader never sees a partial write.
 
 // secretGen generates a credential of the kind a repository URL or an error message can carry.
 func secretGen() *rapid.Generator[string] {
@@ -55,9 +54,8 @@ func TestPropertySanitizeURLLeavesCredentialFreeURLsAlone(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		raw := rapid.StringMatching(`https://[a-z]{1,8}\.example\.com(:[0-9]{2,4})?(/[a-z0-9_-]{1,8}){0,3}(\?[a-z]{1,5}=[a-z0-9]{1,5})?(#[a-z]{1,5})?`).Draw(t, "raw")
 
-		// A URL with nothing to remove has to come back byte-identical. Re-serialising it
-		// through net/url would normalise escaping and case, and the report is compared across
-		// runs by consumers who would read that as a change.
+		// Byte-identical when there is nothing to remove: net/url would normalise escaping
+		// and case, which a consumer diffing two reports reads as a change.
 		assert.Equal(t, raw, SanitizeURL(raw))
 	})
 }
@@ -157,9 +155,8 @@ func reportGen(secret string) *rapid.Generator[Report] {
 			}), 0, 4).Draw(t, "phases"),
 		}
 
-		// The secret is planted in whichever field this draw picks. Which one does not matter
-		// to the promise — that is the point of redacting the finished document rather than
-		// naming the fields that might carry a credential.
+		// Which field carries the secret does not matter — that is the point of redacting the
+		// finished document rather than naming the fields.
 		switch rapid.SampledFrom([]string{"repository", "error", "branch", "mr", "addons"}).Draw(t, "carrier") {
 		case "repository":
 			rep.Repository = "https://" + secret + "@example.com/org/repo.git"
@@ -222,9 +219,8 @@ func TestPropertyWriteLeavesNoTemporaryFileBehind(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		require.NoError(t, Write(fs, filepath.Join(dir, "report.json"), rep, nil))
 
-		// The write is atomic so a consumer polling the path never reads half a document. That
-		// only holds if the temporary file is renamed rather than left next to the real one,
-		// where a glob would pick it up.
+		// Atomicity only holds if the temp file is renamed rather than left beside the real
+		// one, where a glob would pick it up.
 		entries, err := afero.ReadDir(fs, dir)
 		require.NoError(t, err)
 		for _, entry := range entries {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -179,9 +179,8 @@ func TestRecorderAutoMergeOutcome(t *testing.T) {
 	})
 }
 
-// The auto_merge key must be omitted entirely when it was never requested, so a consumer can
-// test for its presence rather than having to distinguish false-because-failed from
-// false-because-unset.
+// Omitted entirely when never requested, so a consumer can test presence rather than tell
+// false-because-failed from false-because-unset.
 func TestAutoMergeOmittedFromJSONWhenNotRequested(t *testing.T) {
 	rec := newTestRecorder()
 	rec.SetMergeRequest("https://example.com/mr/1")

--- a/internal/report/write_failure_test.go
+++ b/internal/report/write_failure_test.go
@@ -10,10 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// failingFs fails one chosen filesystem operation and delegates the rest. writeJSON is written
-// to be atomic -- encode, write to a temp file, rename into place, and clean the temp file up
-// on any failure -- but on a real filesystem those failure branches are only reached by a full
-// disk or a permission change mid-write. This makes each one reachable on demand.
+// failingFs fails one chosen operation and delegates the rest, making writeJSON's atomicity
+// branches reachable — on a real filesystem they need a full disk or a mid-write chmod.
 type failingFs struct {
 	afero.Fs
 	mkdirAll bool
@@ -152,9 +150,8 @@ func TestWriteReportIsAtomic(t *testing.T) {
 }
 
 func TestSanitizeURLNormalizesOnlyWhenItReparses(t *testing.T) {
-	// Both halves of the "err != nil || parsed.User == nil" guard matter. A URL that parses but
-	// carries no credentials is returned verbatim rather than round-tripped through
-	// url.String(), which would rewrite it -- here by lower-casing the scheme and host.
+	// Both halves of the guard matter: a URL with no credentials is returned verbatim, not
+	// round-tripped through url.String(), which lower-cases the scheme and host.
 	const mixedCase = "HTTPS://Example.COM/Group/Repo.git"
 	assert.Equal(t, mixedCase, SanitizeURL(mixedCase))
 

--- a/internal/services/event.go
+++ b/internal/services/event.go
@@ -120,9 +120,8 @@ func (e *PostSiteUpdateEvent) Site() string {
 	return e.site
 }
 
-// AbandonedPackage carries the successor its maintainers suggested, empty when they suggested
-// none. It mirrors composer.AbandonedPackage rather than reusing it: this type is the wire
-// between two addons, and a change to composer's output shape must not reach through it.
+// AbandonedPackage mirrors composer.AbandonedPackage: it is the wire between two addons, so a
+// change to composer's output shape must not reach through it. Replacement is "" when none.
 type AbandonedPackage struct {
 	Name        string
 	Replacement string
@@ -131,11 +130,8 @@ type AbandonedPackage struct {
 type PreMergeRequestCreateEvent struct {
 	event.BasicEvent
 	Title string
-	// Written by composer_audit, read by unsupported_modules, which renders both kinds of
-	// end-of-life finding as one list — to a reviewer they are the same thing.
-	//
-	// Both addons' data is complete when this event fires, and the producer subscribes at
-	// Normal against the consumer's BelowNormal, so the list is filled in before it is read.
+	// Written by composer_audit at Normal, read by unsupported_modules at BelowNormal — that
+	// priority gap is what fills the list before it is read.
 	AbandonedPackages []AbandonedPackage
 }
 

--- a/internal/services/preflight.go
+++ b/internal/services/preflight.go
@@ -9,8 +9,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// CheckResult is one preflight outcome, from the "drupdater check" command or from the
-// fail-fast guard at the start of a real update.
+// CheckResult is one preflight outcome, from "drupdater check" or from a run's own guard.
 type CheckResult struct {
 	Name string
 	OK   bool
@@ -28,15 +27,13 @@ func CheckFailed(name string, detail string) CheckResult {
 	return CheckResult{Name: name, OK: false, Detail: detail}
 }
 
-// ShallowCloneChecker is all CheckGitHistoryComplete needs, so a caller outside this package can
-// supply a small double rather than implement every Repository method.
+// ShallowCloneChecker is all CheckGitHistoryComplete needs, so a caller can supply a small double.
 type ShallowCloneChecker interface {
 	IsShallowClone(path string) (bool, error)
 }
 
-// CheckGitHistoryComplete reports whether workingDir is a shallow clone. Such a checkout commits
-// the update branch fine but fails the push with a cryptic "object not found", because the remote
-// needs an ancestry it does not have. Checking upfront makes that failure actionable.
+// CheckGitHistoryComplete reports whether workingDir is a shallow clone, which commits fine but
+// fails the push much later with a cryptic "object not found".
 func CheckGitHistoryComplete(repository ShallowCloneChecker, workingDir string) CheckResult {
 	const name = "git history complete (not a shallow clone)"
 
@@ -50,14 +47,12 @@ func CheckGitHistoryComplete(repository ShallowCloneChecker, workingDir string) 
 	return CheckOK(name)
 }
 
-// PlatformReqsChecker is all CheckPlatformRequirements needs, narrow for the same reason as
-// ShallowCloneChecker.
+// PlatformReqsChecker is narrow for the same reason as ShallowCloneChecker.
 type PlatformReqsChecker interface {
 	CheckPlatformReqs(ctx context.Context, dir string) (string, error)
 }
 
-// CheckPlatformRequirements reports whether the runtime PHP version satisfies the platform
-// requirements recorded in the project's composer.lock.
+// CheckPlatformRequirements reports whether the runtime PHP satisfies composer.lock's platform.
 func CheckPlatformRequirements(ctx context.Context, composer PlatformReqsChecker, workingDir string) CheckResult {
 	const name = "PHP platform requirements satisfied"
 
@@ -68,15 +63,13 @@ func CheckPlatformRequirements(ctx context.Context, composer PlatformReqsChecker
 	return CheckOK(name)
 }
 
-// ComposerConfigGetter is all CheckSiteSettings needs, narrow for the same reason as
-// ShallowCloneChecker.
+// ComposerConfigGetter is narrow for the same reason as ShallowCloneChecker.
 type ComposerConfigGetter interface {
 	GetConfig(ctx context.Context, dir string, key string) (string, error)
 }
 
-// CheckSiteSettings reports whether site has a settings.php under the configured web root. Its
-// absence means the site was never installed here, so every downstream phase has nothing to
-// build on.
+// CheckSiteSettings looks for the site's settings.php: without it the site was never installed
+// here, and every downstream phase has nothing to build on.
 func CheckSiteSettings(ctx context.Context, composer ComposerConfigGetter, fs afero.Fs, workingDir string, site string) CheckResult {
 	name := fmt.Sprintf("site %q: settings.php", site)
 

--- a/internal/services/toolversions.go
+++ b/internal/services/toolversions.go
@@ -13,9 +13,8 @@ type ComposerVersionReporter interface {
 	Version(ctx context.Context) (composerpkg.Versions, error)
 }
 
-// LookupToolVersions reads the versions for the report, and logs them so a run without --report
-// names them too. Shared by the run and by "drupdater check". A failure warns and yields the
-// zero value: worth one subprocess, never a failed run.
+// LookupToolVersions reads the versions for the report and logs them, so a run without --report
+// names them too. A failure warns and yields the zero value: never worth failing a run over.
 func LookupToolVersions(ctx context.Context, logger *zap.Logger, composer ComposerVersionReporter) report.ToolVersions {
 	versions, err := composer.Version(ctx)
 	if err != nil {

--- a/internal/services/workflow_base.go
+++ b/internal/services/workflow_base.go
@@ -45,9 +45,8 @@ type WorkflowBaseService struct {
 	dispatcher EventDispatcher
 	current    time.Time
 
-	// siteCommitMu serializes the git-committing tail of updateSite. Sites are updated
-	// concurrently, but they share one working tree and git index, and drush config:export
-	// commits via git itself, so the staging/commit steps must not overlap.
+	// siteCommitMu serializes the git-committing tail of updateSite: sites update concurrently
+	// but share one working tree and index.
 	siteCommitMu sync.Mutex
 
 	// reportSink receives the run report on every exit path. nil when --report was not given.
@@ -57,8 +56,7 @@ type WorkflowBaseService struct {
 // Option configures a WorkflowBaseService. Variadic so adding one does not disturb call sites.
 type Option func(*WorkflowBaseService)
 
-// WithReportSink hands the finished report to sink, exactly once per run and after every other
-// deferred cleanup, including when the run fails.
+// WithReportSink hands the finished report to sink once per run, after every other cleanup.
 func WithReportSink(sink func(report.Report)) Option {
 	return func(ws *WorkflowBaseService) {
 		ws.reportSink = sink
@@ -103,10 +101,8 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 	}
 	rec := report.NewRecorder(internal.Version, mode, ws.config.DryRun, ws.config.RepositoryURL, ws.config.Branch, ws.config.Sites)
 
-	// Registered before anything that can fail, so "written on every exit path" holds literally,
-	// and therefore run last, so the report describes the run after every other teardown.
-	//
-	// An AbortError means there was nothing to do, not that the run failed.
+	// Registered first, so it runs last and covers every exit path. An AbortError means there
+	// was nothing to do, not that the run failed.
 	defer func() {
 		if ws.reportSink == nil {
 			return
@@ -129,18 +125,15 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 	// After the timeout, so the lookup is bounded too. Not a phase: it cannot fail the run.
 	rec.SetToolVersions(LookupToolVersions(ctx, ws.logger, ws.composer))
 
-	// platform is nil for a checkout-mode --dry-run run with no token (see cmd/root.go's
-	// tokenRequired): that run never pushes or creates an MR, so no VCS client was built and
-	// the checkout's own git identity (already configured locally, e.g. by CI) is used as-is.
+	// platform is nil for a token-free checkout-mode dry run (see tokenRequired), which keeps
+	// the checkout's own git identity.
 	var username, email string
 	if ws.platform != nil {
 		username, email = ws.platform.GetUser(ctx)
 	}
 
-	// One working directory for the whole run: the existing checkout (default, CI) or a fresh
-	// clone (--clone). Old and new code live here in sequence — baseline install, composer
-	// update, update hooks. Recorded as a phase because a bad token or unreachable host fails
-	// here, one of the most common ways a run fails.
+	// One working directory for the whole run. A phase because a bad token or unreachable host
+	// fails here, one of the most common ways a run fails.
 	var (
 		repository GitRepository
 		worktree   Worktree
@@ -154,8 +147,7 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 		return err
 	}
 
-	// Capture the checkout's current HEAD before any branch is created, so a failed or aborted
-	// run can restore it below — see captureOriginalHead.
+	// Before any branch is created, so a failed run can be put back — see captureOriginalHead.
 	originalRef := ws.captureOriginalHead(repository)
 
 	defer func() {
@@ -169,8 +161,8 @@ func (ws *WorkflowBaseService) StartUpdate(ctx context.Context, addons []interna
 	return ws.runPhases(ctx, rec, repository, worktree, path, addons)
 }
 
-// runPhases executes the update itself, one recorded phase at a time. Separate from StartUpdate
-// so the run's setup and teardown stay readable next to each other.
+// runPhases executes the update, one recorded phase at a time. Separate from StartUpdate so the
+// run's setup and teardown stay readable next to each other.
 func (ws *WorkflowBaseService) runPhases(
 	ctx context.Context,
 	rec *report.Recorder,
@@ -179,9 +171,8 @@ func (ws *WorkflowBaseService) runPhases(
 	path string,
 	addons []internal.Addon,
 ) error {
-	// Fail fast on the structural prerequisites "drupdater check" shares: a shallow checkout
-	// otherwise fails much later with a cryptic "object not found" on push. Extension
-	// requirements are deliberately not checked here (see CheckPlatformReqs).
+	// Fail fast on the prerequisites "drupdater check" shares. Extension requirements are
+	// deliberately not among them — see CheckPlatformReqs.
 	if err := rec.Run("preflight", func() error {
 		if result := CheckGitHistoryComplete(ws.repository, path); !result.OK {
 			return fmt.Errorf("%s: %s", result.Name, result.Detail)
@@ -236,9 +227,8 @@ func (ws *WorkflowBaseService) runPhases(
 		return err
 	}
 
-	// Its own phase, ahead of publish, because it must happen under --dry-run too. Rendered
-	// only when publishing, a broken template would be invisible to every dry run and surface
-	// in a real run only after the branch had been pushed.
+	// Ahead of publish so it runs under --dry-run too: rendered later, a broken template would
+	// only surface after the branch had been pushed.
 	var mrTitle, mrDescription string
 	if err := rec.Run("render merge request", func() error {
 		var renderErr error
@@ -257,11 +247,8 @@ func (ws *WorkflowBaseService) runPhases(
 	return nil
 }
 
-// renderMergeRequest produces the title and description for the run's merge request.
-//
-// The title starts as the maintenance-update default and is offered to the addons through
-// pre-merge-request-create — how composer_audit re-labels a security run. The event fires here
-// rather than in publishWork so a dry run reports the title a real run would have used.
+// renderMergeRequest produces the title and description. The title starts as the maintenance
+// default and is offered to the addons — how composer_audit re-labels a security run.
 func (ws *WorkflowBaseService) renderMergeRequest(addons []internal.Addon) (string, string, error) {
 	e := NewPreMergeRequestCreateEvent(fmt.Sprintf("%s: Drupal Maintenance Updates", ws.current.Format("January 2006")))
 	if err := ws.dispatcher.FireEvent(e); err != nil {
@@ -276,12 +263,8 @@ func (ws *WorkflowBaseService) renderMergeRequest(addons []internal.Addon) (stri
 	return e.Title, description, nil
 }
 
-// captureOriginalHead returns the checkout's current HEAD, so StartUpdate can put a failed run's
-// working directory back where it found it — otherwise the checkout is left on drupdater's
-// throwaway work branch with allow-plugins possibly still set to true.
-//
-// nil in clone mode (cleanup discards the whole temp directory anyway) or if HEAD is unreadable:
-// this is a safety net, not something to abort a run over.
+// captureOriginalHead returns the checkout's HEAD so a failed run can be put back rather than
+// left on drupdater's throwaway work branch. A safety net: nil in clone mode or on failure.
 func (ws *WorkflowBaseService) captureOriginalHead(repository GitRepository) *plumbing.Reference {
 	if ws.config.Clone {
 		return nil
@@ -294,10 +277,8 @@ func (ws *WorkflowBaseService) captureOriginalHead(repository GitRepository) *pl
 	return ref
 }
 
-// restoreOriginalCheckout switches worktree back to originalRef, discarding any uncommitted
-// changes and stray commits accumulated on drupdater's own throwaway work branch. It runs only
-// to tidy up after a run that has already failed or been aborted, so an error here is logged,
-// not returned: it must never mask the original failure.
+// restoreOriginalCheckout switches worktree back to originalRef, discarding whatever the work
+// branch accumulated. Errors are logged, never returned: this must not mask the real failure.
 func (ws *WorkflowBaseService) restoreOriginalCheckout(worktree Worktree, originalRef *plumbing.Reference) {
 	opts := &git.CheckoutOptions{Force: true}
 	if originalRef.Name().IsBranch() {
@@ -320,27 +301,19 @@ func (ws *WorkflowBaseService) acquireWorkingCopy(username, email string) (GitRe
 	return ws.repository.OpenRepository(ws.config.WorkingDir, username, email)
 }
 
-// stageScaffoldChanges stages what the dependency update rewrote outside composer.*.
+// stageScaffoldChanges stages the web-root files drupal-scaffold rewrites on a core update --
+// .htaccess, robots.txt, index.php -- which the composer.* glob does not cover.
 //
-// drupal-scaffold owns files in the web root -- .htaccess, robots.txt, index.php, update.php --
-// and a core update rewrites them. They are not covered by the composer.* glob, so without this
-// the run ends with a dirty working tree and the merge request omits changes the project is
-// expected to carry.
-//
-// Only paths git already tracks are staged. Untracked ones are left alone on purpose: vendor/,
-// web/core and the site's generated files legitimately sit in the checkout and belong to nobody.
-//
-// Each site's settings.php is excluded even though it is tracked and modified: the installer
-// appends the throwaway SQLite database to it (pkg/drupal/installer.go), and committing that
-// would put test credentials and a local path into the merge request.
+// Tracked paths only: vendor/ and web/core legitimately sit untracked in the checkout. Each
+// site's settings.php is excluded too, because the installer appends throwaway SQLite
+// credentials to it (pkg/drupal/installer.go).
 func (ws *WorkflowBaseService) stageScaffoldChanges(ctx context.Context, path string, worktree Worktree) error {
 	status, err := worktree.Status()
 	if err != nil {
 		return fmt.Errorf("failed to read worktree status: %w", err)
 	}
 
-	// Sorted so the staging order does not depend on map iteration, keeping a run's commit
-	// reproducible.
+	// Sorted so the staging order does not depend on map iteration.
 	candidates := make([]string, 0, len(status))
 	for file, fileStatus := range status {
 		if fileStatus.Worktree == git.Untracked || fileStatus.Worktree == git.Unmodified {
@@ -353,8 +326,7 @@ func (ws *WorkflowBaseService) stageScaffoldChanges(ctx context.Context, path st
 	}
 	slices.Sort(candidates)
 
-	// Only looked up once there is something to stage: an update that rewrote nothing outside
-	// composer.* has no reason to shell out to composer again.
+	// Looked up only when there is something to stage, to save a composer subprocess.
 	webroot, err := composer.WebRoot(ctx, ws.composer, path)
 	if err != nil {
 		return fmt.Errorf("failed to determine web root: %w", err)
@@ -366,12 +338,8 @@ func (ws *WorkflowBaseService) stageScaffoldChanges(ctx context.Context, path st
 
 	staged := make([]string, 0, len(candidates))
 	for _, file := range candidates {
-		// Confined to the web root, because that is the only tree drupal-scaffold writes to.
-		// Everything outside it that a run touches belongs to a later phase: the configuration
-		// export and the translations update each commit their own directories, per site, after
-		// the sites have been updated. Sweeping those in here would commit them mid-update, in
-		// the state the baseline install left them -- core.extension.yml still carrying the
-		// installer's sqlite entry, for one.
+		// Web root only: everything outside it belongs to a later phase, and sweeping it in
+		// here would commit it mid-update, still carrying the baseline install's state.
 		if !strings.HasPrefix(file, webroot+"/") {
 			continue
 		}
@@ -389,9 +357,8 @@ func (ws *WorkflowBaseService) stageScaffoldChanges(ctx context.Context, path st
 	return nil
 }
 
-// forEachSite runs fn for every configured site concurrently, bounded by config.Concurrency
-// (or GOMAXPROCS(0), which reflects the container's CPU quota, when unset), and cancels the
-// rest on the first error.
+// forEachSite runs fn per site concurrently, bounded by config.Concurrency, cancelling the rest
+// on the first error.
 func (ws *WorkflowBaseService) forEachSite(ctx context.Context, fn func(context.Context, string) error) error {
 	g, groupCtx := errgroup.WithContext(ctx)
 	limit := ws.config.Concurrency
@@ -407,13 +374,12 @@ func (ws *WorkflowBaseService) forEachSite(ctx context.Context, fn func(context.
 	return g.Wait()
 }
 
-// cleanup removes the artifacts the run created. In clone mode that's this run's own temp
-// clone; in checkout mode it's the SQLite databases and private files written beside the
-// checkout.
+// cleanup removes the run's artifacts: its temp clone, or the files a site install wrote beside
+// the checkout.
 func (ws *WorkflowBaseService) cleanup(path string) {
 	if ws.config.Clone {
-		// Only this run's clone directory, not the shared per-URL parent, so a concurrent run of
-		// the same repository isn't wiped out. The Rel guard keeps the temp dir itself safe.
+		// This run's own directory, not the shared per-URL parent, so a concurrent run of the
+		// same repository isn't wiped out. The Rel guard keeps the temp dir itself safe.
 		if rel, err := filepath.Rel(os.TempDir(), path); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
 			os.RemoveAll(path)
 		}
@@ -423,13 +389,11 @@ func (ws *WorkflowBaseService) cleanup(path string) {
 }
 
 // CleanupSiteArtifacts removes the SQLite databases and private files a site install writes
-// beside the checkout, given the directory the checkout sits in. Shared with "drupdater check
-// --full", which performs the same installs and owes the same cleanup.
+// beside the checkout. Shared with "drupdater check --full", which owes the same cleanup.
 func CleanupSiteArtifacts(parent string, sites []string) {
 	for _, site := range sites {
 		os.Remove(filepath.Join(parent, site+".sqlite"))
-		// Only the per-site directory, never the whole "private" tree: that is a standard Drupal
-		// layout and can hold real project data this run does not own.
+		// Per-site only: "private" is a standard Drupal tree and can hold real project data.
 		os.RemoveAll(filepath.Join(parent, "private", site))
 	}
 	// Drops the parent only if it is now empty — os.Remove refuses a non-empty directory.
@@ -439,12 +403,9 @@ func CleanupSiteArtifacts(parent string, sites []string) {
 func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository GitRepository, worktree Worktree, path string, rec *report.Recorder) (string, error) {
 	ws.logger.Info("updating dependencies")
 
-	// A dedicated branch, because in checkout mode the addons commit as they go: without it, an
-	// abort or mid-run failure would strand those commits on the user's own branch. The final,
-	// hash-named branch is cut from this one once the composer.lock hash is known.
-	//
-	// Flat name, not "drupdater/work-<ts>": a repo with a branch named "drupdater" makes
-	// refs/heads/drupdater a file, blocking any nested drupdater/* ref.
+	// A dedicated branch: the addons commit as they go, and a mid-run failure would otherwise
+	// strand those commits on the user's own branch. Flat name, not "drupdater/work-<ts>":
+	// a branch named "drupdater" makes refs/heads/drupdater a file, blocking nested refs.
 	workBranch := fmt.Sprintf("drupdater-work-%d", ws.current.UnixNano())
 	if err := worktree.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName(workBranch),
@@ -526,11 +487,8 @@ func (ws *WorkflowBaseService) updateSharedCode(ctx context.Context, repository 
 
 // ensureUpdateBranchAvailable returns an AbortError if updateBranchName is already taken, locally
 // or on the remote, and a plain error if either check itself fails.
-//
-// The local check runs first: a prior failed run of the same content hash leaves its branch
-// behind (restoreOriginalCheckout restores HEAD but deletes nothing). Without it the Create:true
-// checkout below fails on go-git's raw message instead of the clean AbortError a remote
-// collision gets.
+// The local check runs first: a prior failed run leaves its branch behind, and without it the
+// checkout below fails on go-git's raw message instead of a clean AbortError.
 func (ws *WorkflowBaseService) ensureUpdateBranchAvailable(repository GitRepository, updateBranchName string) error {
 	if _, err := repository.Reference(plumbing.NewBranchReferenceName(updateBranchName), false); err == nil {
 		return AbortError{Msg: fmt.Sprintf("branch %s already exists locally, skipping", updateBranchName)}
@@ -538,9 +496,8 @@ func (ws *WorkflowBaseService) ensureUpdateBranchAvailable(repository GitReposit
 		return fmt.Errorf("failed to check for a local %s branch: %w", updateBranchName, err)
 	}
 
-	// The remote half only matters for a branch that will be pushed, and reaching the remote
-	// would break the one documented token-free case, a checkout-mode dry run: go-git sends an
-	// empty password rather than no credential, which hosts reject even for a public repository.
+	// Skipped for a dry run: go-git sends an empty password rather than no credential, which
+	// hosts reject even for a public repository — breaking the token-free case.
 	if ws.config.DryRun {
 		return nil
 	}
@@ -577,13 +534,11 @@ func (ws *WorkflowBaseService) updateSite(ctx context.Context, path string, work
 
 	}
 
-	// The remaining steps commit into the shared working tree, so they run one site at a time
-	// even though the sites themselves are updated concurrently.
+	// The remaining steps commit into the shared working tree, so one site at a time.
 	return ws.commitSiteChanges(ctx, path, worktree, site)
 }
 
-// commitSiteChanges runs the post-site-update event and configuration export under a lock so
-// the git operations of concurrently-updated sites don't race on the shared index.
+// commitSiteChanges holds a lock so concurrently-updated sites don't race on the shared index.
 func (ws *WorkflowBaseService) commitSiteChanges(ctx context.Context, path string, worktree Worktree, site string) error {
 	ws.siteCommitMu.Lock()
 	defer ws.siteCommitMu.Unlock()
@@ -601,8 +556,7 @@ func (ws *WorkflowBaseService) commitSiteChanges(ctx context.Context, path strin
 	return nil
 }
 
-// toReportPackages converts composer's package changes into the report's own schema type, kept
-// separate deliberately — see report.PackageChange.
+// toReportPackages converts to the report's own schema type — see report.PackageChange.
 func toReportPackages(changes []composer.PackageChange) []report.PackageChange {
 	if len(changes) == 0 {
 		return nil
@@ -646,9 +600,8 @@ func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRe
 	ws.logger.Info("merge request created", zap.String("url", mr.URL))
 	rec.SetMergeRequest(mr.URL)
 
-	// Best-effort: the branch is pushed and the MR exists by now, so failing here would report a
-	// red job for a perfectly good MR. Recorded either way, since a logged warning is easy to
-	// miss and the report would otherwise show a clean success for an MR that will never merge.
+	// Best-effort: the MR already exists, so failing here would redden a perfectly good job.
+	// Recorded either way, or the report shows a clean success for an MR that will never merge.
 	if ws.config.ActiveRunType().AutoMerge {
 		err := ws.platform.EnableAutoMerge(ctx, mr)
 		rec.SetAutoMerge(err)
@@ -662,8 +615,7 @@ func (ws *WorkflowBaseService) publishWork(ctx context.Context, repository GitRe
 	return nil
 }
 
-// descriptionTemplates parses the embedded merge request templates once. The FS is compiled in,
-// so the result — success or failure — is the same on every call.
+// descriptionTemplates parses the embedded templates once: the FS is compiled in, result fixed.
 var descriptionTemplates = sync.OnceValues(func() (*template.Template, error) {
 	return template.ParseFS(templates, "templates/*.go.tmpl")
 })

--- a/internal/services/workflow_base_property_test.go
+++ b/internal/services/workflow_base_property_test.go
@@ -9,11 +9,9 @@ import (
 	"pgregory.net/rapid"
 )
 
-// report.PackageChange deliberately mirrors composer.PackageChange instead of reusing it, so
-// that a refactor in the composer package cannot rename a field every consumer of the published
-// report depends on. That decoupling only pays off if something notices when the two drift, and
-// a hand-written example only covers the fields whoever wrote it filled in. Generating the whole
-// struct is what makes a dropped field fail.
+// report.PackageChange mirrors composer.PackageChange so a refactor cannot rename a published
+// field. That only pays off if drift is noticed, and a hand-written example covers only the
+// fields its author filled in — generating the whole struct is what makes a dropped field fail.
 
 func packageChangeGen() *rapid.Generator[composer.PackageChange] {
 	return rapid.Custom(func(t *rapid.T) composer.PackageChange {

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -93,10 +93,8 @@ func TestStartUpdate(t *testing.T) {
 }
 
 func TestStartUpdatePublishUsesLiveContext(t *testing.T) {
-	// Regression: publishWork must run on the outer (timeout-bounded) context, not the
-	// errgroup-derived context. The errgroup context is cancelled as soon as g.Wait()
-	// returns, so if publishWork received it, CreateMergeRequest would see a cancelled
-	// context. Assert the context handed to CreateMergeRequest is still alive.
+	// Regression: publishWork must run on the outer context. The errgroup's is cancelled as
+	// soon as g.Wait() returns, so CreateMergeRequest would see a dead one.
 	logger := zap.NewNop()
 	installer := NewMockInstaller(t)
 	repositoryService := NewMockRepository(t)
@@ -433,11 +431,9 @@ func TestStartUpdateBranchAlreadyExists(t *testing.T) {
 }
 
 func TestStartUpdateLocalBranchAlreadyExists(t *testing.T) {
-	// Regression: a local ref left over from a prior checkout-mode run of the same
-	// code-content hash (one that reached this branch before failing later) must abort with the
-	// same clean AbortError a remote collision gets, not the raw go-git "a branch named ...
-	// already exists" from the Create:true checkout that follows. BranchExists (the remote
-	// check) must never even run once the local ref is found.
+	// Regression: a local ref left by a prior run of the same content hash must abort with the
+	// clean AbortError, not go-git's raw message from the checkout that follows — and the
+	// remote check must not run at all once the local ref is found.
 	logger := zap.NewNop()
 	installer := NewMockInstaller(t)
 	repositoryService := NewMockRepository(t)
@@ -613,9 +609,8 @@ func TestStartUpdateWithDryRun(t *testing.T) {
 }
 
 func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
-	// Regression for issue #167: a checkout-mode --dry-run run needs no token and therefore
-	// cmd/root.go builds no VCS platform for it. StartUpdate must not dereference a nil platform
-	// to get the commit identity; it proceeds with whatever identity the checkout already has.
+	// Regression for issue #167: a token-free dry run has no VCS platform, and StartUpdate must
+	// not dereference nil to get the commit identity.
 	logger := zap.NewNop()
 	installer := NewMockInstaller(t)
 	repositoryService := NewMockRepository(t)
@@ -673,9 +668,8 @@ func TestStartUpdateCheckoutDryRunWithoutPlatform(t *testing.T) {
 	repository.AssertExpectations(t)
 	drush.AssertExpectations(t)
 	mockComposer.AssertExpectations(t)
-	// A --dry-run never pushes, so ensureUpdateBranchAvailable deliberately skips the remote.
-	// This is the configuration documented as needing no token at all, and reaching the remote
-	// here used to fail it outright rather than merely need one.
+	// A --dry-run never pushes, so the remote check is skipped — reaching out used to fail the
+	// one configuration documented as needing no token.
 	repositoryService.AssertNotCalled(t, "BranchExists", mock.Anything, mock.Anything, mock.Anything)
 }
 
@@ -1429,11 +1423,8 @@ func TestStartUpdateWorkBranchCheckoutError(t *testing.T) {
 }
 
 func TestStartUpdateRestoresCheckoutOnFailureInCheckoutMode(t *testing.T) {
-	// Regression: a checkout-mode run that fails or aborts must not leave the checkout on
-	// drupdater's own throwaway work branch with an uncommitted composer.json (e.g.
-	// composer_allow_plugins' allow-plugins:true, set before the failure and never reverted).
-	// StartUpdate captures the original HEAD up front and, on any non-nil return in checkout
-	// mode, checks the worktree back out to it.
+	// Regression: a failed checkout-mode run must not leave the checkout on the throwaway work
+	// branch with an uncommitted composer.json — allow-plugins:true, say, never reverted.
 	logger := zap.NewNop()
 	installer := NewMockInstaller(t)
 	repositoryService := NewMockRepository(t)
@@ -1452,11 +1443,8 @@ func TestStartUpdateRestoresCheckoutOnFailureInCheckoutMode(t *testing.T) {
 	}
 
 	worktree := NewMockWorktree(t)
-	// updateSharedCode checks out a dedicated work branch before doing any work; the restore
-	// checkout (if any) happens afterward. Capture every call's arguments rather than trying to
-	// distinguish them via a second, more specific expectation, since testify matches expected
-	// calls for the same method in registration order and a wildcard registered first would
-	// simply swallow the later, more specific call too.
+	// Every call's arguments are captured rather than split across two expectations: testify
+	// matches in registration order, so a wildcard registered first swallows the specific one.
 	var checkoutCalls []*git.CheckoutOptions
 	worktree.EXPECT().Checkout(mock.Anything).RunAndReturn(func(opts *git.CheckoutOptions) error {
 		checkoutCalls = append(checkoutCalls, opts)
@@ -1660,11 +1648,8 @@ func TestCleanup(t *testing.T) {
 	})
 
 	t.Run("clone mode refuses to remove the temp dir itself", func(t *testing.T) {
-		// Point os.TempDir() at a sandbox first. This subtest deliberately asks cleanup()
-		// to delete the temp dir, relying on the guard in cleanup() to refuse — so if that
-		// guard is ever broken (a refactor, or a mutation-testing run that negates it),
-		// the RemoveAll must land in a directory owned by this test rather than wiping the
-		// machine's real temp dir out from under everything else running on it.
+		// This asks cleanup() to delete the temp dir and relies on its guard to refuse, so
+		// os.TempDir() is pointed at a sandbox: a broken guard must not wipe the real one.
 		t.Setenv("TMPDIR", t.TempDir())
 
 		ws := &WorkflowBaseService{logger: logger, config: internal.Config{Clone: true}}
@@ -1698,10 +1683,8 @@ func TestEnsureUpdateBranchAvailable(t *testing.T) {
 	}
 
 	t.Run("a dry run never reaches the remote", func(t *testing.T) {
-		// The remote half of this check only matters when the branch is going to be pushed,
-		// and a --dry-run never pushes. Reaching out anyway breaks the one configuration
-		// documented as needing no token at all: a checkout-mode dry run. BranchExists is
-		// deliberately left unstubbed, so the mock fails the test if it is called.
+		// A --dry-run never pushes, so the remote is never reached. BranchExists is left
+		// unstubbed, so the mock fails the test if it is called.
 		repository := NewMockRepository(t)
 		ws := &WorkflowBaseService{
 			logger:     zap.NewNop(),
@@ -1755,13 +1738,8 @@ func TestEnsureUpdateBranchAvailable(t *testing.T) {
 	})
 }
 
-// anyCtx matches any non-nil context.Context in a mock expectation.
-//
-// The exact value cannot be pinned: StartUpdate runs the per-site work through an errgroup,
-// which derives a cancellable child context, so what reaches installer.Install is not the
-// context handed to StartUpdate. Requiring non-nil still catches the failure that matters --
-// a call site that stops propagating the context altogether, which would silently disable
-// cancellation and the run timeout for everything below it.
+// anyCtx matches any non-nil context.Context: the errgroup derives a child, so the exact value
+// cannot be pinned, but non-nil still catches a call site that stops propagating it.
 var anyCtx = mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })
 
 // expectVersionLookup declares the version call every run makes. What the versions end up as is
@@ -1770,12 +1748,8 @@ func expectVersionLookup(composerMock *MockComposer) {
 	composerMock.EXPECT().Version(anyCtx).Return(composer.Versions{Composer: "2.10.2", PHP: "8.3.14"}, nil)
 }
 
-// workBranchCheckout pins the options of every branch drupdater creates.
-//
-// Both are load-bearing. Create is required because neither branch exists yet, so without it
-// the checkout fails outright. Keep preserves the working tree across the switch; dropping it
-// would reset the tree and discard changes the run has already made, which is exactly what the
-// work branch exists to carry.
+// workBranchCheckout pins both options: Create because neither branch exists yet, and Keep
+// because dropping it resets the tree and discards the changes the work branch exists to carry.
 var workBranchCheckout = mock.MatchedBy(func(opts *git.CheckoutOptions) bool {
 	return opts != nil && opts.Create && opts.Keep && !opts.Force &&
 		(strings.HasPrefix(opts.Branch.Short(), "drupdater-work-") ||
@@ -1821,13 +1795,9 @@ func TestStageScaffoldChanges(t *testing.T) {
 	})
 
 	t.Run("stages nothing outside the web root", func(t *testing.T) {
-		// Regression: staging every tracked change swept the configuration export and the
-		// translations into the shared-code commit, in the state the baseline install had left
-		// them -- core.extension.yml still carrying the installer's sqlite entry. The next run
-		// then refused to install from that configuration ("Unable to uninstall the SQLite
-		// module because: The module 'SQLite' is providing the database driver 'sqlite'"), so
-		// the update looked fine and was not reinstallable. Those trees belong to the per-site
-		// export, which commits them itself, after the sites have been updated.
+		// Regression: staging every tracked change swept the config export into the
+		// shared-code commit, still carrying the installer's sqlite entry, and the next run
+		// then refused to install from it. Those trees belong to the per-site export.
 		worktree := NewMockWorktree(t)
 		worktree.EXPECT().Status().Return(git.Status{
 			"web/robots.txt":                 {Worktree: git.Modified},

--- a/internal/services/workflow_report_test.go
+++ b/internal/services/workflow_report_test.go
@@ -202,9 +202,8 @@ func TestReportRepositoryURLHasNoCredentials(t *testing.T) {
 	assert.NotContains(t, h.got.Repository, "s3cret")
 }
 
-// A --dry-run stops before publishing but is still a successful run: it did everything it was
-// asked to do. This is one of the cases that produces no merge request and therefore no output
-// at all without --report.
+// A --dry-run did everything it was asked to, so it is a success — and without --report it
+// produces no output at all.
 func TestReportWrittenOnDryRun(t *testing.T) {
 	h := newReportHarness(t, true)
 	h.expectFullRun(t)
@@ -238,9 +237,8 @@ func TestReportWrittenOnFailureNamesThePhase(t *testing.T) {
 	assert.Nil(t, h.got.MergeRequest)
 }
 
-// Acquiring the working copy is the first thing that can fail, and one of the most common ways
-// a run fails in practice: a bad token, an unreachable host, an unreadable checkout. The report
-// must still be written — this is precisely the case "written on every exit path" is for.
+// Acquiring the working copy is the first thing that can fail, and the case that "written on
+// every exit path" exists for.
 func TestReportWrittenWhenAcquiringTheWorkingCopyFails(t *testing.T) {
 	h := newReportHarness(t, false)
 	h.repoSvc.ExpectedCalls = nil
@@ -292,15 +290,12 @@ func TestRunWithoutReportSinkIsUnaffected(t *testing.T) {
 	assert.Nil(t, h.got)
 }
 
-// mergeRequestAddon stands in for a real addon at the two points the merge request is assembled:
-// it renames the title through pre-merge-request-create, the way composer_audit re-labels a
-// security run, and contributes a section to the description.
+// mergeRequestAddon stands in at both points the merge request is assembled: it renames the
+// title and contributes a description section.
 type mergeRequestAddon struct {
 	title   string
 	section string
-	// err makes the pre-merge-request-create handler fail, standing in for an addon that cannot
-	// produce its part of the merge request. renderErr does the same one step later, when the
-	// description template asks the addon for its section.
+	// err fails the handler, renderErr the section one step later.
 	err       error
 	renderErr error
 }
@@ -325,8 +320,7 @@ func (a *mergeRequestAddon) RenderTemplate() (string, error) { return a.section,
 
 var _ internal.Addon = (*mergeRequestAddon)(nil)
 
-// A --dry-run opens no merge request, but it does assemble one. Recording the title and
-// description is what lets a dry run be reviewed at all -- and what makes a broken description
+// A --dry-run assembles a merge request without opening one, which is what makes a broken
 // template visible before a real run has pushed anything.
 func TestReportRecordsMergeRequestContentOnDryRun(t *testing.T) {
 	h := newReportHarness(t, true)
@@ -347,9 +341,7 @@ func TestReportRecordsMergeRequestContentOnDryRun(t *testing.T) {
 	assert.Nil(t, h.got.MergeRequest)
 }
 
-// The reported content has to be the published content, not a second rendering of it: a report
-// that showed something other than what the reviewer sees on the merge request would be worse
-// than no report at all.
+// The reported content must be the published content, not a second rendering of it.
 func TestReportedMergeRequestContentIsWhatWasPublished(t *testing.T) {
 	h := newReportHarness(t, false)
 	h.expectFullRun(t)
@@ -373,9 +365,8 @@ func TestReportedMergeRequestContentIsWhatWasPublished(t *testing.T) {
 	assert.Equal(t, publishedDescription, h.got.MergeRequestDescription)
 }
 
-// Assembling the merge request is a phase like any other, so a failure there is attributed
-// rather than surfacing as an unexplained error at the end of a run. Both halves can fail: the
-// event that settles the title, and the template that renders the description.
+// A phase like any other, so its failure is attributed rather than unexplained. Both halves
+// can fail: the event settling the title, and the template rendering the description.
 func TestReportNamesTheRenderPhaseWhenAssemblyFails(t *testing.T) {
 	t.Run("the title event fails", func(t *testing.T) {
 		titleErr := errors.New("addon could not produce a title")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,8 +48,7 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
-  # Analytics is opt-in per build: the publish workflow sets DRUPDATER_GOATCOUNTER,
-  # so `mkdocs serve` and local builds emit no tracking script at all.
+  # Opt-in per build: only the publish workflow sets DRUPDATER_GOATCOUNTER.
   goatcounter: !ENV [DRUPDATER_GOATCOUNTER, false]
   social:
     - icon: fontawesome/brands/github
@@ -74,9 +73,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  # base_path includes the repository root so pages can embed files that live
-  # beside the code — the addon golden files and .github/assert-report.jq — and
-  # therefore cannot drift from what the tests and CI actually use.
+  # The repository root, so pages can embed the golden files and jq scripts CI itself uses.
   - pymdownx.snippets:
       base_path:
         - .

--- a/mutago.yaml
+++ b/mutago.yaml
@@ -1,14 +1,9 @@
 # Mutation testing configuration — https://github.com/quality-gates/mutago
 #
-# Only loaded when passed explicitly with `--config mutago.yaml`; there is no
-# auto-discovery. The decoder rejects unknown keys, so a typo aborts the run.
-#
-# Thresholds deliberately live on the command line, not here: the pull request
-# gate scores only the changed lines while the weekly full run is informational,
-# so they need different values.
+# Loaded only via `--config mutago.yaml`; there is no auto-discovery. Thresholds live on the
+# command line, because the PR gate and the weekly full run need different values.
 
-# `_test.go` files are never mutated, which already covers the generated mockery
-# files (one `mocks_test.go` per package). This keeps any other generated source
-# out as well.
+# `_test.go` is never mutated, which covers the generated mocks; this keeps other generated
+# source out too.
 ignore_source_lines:
   - "// Code generated"

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -36,30 +36,20 @@ func NewCLI(logger *zap.Logger) *CLI {
 	}
 }
 
-// requiredComposerEnv is forced on every invocation (see Env) rather than left to the
-// Dockerfile, which only covers runs that use the published image.
-//
-//   - COMPOSER_PROCESS_TIMEOUT: composer's 300s default kills a large install mid-phase with a
-//     message that names no timeout.
-//   - COMPOSER_NO_AUDIT: the implicit post-update audit is output Update() cannot parse.
-//     Auditing is the composer_audit addon's job.
-//
-// Deployment policy (COMPOSER_HOME, COMPOSER_CACHE_DIR, …) is deliberately not forced here.
+// requiredComposerEnv is forced on every invocation (see Env), not left to the Dockerfile, which
+// only covers the published image. The 300s default timeout kills a large install mid-phase, and
+// the implicit audit is output Update() cannot parse. Deployment policy is not forced here.
 var requiredComposerEnv = []string{
 	"COMPOSER_PROCESS_TIMEOUT=0",
 	"COMPOSER_NO_AUDIT=1",
 }
 
-// Env applies requiredComposerEnv to env, passing every other entry through in order — notably
-// COMPOSER_AUTH, which carries registry credentials.
+// Env applies requiredComposerEnv to env, passing everything else through in order — notably
+// COMPOSER_AUTH. Inherited assignments to a required variable are dropped rather than shadowed,
+// so the outcome does not depend on how os/exec resolves duplicate keys.
 //
-// Inherited assignments to a required variable are dropped rather than shadowed, so the outcome
-// depends on this function and not on how os/exec resolves duplicate keys.
-//
-// Exported because drush, phpcs and rector run through `composer exec` and inherit the same
-// process timeout. Every package building a composer *exec.Cmd should set:
-//
-//	command.Env = composer.Env(command.Environ())
+// Exported because drush, phpcs and rector run through `composer exec`; each should set
+// command.Env = composer.Env(command.Environ()).
 func Env(env []string) []string {
 	result := make([]string, 0, len(env)+len(requiredComposerEnv))
 	for _, entry := range env {
@@ -76,8 +66,7 @@ func Env(env []string) []string {
 	return append(result, requiredComposerEnv...)
 }
 
-// command returns the runner for a composer invocation in dir. Built per call so a test that
-// swaps execCommand after the CLI was constructed still diverts the subprocess.
+// command is built per call so a test swapping execCommand later still diverts the subprocess.
 func (s *CLI) command(dir string) Command {
 	return Command{New: execCommand, Logger: s.logger, Dir: dir}
 }
@@ -86,22 +75,19 @@ func (s *CLI) execComposer(ctx context.Context, dir string, args ...string) (str
 	return s.command(dir).Combined(ctx, args...)
 }
 
-// execComposerJSON returns stdout only. Commands whose output is parsed as JSON must use this:
-// composer's stderr notices would otherwise corrupt the payload. stderr still reaches the log.
+// execComposerJSON returns stdout only, so composer's stderr notices cannot corrupt the payload.
 func (s *CLI) execComposerJSON(ctx context.Context, dir string, args ...string) (string, error) {
 	stdout, _, err := s.command(dir).Split(ctx, args...)
 	return stdout, err
 }
 
-// Versions are the tool versions a run's outcome depends on: composer because drupdater wraps
-// it, PHP because the image is built per PHP version.
+// Versions are the tool versions a run's outcome depends on.
 type Versions struct {
 	Composer string
 	PHP      string
 }
 
-// composer --version prints its own version on stdout and PHP's on stderr, so both are scraped
-// out of the merged output.
+// composer --version puts its version on stdout and PHP's on stderr — hence the merged output.
 var (
 	composerVersionRe = regexp.MustCompile(`(?m)^Composer version (\S+)`)
 	phpVersionRe      = regexp.MustCompile(`(?m)^PHP version (\S+)`)
@@ -154,14 +140,9 @@ func (s *CLI) Update(ctx context.Context, dir string, packages []string, package
 		return changes, fmt.Errorf("failed to update dependencies: %w, output: %s, arg: %v", err, out, args)
 	}
 
-	// Grouped by action rather than scanned line by line, so the result stays ordered by action
-	// however composer interleaved its output.
-	//
-	// Deduplicated because composer reports a version change twice: once resolving the lock
-	// ("Lock file operations") and again installing it ("Package operations"), in identical
-	// wording. Installs differ between the two ("Locking" vs "Installing") and only the second is
-	// matched, so nothing is lost by keeping the first of each. One update produces at most one
-	// operation per package, so an exact repeat is always the same operation seen twice.
+	// Grouped by action, not scanned line by line, so the result stays ordered however composer
+	// interleaved its output. Deduplicated because composer reports a version change twice, once
+	// for the lock and once for the install, in identical wording.
 	seen := make(map[PackageChange]struct{})
 	for _, pattern := range packageChangePatterns {
 		for _, match := range pattern.re.FindAllStringSubmatch(out, -1) {
@@ -184,14 +165,11 @@ func (s *CLI) Update(ctx context.Context, dir string, packages []string, package
 }
 
 // packageChangePatterns matches composer update's report of what it did, one entry per action.
-//
-// The order is the order the changes come back in, which the merge request description and the
-// report both carry, so it is part of what a consumer sees.
+// This order is the order the changes come back in, which both the report and the MR carry.
 var packageChangePatterns = []struct {
 	action string
 	re     *regexp.Regexp
 	// from and to are the capture groups holding those versions; 0 means the action has none.
-	// A removal reports only the version going away, an install only the one arriving.
 	from int
 	to   int
 }{
@@ -201,8 +179,7 @@ var packageChangePatterns = []struct {
 	{action: "Install", re: oneVersionRegex("Installing"), to: 2},
 }
 
-// versionPattern includes "+" and "~" in the class so build-metadata versions (1.0.0+21AF26D3)
-// still match.
+// versionPattern allows "+" and "~" so build-metadata versions (1.0.0+21AF26D3) still match.
 const versionPattern = `[\w.\-+~]+`
 
 func twoVersionRegex(verb string) *regexp.Regexp {
@@ -238,10 +215,7 @@ func (s *CLI) Remove(ctx context.Context, dir string, packages ...string) (strin
 }
 
 // Audit returns both halves of `composer audit` output: advisories and abandoned packages.
-//
-// --abandoned is deliberately not passed. The object is already in the JSON either way, and
-// omitting the flag lets the project's own `audit.abandoned: ignore` keep dismissed packages
-// out of every merge request.
+// --abandoned is not passed, so the project's own `audit.abandoned: ignore` still applies.
 func (s *CLI) Audit(ctx context.Context, dir string) (Audit, error) {
 	var composerAudit Audit
 	out, err := s.execComposerJSON(ctx, dir, "audit", "--format=json", "--locked", "--no-plugins")
@@ -277,8 +251,7 @@ type Advisory struct {
 // AdvisoriesMap is keyed by package name.
 type AdvisoriesMap map[string]json.RawMessage
 
-// AbandonedPackage has an empty Replacement when the maintainers suggested no successor,
-// which composer expresses as JSON null.
+// AbandonedPackage has an empty Replacement when composer reported JSON null — no successor.
 type AbandonedPackage struct {
 	PackageName string `json:"packageName"`
 	Replacement string `json:"replacement"`
@@ -289,8 +262,7 @@ type Audit struct {
 	Abandoned  []AbandonedPackage `json:"abandoned"`
 }
 
-// UnmarshalJSON flattens nested advisories into a single list and the abandoned object into a
-// sorted list.
+// UnmarshalJSON flattens nested advisories and the abandoned object into sorted lists.
 func (c *Audit) UnmarshalJSON(data []byte) error {
 	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -307,10 +279,8 @@ func (c *Audit) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// flattenAdvisories flattens composer audit's `advisories` object. Composer emits a package's
-// advisories either as a list or as a keyed map (drupal/core does the latter); both shapes must
-// land in the same list or an advisory silently vanishes from a security report. Any other
-// shape means there is nothing to report.
+// flattenAdvisories handles both shapes composer emits — a list, or a keyed map as drupal/core
+// gets — since missing one silently drops an advisory from a security report.
 func flattenAdvisories(advisoriesData any) ([]Advisory, error) {
 	advMap, ok := advisoriesData.(map[string]any)
 	// Equivalent mutant: ranging a nil map already yields (nil, nil). Kept to state the intent.
@@ -344,12 +314,8 @@ func flattenAdvisories(advisoriesData any) ([]Advisory, error) {
 	return advisories, nil
 }
 
-// flattenAbandoned flattens composer audit's `abandoned` object into a sorted list.
-//
-// With nothing to report composer emits an empty JSON *array*, not an object, so a failed
-// assertion must read as "none" — this list is supplementary and no shape of it is worth
-// failing a security run over. Sorted because map order is random and the report and merge
-// request description must be byte-identical for unchanged input.
+// flattenAbandoned flattens composer audit's `abandoned` object into a sorted list. With nothing
+// to report composer emits an empty JSON *array*, so a failed assertion must read as "none".
 func flattenAbandoned(abandonedData any) []AbandonedPackage {
 	entries, ok := abandonedData.(map[string]any)
 	if !ok {
@@ -373,8 +339,7 @@ func flattenAbandoned(abandonedData any) []AbandonedPackage {
 	return abandoned
 }
 
-// platformRequirementConstraint describes the unmet constraint for a failed/missing row of
-// `composer check-platform-reqs --format=json` output.
+// platformRequirementConstraint is the unmet constraint of a failed or missing row.
 type platformRequirementConstraint struct {
 	Constraint string `json:"constraint"`
 }
@@ -388,15 +353,13 @@ type platformRequirement struct {
 	FailedRequirement *platformRequirementConstraint `json:"failed_requirement"`
 }
 
-// CheckPlatformReqs verifies the PHP version satisfies composer.lock. `Update` runs with
-// --ignore-platform-reqs, so this is the only fail-fast check and runs ahead of it for a clear
-// message. Extension requirements (ext-*) are ignored — the operator cannot act on which
-// extensions drupdater's own runtime loaded. The returned output names the unmet requirements.
+// CheckPlatformReqs verifies the PHP version satisfies composer.lock, and is the only fail-fast
+// check because `Update` runs with --ignore-platform-reqs. ext-* is ignored: the operator cannot
+// act on which extensions drupdater's own runtime loaded.
 func (s *CLI) CheckPlatformReqs(ctx context.Context, dir string) (string, error) {
 	out, err := s.execComposer(ctx, dir, "check-platform-reqs", "--lock", "--no-ansi", "--format=json")
 
-	// composer prints an informational line ahead of the payload, so extract the array rather
-	// than parsing the whole blob.
+	// composer prints an informational line ahead of the payload, so extract just the array.
 	jsonPayload := out
 	if start, end := strings.Index(out, "["), strings.LastIndex(out, "]"); start != -1 && end > start {
 		jsonPayload = out[start : end+1]
@@ -478,11 +441,9 @@ func (s *CLI) GetInstalledPackageVersion(ctx context.Context, dir string, packag
 	return composerShow.Versions[0], nil
 }
 
-// GetAllowPlugins returns composer's allow-plugins config as a package -> allowed map.
-//
-// The setting is polymorphic — an object of per-package entries, `true`, `false`, `[]`, `null`,
-// or unset — and only the object form carries entries, so every other shape yields an empty
-// map. Never nil: callers add newly discovered plugins to it.
+// GetAllowPlugins returns composer's allow-plugins config as a package -> allowed map. The
+// setting is polymorphic and only its object form carries entries, so every other shape yields
+// an empty map — never nil, since callers add newly discovered plugins to it.
 func (s *CLI) GetAllowPlugins(ctx context.Context, dir string) (map[string]bool, error) {
 	allowPluginsJSON, err := s.GetConfig(ctx, dir, "allow-plugins")
 	if err != nil {
@@ -527,8 +488,8 @@ func (s *CLI) SetConfig(ctx context.Context, dir string, key string, value strin
 	return err
 }
 
-// GetDependencyPatches returns patches declared by installed dependencies, as
-// targetPackage -> set of patch files. These apply on top of the root composer.json patches.
+// GetDependencyPatches returns targetPackage -> patch files declared by installed dependencies,
+// which apply on top of the root composer.json patches.
 func (s *CLI) GetDependencyPatches(_ context.Context, dir string) (map[string]map[string]bool, error) {
 	content, err := afero.ReadFile(s.fs, dir+"/composer.lock")
 	if err != nil {
@@ -568,12 +529,11 @@ type lockPackage struct {
 	Extra json.RawMessage `json:"extra"`
 }
 
-// Appended to every scratch project so a contrib module resolves even when the project declares
-// its repositories somewhere this code cannot read.
+// Appended to every scratch project so a contrib module resolves even when the project's own
+// repositories are declared somewhere this code cannot read.
 const drupalOrgRepositoryURL = "https://packages.drupal.org/8"
 
-// scratchComposerProject is the composer.json of the patch-test project. Written fresh before
-// every check (see resetScratchProject) so one check cannot leave state another reads.
+// scratchComposerProject is rewritten before every check, so one check leaves no state another reads.
 type scratchComposerProject struct {
 	Name         string            `json:"name"`
 	Type         string            `json:"type"`
@@ -583,16 +543,11 @@ type scratchComposerProject struct {
 	Extra        map[string]any    `json:"extra"`
 }
 
-// buildScratchComposerJSON returns the scratch project's composer.json, carrying over the
-// repositories declared by the project in projectDir.
+// buildScratchComposerJSON carries over projectDir's repositories, without which a private
+// registry's package is unresolvable and composer_patches misreads that as "does not apply".
 //
-// Without them a package from a private registry or in-house fork is unresolvable here, and
-// composer_patches reads that failure as "the patch does not apply" — pinning the package and
-// reporting a conflict that never happened, on every run.
-//
-// The project's repositories come first so a private fork keeps its priority. drupal.org is a
-// fallback and packagist.org stays enabled even if the project disables it: resolving more than
-// the real project can costs nothing and cannot affect its lock.
+// The project's repositories come first so a private fork keeps its priority; drupal.org and
+// packagist.org stay enabled regardless, which costs nothing and cannot affect the real lock.
 func (s *CLI) buildScratchComposerJSON(projectDir string) ([]byte, error) {
 	repositories := s.projectRepositories(projectDir)
 
@@ -619,10 +574,8 @@ func (s *CLI) buildScratchComposerJSON(projectDir string) ([]byte, error) {
 	})
 }
 
-// projectRepositories returns the repository entries declared by the project in projectDir.
-//
-// An unreadable or unparsable composer.json yields no entries rather than an error: checking
-// against fewer repositories beats failing the patch check outright.
+// projectRepositories returns projectDir's declared repositories. An unreadable composer.json
+// yields none rather than an error: fewer repositories beats failing the patch check outright.
 func (s *CLI) projectRepositories(projectDir string) []json.RawMessage {
 	if projectDir == "" {
 		return nil
@@ -662,9 +615,8 @@ func (s *CLI) projectRepositories(projectDir string) []json.RawMessage {
 	return repositories
 }
 
-// orderedObjectValues returns a JSON object's values in declaration order, and whether raw was
-// an object at all. A map[string]json.RawMessage would be shorter but loses that order, and
-// sorting the keys instead — as this once did — reorders the project's repositories.
+// orderedObjectValues returns a JSON object's values in declaration order. A map would be
+// shorter but loses that order, reordering the project's repositories.
 func orderedObjectValues(raw json.RawMessage) ([]json.RawMessage, bool) {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 
@@ -689,13 +641,9 @@ func orderedObjectValues(raw json.RawMessage) ([]json.RawMessage, bool) {
 	return values, true
 }
 
-// normalizeRepository prepares a repository entry for the scratch project, reporting false for
-// entries that must not be carried over.
-//
-// A disable entry such as {"packagist.org": false} is dropped — the scratch project needs
-// packagist.org for composer-patches even when the real project mirrors everything. A "path"
-// repository's relative URL is resolved against the project, since the scratch project lives
-// in a temp directory where that path points nowhere.
+// normalizeRepository prepares an entry for the scratch project, false when it must be dropped.
+// A disable entry like {"packagist.org": false} goes, since the scratch project needs packagist
+// for composer-patches. A "path" repository's relative URL is resolved against the project.
 func normalizeRepository(raw json.RawMessage, projectDir string) (json.RawMessage, bool) {
 	var entry map[string]any
 	if err := json.Unmarshal(raw, &entry); err != nil {
@@ -740,13 +688,10 @@ func (s *CLI) initTempDir() {
 	s.tempDir, s.initErr = afero.TempDir(s.fs, "", "composer-service")
 }
 
-// resetScratchProject restores the scratch project before each check. Every check runs
-// `composer require <pkg>:<version>` here, which sticks; without a reset a version conflict
-// between two unrelated earlier checks fails the require, and that failure reads as "the patch
-// does not apply" — silently pinning the wrong package.
-//
-// composer.json is rebuilt here rather than at init because it carries the project's
-// repositories, which are unknown until a check asks.
+// resetScratchProject undoes the `composer require` each check leaves behind: without it, a
+// conflict between two unrelated checks fails the require and reads as "the patch does not
+// apply". composer.json is rebuilt here, not at init, because it carries the project's
+// repositories, unknown until a check asks.
 func (s *CLI) resetScratchProject(projectDir string) error {
 	composerJSON, err := s.buildScratchComposerJSON(projectDir)
 	if err != nil {
@@ -764,8 +709,7 @@ func (s *CLI) resetScratchProject(projectDir string) error {
 	return nil
 }
 
-// Cleanup removes the patch-test scratch project. A no-op when no check ran, and safe to call
-// twice. Defer it for the lifetime of the CLI, or every run leaks a full vendor tree.
+// Cleanup removes the patch-test scratch project; defer it, or every run leaks a vendor tree.
 func (s *CLI) Cleanup() {
 	if s.tempDir == "" {
 		return
@@ -783,21 +727,15 @@ type patchTestConfig struct {
 	Patches map[string]map[string]string `json:"patches"`
 }
 
-// CheckIfPatchApplies reports whether a single patch still applies to packageName at
-// packageVersion.
+// CheckIfPatchApplies reports whether one patch still applies to packageName at packageVersion.
 func (s *CLI) CheckIfPatchApplies(ctx context.Context, projectDir string, packageName string, packageVersion string, patchPath string) (bool, error) {
 	return s.CheckIfPatchesApply(ctx, projectDir, packageName, packageVersion, []string{patchPath})
 }
 
-// requireIntoScratch installs the package under test and classifies the outcome: true when the
-// patched package installed, false when the patch was rejected, error when composer never got
-// the package at all.
-//
-// The third case must stay distinct: false makes composer_patches pin the package and report a
-// conflict, which is right for a stale patch and wrong for an unreachable registry or a rejected
-// credential — that pins silently on every run for a reason the reviewer cannot act on.
-//
-// Deliberately not --quiet: that suppresses the message this classification reads.
+// requireIntoScratch installs the package under test: true when it installed, false when the
+// patch was rejected, error when composer never got the package. The third case must stay
+// distinct — false pins the package, which is wrong for an unreachable registry. Not --quiet:
+// that suppresses the message this classification reads.
 func (s *CLI) requireIntoScratch(ctx context.Context, packageName string, packageVersion string) (bool, error) {
 	out, err := s.execComposer(ctx, s.tempDir,
 		"require", "--ignore-platform-reqs", packageName+":"+packageVersion, "--with-all-dependencies")
@@ -812,20 +750,15 @@ func (s *CLI) requireIntoScratch(ctx context.Context, packageName string, packag
 	return false, nil //nolint:nilerr // composer obtained the package and the patch was rejected
 }
 
-// unresolvableReason reports whether composer's output says it could not obtain the package,
-// and why.
+// unresolvableReason reports whether composer could not obtain the package, and why. A rejected
+// patch wins outright: the dist-to-source fallback logs "could not be downloaded (404)" and then
+// succeeds, so the unresolvable patterns alone would misread a genuine rejection.
 //
-// A rejected patch is checked first and wins outright: composer's dist-to-source fallback logs
-// `… could not be downloaded (404)` and then succeeds, so matching the unresolvable patterns
-// alone would misread a genuine patch rejection and ship a patch that does not apply.
-//
-// Both match composer's English output, so a reworded message silently changes the
-// classification. Prefer adding a pattern to loosening one.
+// Both match composer's English output, so prefer adding a pattern to loosening one.
 func unresolvableReason(out string) (string, bool) {
 	lower := strings.ToLower(out)
 
-	// composer-patches v1 prints the first form on any patch failure, and the second when
-	// composer-exit-on-patch-failure turns that failure into the exception that ends the run.
+	// The two wordings composer-patches v1 uses for a patch failure.
 	if strings.Contains(lower, "could not apply patch") || strings.Contains(lower, "cannot apply patch") {
 		return "", false
 	}
@@ -847,9 +780,8 @@ var unresolvablePatterns = []struct{ pattern, reason string }{
 	{"could not be downloaded", "a required download failed"},
 }
 
-// CheckIfPatchesApply reports whether patchPaths all apply together to packageName at
-// packageVersion. The keys are zero-padded indexes: composer-patches v1 treats them as free-text
-// descriptions, but applies them in key order, so the caller's order must survive JSON encoding.
+// CheckIfPatchesApply reports whether patchPaths all apply together. The keys are zero-padded
+// indexes because composer-patches v1 applies patches in key order.
 func (s *CLI) CheckIfPatchesApply(ctx context.Context, projectDir string, packageName string, packageVersion string, patchPaths []string) (bool, error) {
 	s.initOnce.Do(s.initTempDir)
 	if s.initErr != nil {
@@ -879,8 +811,8 @@ func (s *CLI) CheckIfPatchesApply(ctx context.Context, projectDir string, packag
 	return s.requireIntoScratch(ctx, packageName, packageVersion)
 }
 
-// dependsRegex matches a row of `composer depends`. The version token matches any non-space
-// run, so dev-main and 1.0.0-beta1 are captured too.
+// dependsRegex matches a row of `composer depends`. The version token is any non-space run, so
+// dev-main and 1.0.0-beta1 are captured too.
 var dependsRegex = regexp.MustCompile(`(?m)^(\S+)\s+\S+\s+requires\b`)
 
 func (s *CLI) GetInstalledPlugins(ctx context.Context, dir string) (map[string]any, error) {
@@ -934,15 +866,12 @@ func (s *CLI) UpdateLockHash(ctx context.Context, dir string) error {
 	return err
 }
 
-// ConfigGetter is the one method WebRoot needs, so a caller's own narrow composer interface
-// satisfies it without importing this package's whole CLI.
+// ConfigGetter is the one method WebRoot needs, so a caller's own interface satisfies it.
 type ConfigGetter interface {
 	GetConfig(ctx context.Context, dir string, key string) (string, error)
 }
 
 // WebRoot returns the project's Drupal web root, relative to dir and without a trailing slash.
-// Everything Drupal — settings.php, custom modules, the config sync directory — is addressed
-// from it, so several packages need the same lookup.
 func WebRoot(ctx context.Context, cfg ConfigGetter, dir string) (string, error) {
 	webroot, err := cfg.GetConfig(ctx, dir, "extra.drupal-scaffold.locations.web-root")
 	if err != nil {

--- a/pkg/composer/composer_env_test.go
+++ b/pkg/composer/composer_env_test.go
@@ -74,9 +74,8 @@ func TestComposerEnv(t *testing.T) {
 	})
 
 	t.Run("keeps entries that are not KEY=VALUE", func(t *testing.T) {
-		// Including one that is a bare forced variable name: os.Environ() promises nothing about
-		// its entries containing "=", and a name on its own assigns nothing and so overrides
-		// nothing.
+		// Including a bare variable name: os.Environ() does not promise every entry has "=",
+		// and a name alone assigns — and so overrides — nothing.
 		got := Env([]string{"NOT_AN_ASSIGNMENT", "COMPOSER_PROCESS_TIMEOUT"})
 
 		assert.Contains(t, got, "NOT_AN_ASSIGNMENT")
@@ -106,9 +105,8 @@ func TestExecComposerEnvironmentReachesTheSubprocess(t *testing.T) {
 	service := &CLI{logger: zap.NewNop()}
 
 	t.Run("execComposer forces the process timeout over an inherited one", func(t *testing.T) {
-		// The whole point of the issue: a 300s cap that nobody configured kills a long
-		// `composer update` mid-phase. Assert on what the subprocess actually sees, not on the
-		// slice drupdater built, so a value that never survives into the child is caught.
+		// Asserted on what the subprocess sees, not the slice drupdater built, so a value
+		// that never survives into the child is caught.
 		fakeComposer(t, helperEnv(
 			"GO_HELPER_PROCESS_PRINT_ENV=COMPOSER_PROCESS_TIMEOUT",
 			"COMPOSER_PROCESS_TIMEOUT=300",
@@ -161,9 +159,8 @@ func TestExecComposerEnvironmentReachesTheSubprocess(t *testing.T) {
 	})
 
 	t.Run("inherits the process environment when the caller set none", func(t *testing.T) {
-		// exec.Cmd with a nil Env inherits os.Environ(); building the forced values on top of it
-		// must not drop that inheritance, or composer loses PATH and every other variable it
-		// needs.
+		// A nil Env inherits os.Environ(), which the forced values must not drop — composer
+		// would lose PATH.
 		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
 		t.Setenv("GOCOVERDIR", "/tmp")
 		t.Setenv("GO_HELPER_PROCESS_PRINT_ENV", "COMPOSER_AUTH")

--- a/pkg/composer/composer_extra_test.go
+++ b/pkg/composer/composer_extra_test.go
@@ -51,9 +51,8 @@ func TestNewCLI(t *testing.T) {
 }
 
 func TestGetAllowPluginsPolymorphicShapes(t *testing.T) {
-	// composer accepts several shapes for allow-plugins. Only the object form carries
-	// per-package entries; the rest mean "nothing to merge" and must not fail the run, because
-	// composer_allow_plugins is mandatory and would abort every update on such a project.
+	// Only the object form carries entries; the rest mean "nothing to merge" and must not fail
+	// the run, since composer_allow_plugins is mandatory.
 	for _, shape := range []string{"true", "false", "[]", "null", ""} {
 		t.Run("shape "+shape, func(t *testing.T) {
 			stubComposerOutput(t, shape)
@@ -139,9 +138,7 @@ func TestResetScratchProject(t *testing.T) {
 	service.initOnce.Do(service.initTempDir)
 	require.NoError(t, service.initErr)
 
-	// Simulate what a prior CheckIfPatchApplies/CheckIfPatchesApply call left behind: a
-	// composer.json with a pinned require added by `composer require` for an earlier, unrelated
-	// check, plus the composer.lock and vendor tree that call produced.
+	// What a prior patch check leaves behind: a pinned require, plus its lock and vendor tree.
 	require.NoError(t, afero.WriteFile(fs, service.tempDir+"/composer.json", []byte(`{"require":{"some/leftover-package":"1.2.3"}}`), 0644))
 	require.NoError(t, afero.WriteFile(fs, service.tempDir+"/composer.lock", []byte("{}"), 0644))
 	require.NoError(t, afero.WriteFile(fs, service.tempDir+"/vendor/autoload.php", []byte("<?php"), 0644))
@@ -205,13 +202,9 @@ func TestUpdatePropagatesFailure(t *testing.T) {
 }
 
 func TestUpdateDeduplicatesTheTwoOperationSections(t *testing.T) {
-	// composer reports a version change twice -- once resolving the lock, once installing it --
-	// in identical wording, so a naive scan reports every upgrade and downgrade double. That
-	// reaches the run report's .packages and the merge request's dependency table, where a
-	// reviewer sees each package listed twice.
-	//
-	// Installs are worded differently per section ("Locking" vs "Installing") and only the
-	// second form is matched, so they must still arrive exactly once.
+	// composer reports a version change twice in identical wording, so a naive scan lists every
+	// upgrade twice in the report and the dependency table. Installs are worded differently per
+	// section and only the second form is matched, so they must still arrive exactly once.
 	stubComposerOutput(t, `Loading composer repositories with package information
 Updating dependencies
 Lock file operations: 1 install, 2 updates, 1 removal
@@ -330,11 +323,8 @@ func TestGetInstalledPackageVersionErrors(t *testing.T) {
 }
 
 func TestDiffFallsBackWhenTooLargeInBytes(t *testing.T) {
-	// GitHub/GitLab's merge/pull request body limit is a byte limit, not a rune count. A diff
-	// table full of multi-byte characters (accented package or issue titles, say) can be under
-	// the threshold in runes yet already over it in bytes, so the fallback must measure bytes.
-	// "é" is a single rune but 2 bytes in UTF-8: 40000 of them is 40000 runes (under the 63000
-	// rune threshold) but 80000 bytes (over it).
+	// The MR body limit is bytes, not runes: 40000 "é" is under the rune threshold and over the
+	// byte one, so the fallback must measure bytes.
 	hugeMultiByte := strings.Repeat("é", 40000)
 
 	var calls int

--- a/pkg/composer/composer_property_test.go
+++ b/pkg/composer/composer_property_test.go
@@ -13,10 +13,8 @@ import (
 	"pgregory.net/rapid"
 )
 
-// The helpers below all read output or configuration produced by Composer, which is to say by
-// something outside this repository's control. Each has a doc comment naming a concrete bug it
-// exists to prevent; these properties state that promise over the whole input space instead of
-// over the one example that prompted the comment.
+// The helpers below read output produced outside this repository's control, so these properties
+// state each one's promise over the whole input space rather than over one example.
 
 // jsonKeyGen generates an object key of the shape composer.json uses for a repository entry.
 func jsonKeyGen() *rapid.Generator[string] {
@@ -27,9 +25,8 @@ func TestPropertyOrderedObjectValuesKeepsDeclarationOrder(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		keys := rapid.SliceOfN(jsonKeyGen(), 0, 6).Draw(t, "keys")
 
-		// Values are made distinguishable by index so that a reordering is visible; sorting the
-		// keys, which this function once did, would shuffle the caller's repositories into a
-		// priority order the project never declared.
+		// Indexed so a reordering is visible: sorting the keys, which this once did, shuffles
+		// the repositories into a priority the project never declared.
 		pairs := make([]string, 0, len(keys))
 		want := make([]json.RawMessage, 0, len(keys))
 		for i, key := range keys {
@@ -72,10 +69,8 @@ func TestPropertyNormalizeRepositoryDropsOnlyTheDisableForm(t *testing.T) {
 		name := jsonKeyGen().Draw(t, "name")
 		disabled := rapid.Bool().Draw(t, "disabled")
 
-		// The disable form is one repository name mapped to a bool, and nothing else. It is
-		// matched on that exact shape because a real entry may carry a bool of its own —
-		// {"type":"composer","url":"...","canonical":false} is how a mirror is declared, and
-		// dropping that would silently change which packages resolve.
+		// Matched on the exact disable shape, because a real entry carries a bool of its own:
+		// a mirror is {"type":"composer","url":"…","canonical":false}.
 		_, keep := normalizeRepository(json.RawMessage(fmt.Sprintf(`{%q:%t}`, name, disabled)), "/project")
 		assert.False(t, keep, "a single name mapped to a bool is a disable entry")
 
@@ -101,9 +96,7 @@ func TestPropertyNormalizeRepositoryResolvesRelativePathsOnce(t *testing.T) {
 		require.NoError(t, json.Unmarshal(normalized, &got))
 		assert.Equal(t, filepath.Join(projectDir, relative), got.URL)
 
-		// Idempotent: the resolved URL is absolute, so normalising again must not join it onto
-		// the project directory a second time. The scratch project is rebuilt per check, and a
-		// doubled prefix would point at a directory that does not exist.
+		// Idempotent: the resolved URL is absolute, and a doubled prefix points nowhere.
 		again, keep := normalizeRepository(normalized, projectDir)
 		require.True(t, keep)
 		assert.JSONEq(t, string(normalized), string(again))
@@ -115,9 +108,8 @@ func TestPropertyNormalizeRepositoryPassesNonPathEntriesThrough(t *testing.T) {
 		repoType := rapid.SampledFrom([]string{"composer", "vcs", "git", "artifact", "package"}).Draw(t, "type")
 		url := rapid.StringMatching(`https://[a-z]{1,8}\.example\.com/[a-z]{0,8}`).Draw(t, "url")
 
-		// Only "path" repositories carry a filesystem location that the scratch project has to
-		// have rewritten. Everything else must arrive byte-identical, since re-marshalling it
-		// would reorder keys and could drop a field this struct does not know about.
+		// Only "path" entries are rewritten. Everything else must arrive byte-identical:
+		// re-marshalling reorders keys and can drop a field this struct does not know.
 		entry := json.RawMessage(fmt.Sprintf(`{"type":%q,"url":%q}`, repoType, url))
 		got, keep := normalizeRepository(entry, "/project")
 		assert.True(t, keep)
@@ -138,11 +130,9 @@ func TestPropertyUnresolvableReasonLetsPatchRejectionWin(t *testing.T) {
 		}), 0, 4).Draw(t, "markers")
 		noise := rapid.StringMatching(`[a-z .:/'"-]{0,40}`).Draw(t, "noise")
 
-		// Composer's dist-to-source fallback prints "could not be downloaded" and then carries
-		// on, so an unresolvable marker can sit in output that describes a genuine patch
-		// rejection. Classifying that as "could not obtain the package" would leave the package
-		// unpinned and ship a patch that does not apply — the worse of the two failures, so the
-		// rejection wins no matter how many markers accompany it.
+		// The dist-to-source fallback prints "could not be downloaded" and carries on, so an
+		// unresolvable marker can sit in output describing a genuine rejection. Shipping a
+		// patch that does not apply is the worse failure, so the rejection always wins.
 		out := noise + rejection + noise + strings.Join(markers, noise)
 		reason, unresolvable := unresolvableReason(out)
 		assert.False(t, unresolvable)
@@ -206,9 +196,7 @@ func TestPropertyAuditUnmarshalFlattensEveryShape(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		packages := rapid.SliceOfNDistinct(jsonKeyGen(), 0, 4, rapid.ID).Draw(t, "packages")
 
-		// Composer emits the advisories of a package either as a list or as a keyed map,
-		// depending on the package. Both have to flatten into the same one list, or an advisory
-		// silently disappears from a security report.
+		// Both shapes must flatten into one list, or an advisory disappears from the report.
 		entries := make([]string, 0, len(packages))
 		want := make([]string, 0)
 		for _, pkg := range packages {
@@ -259,11 +247,8 @@ func TestPropertyAuditUnmarshalToleratesAMissingAdvisoriesKey(t *testing.T) {
 	})
 }
 
-// TestPropertyAuditUnmarshalOrdersAbandonedByName states that the abandoned list does not
-// depend on the order composer happened to emit its keys in. It is built by ranging over a Go
-// map, whose iteration order is randomised per run, so without the sort the same audit output
-// would render a different merge request description and a different report on every run — and
-// a consumer diffing two reports of an unchanged site would see phantom changes.
+// The abandoned list is built by ranging a Go map, so without the sort the same audit output
+// renders a different report every run and a consumer diffing two sees phantom changes.
 func TestPropertyAuditUnmarshalOrdersAbandonedByName(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		names := rapid.SliceOfNDistinct(jsonKeyGen(), 0, 6, rapid.ID).Draw(t, "names")
@@ -293,11 +278,8 @@ func TestPropertyAuditUnmarshalOrdersAbandonedByName(t *testing.T) {
 	})
 }
 
-// TestPropertyComposerEnvLeavesEverythingElseAlone states the law Env has to obey for
-// the Dockerfile's other variables, COMPOSER_AUTH, PATH and anything else a deployment sets: it
-// forces the entries drupdater's correctness depends on and passes every other entry through
-// unchanged and in order. Forcing an environment by rebuilding it is the kind of change that
-// silently drops a variable nobody thought to write a test for.
+// Env forces the entries drupdater's correctness depends on and passes everything else through
+// unchanged and in order — rebuilding an environment silently drops variables nobody tested.
 func TestPropertyComposerEnvLeavesEverythingElseAlone(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		env := rapid.SliceOfN(envEntryGen(), 0, 8).Draw(t, "env")
@@ -324,9 +306,8 @@ func TestPropertyComposerEnvLeavesEverythingElseAlone(t *testing.T) {
 	})
 }
 
-// envEntryGen generates an environment entry, drawing the key from the forced variables often
-// enough that the override path is exercised, and occasionally emitting an entry that is not an
-// assignment at all — os.Environ() makes no promise that every entry contains "=".
+// envEntryGen draws forced keys often enough to exercise the override path, and sometimes emits
+// a non-assignment: os.Environ() does not promise every entry contains "=".
 func envEntryGen() *rapid.Generator[string] {
 	return rapid.Custom(func(t *rapid.T) string {
 		key := rapid.SampledFrom([]string{

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -55,9 +55,7 @@ func TestExecComposer(t *testing.T) {
 }
 
 func TestGetComposerUpdatesMatchesEveryOccurrence(t *testing.T) {
-	// Two of each action. The parser asks the regexes for *all* matches; with only one of a
-	// kind, "first match only" and "all matches" are indistinguishable, and a real update
-	// touching several packages would silently report just one of them per category.
+	// Two of each action: with one, "first match" and "all matches" are indistinguishable.
 	logData := `- Upgrading drupal/core (10.2.0 => 10.3.1)
 - Upgrading drupal/token (1.11.0 => 1.13.0)
 - Downgrading drupal/paragraphs (1.17.0 => 1.16.0)
@@ -499,10 +497,7 @@ Using version ^11.1 for drupal/core`
 	})
 
 	t.Run("Package name with special JSON characters produces valid JSON", func(t *testing.T) {
-		// This test verifies that packageName, packageVersion, and patchPath
-		// containing double-quotes or backslashes are safely marshaled via
-		// json.Marshal rather than string concatenation, which would produce
-		// invalid JSON.
+		// Quotes and backslashes must go through json.Marshal, not concatenation.
 		fs := afero.NewMemMapFs()
 
 		capturedPatchesJSON := ""
@@ -520,9 +515,7 @@ Using version ^11.1 for drupal/core`
 			fs:     fs,
 		}
 
-		// Use a package name that contains a double-quote and a backslash —
-		// these would break raw string concatenation but must be escaped by
-		// json.Marshal, resulting in valid JSON.
+		// A name that breaks raw concatenation but must survive json.Marshal.
 		_, err := service.CheckIfPatchApplies(t.Context(), "/project", `drupal/"core"`, `1.0\0`, `path/to/"patch"`)
 		require.NoError(t, err)
 
@@ -699,13 +692,9 @@ func TestCheckPlatformReqs(t *testing.T) {
 	})
 
 	t.Run("output with trailing noise after the array", func(t *testing.T) {
-		// Combined stdout/stderr can interleave text on both sides of the payload, so the span
-		// runs to the *last* closing bracket rather than the first.
-		//
-		// Known limit: trailing text containing its own brackets (say "Done in 0.4s [cached]")
-		// would extend the span past the payload and fail to parse. Composer does not emit that
-		// today, and widening the extraction to a real scanner is a behaviour change this test
-		// deliberately does not assume.
+		// Merged output interleaves text on both sides of the payload, so the span runs to the
+		// last closing bracket. Known limit: trailing text with its own brackets would extend
+		// it past the payload — composer does not emit that today.
 		json := "Checking platform requirements using the lock file\n" +
 			`[{"name":"php","version":"8.4.23","status":"success","failed_requirement":null,"provider":null}]` +
 			"\nDone in 0.4s"

--- a/pkg/composer/exec.go
+++ b/pkg/composer/exec.go
@@ -9,15 +9,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// CommandFactory builds the *exec.Cmd to run. Every package that shells out to composer keeps
-// its own package-level variable of this type as its test seam and passes it in per call, so
-// swapping the variable still diverts the subprocess.
+// CommandFactory builds the *exec.Cmd to run. Each package keeps its own variable of this type
+// as its test seam and passes it in per call, so swapping it still diverts the subprocess.
 type CommandFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
 
-// Command is one composer invocation: run in Dir, under the environment Env guarantees.
-//
-// Shared by every package that drives composer — drush, phpcs and rector all run through
-// `composer exec` — so the process timeout and the debug logging are stated once.
+// Command is one composer invocation: run in Dir, under the environment Env guarantees. Shared
+// by drush, phpcs and rector too, which all go through `composer exec`.
 type Command struct {
 	New    CommandFactory
 	Logger *zap.Logger
@@ -29,19 +26,16 @@ type Command struct {
 func (c Command) build(ctx context.Context, args ...string) *exec.Cmd {
 	command := c.New(ctx, "composer", args...)
 	command.Dir = c.Dir
-	// Environ() falls back to os.Environ(), so this layers on the deployment's environment
-	// instead of replacing it.
+	// Environ() falls back to os.Environ(), layering on the deployment's environment.
 	command.Env = append(Env(command.Environ()), c.ExtraEnv...)
 	return command
 }
 
-// Combined runs the command with stdout and stderr merged, as CombinedOutput does, and returns
-// the output with its trailing newline stripped.
+// Combined merges stdout and stderr, and strips the output's trailing newline.
 func (c Command) Combined(ctx context.Context, args ...string) (string, error) {
 	command := c.build(ctx, args...)
 
-	// One buffer for both streams: what CombinedOutput does internally, kept here because
-	// CombinedOutput refuses a command whose Stdout is already set.
+	// Hand-rolled because CombinedOutput refuses a command whose Stdout is already set.
 	var merged bytes.Buffer
 	command.Stdout = &merged
 	command.Stderr = &merged
@@ -53,9 +47,7 @@ func (c Command) Combined(ctx context.Context, args ...string) (string, error) {
 	return output, err
 }
 
-// Split keeps the streams apart. Commands whose stdout is parsed as JSON must use this: a
-// composer or PHP notice on stderr would otherwise corrupt the payload. stderr still reaches
-// the log, and is returned so a caller can quote it in an error.
+// Split keeps the streams apart, so a PHP notice on stderr cannot corrupt a JSON payload.
 func (c Command) Split(ctx context.Context, args ...string) (stdout string, stderr string, err error) {
 	command := c.build(ctx, args...)
 

--- a/pkg/composer/exec_test.go
+++ b/pkg/composer/exec_test.go
@@ -11,13 +11,11 @@ import (
 	"go.uber.org/zap"
 )
 
-// Command is shared by every package that drives composer -- drush, phpcs and rector all go
-// through `composer exec` -- so its contracts are asserted here rather than inferred from those
-// packages' tests, which only ever exercise them by accident.
+// Command is shared by drush, phpcs and rector, so its contracts are asserted here rather than
+// inferred from tests that exercise them by accident.
 
-// shellCommand builds a factory that runs script through sh instead of composer, and records the
-// invocation Command asked for. Two things in one because they are two halves of the same
-// question: what was requested, and what the process then saw.
+// shellCommand runs script through sh instead of composer and records what Command asked for:
+// two halves of one question, what was requested and what the process saw.
 func shellCommand(script string, seen *[]string) CommandFactory {
 	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
 		*seen = append([]string{name}, args...)
@@ -50,10 +48,8 @@ func TestCommandBuild(t *testing.T) {
 	})
 
 	t.Run("ExtraEnv beats the environment composer would otherwise be given", func(t *testing.T) {
-		// The whole reason ExtraEnv is appended after Env rather than before it. os/exec keeps
-		// the last entry for a repeated key, so the order in build() is what decides the value
-		// the subprocess reads -- and COMPOSER_PROCESS_TIMEOUT is one Env forces itself.
-		// Reversing the append is invisible to every other test in this module.
+		// os/exec keeps the last entry for a repeated key, so the append order in build() is
+		// what decides the value — and reversing it is invisible to every other test here.
 		var seen []string
 		c := Command{
 			New:      shellCommand(`printf %s "$COMPOSER_PROCESS_TIMEOUT"`, &seen),
@@ -106,9 +102,8 @@ func TestCommandCombined(t *testing.T) {
 	})
 
 	t.Run("strips exactly one trailing newline", func(t *testing.T) {
-		// Callers compare this against bare strings and parse it as JSON, so the trailing
-		// newline every command emits must go -- and only that one, or output whose last line
-		// is deliberately blank comes back altered.
+		// Callers compare this against bare strings, so the trailing newline must go — and
+		// only that one, or a deliberately blank last line comes back altered.
 		var seen []string
 		c := Command{New: shellCommand(`printf 'a\n\n'`, &seen), Logger: zap.NewNop()}
 

--- a/pkg/composer/scratch_project_test.go
+++ b/pkg/composer/scratch_project_test.go
@@ -32,11 +32,8 @@ func stubComposerFailureWithOutput(t *testing.T, out string) {
 	t.Cleanup(func() { execCommand = exec.CommandContext })
 }
 
-// newScratchCLI returns a CLI backed by the real filesystem, plus a project directory holding
-// projectComposerJSON (or no composer.json at all, when it is empty).
-//
-// The real filesystem, not a MemMapFs: the scratch project's temp directory becomes a
-// subprocess's working directory, and a directory that exists only in memory cannot be one.
+// newScratchCLI returns a CLI on the real filesystem, not a MemMapFs: the scratch project's temp
+// directory becomes a subprocess's working directory, which an in-memory one cannot be.
 func newScratchCLI(t *testing.T, projectComposerJSON string) (*CLI, string) {
 	t.Helper()
 	projectDir := t.TempDir()
@@ -49,11 +46,9 @@ func newScratchCLI(t *testing.T, projectComposerJSON string) (*CLI, string) {
 }
 
 func TestBuildScratchComposerJSONShape(t *testing.T) {
-	// Every other test here decodes only "repositories", so nothing pins the rest of the
-	// document -- yet each remaining field is what makes the patch check work at all:
-	// composer-patches must be required for patches to be applied, plugins must be allowed for
-	// it to run, and composer-exit-on-patch-failure is what turns a failed patch into a
-	// non-zero exit instead of a silent pass that reports every patch as applying cleanly.
+	// Every other test decodes only "repositories", yet the rest is what makes the check work:
+	// composer-patches required, its plugin allowed, and exit-on-patch-failure turning a failed
+	// patch into a non-zero exit instead of a silent pass.
 	service, projectDir := newScratchCLI(t, "")
 
 	out, err := service.buildScratchComposerJSON(projectDir)
@@ -83,9 +78,8 @@ func TestBuildScratchComposerJSONShape(t *testing.T) {
 
 func TestBuildScratchComposerJSON(t *testing.T) {
 	t.Run("carries the project's repositories, in order, ahead of the drupal.org fallback", func(t *testing.T) {
-		// The regression this guards: a package served only from a private registry could not be
-		// resolved in the scratch project at all, so its patch check failed for a reason that had
-		// nothing to do with the patch.
+		// Regression: a package served only from a private registry was unresolvable here, so
+		// its patch check failed for a reason unrelated to the patch.
 		service, projectDir := newScratchCLI(t, `{
 			"repositories": [
 				{"type": "composer", "url": "https://repo.packagist.com/acme/"},
@@ -108,10 +102,8 @@ func TestBuildScratchComposerJSON(t *testing.T) {
 	})
 
 	t.Run("keeps the object form in declaration order, not alphabetical order", func(t *testing.T) {
-		// Order is composer's resolution priority in the object form just as in the array form.
-		// Sorting by key -- which an earlier revision did, for byte-stability -- would put the
-		// public repository ahead of the private fork declared before it, so the fork loses and
-		// its patch is tested against the wrong package: the very failure this fix removes.
+		// Order is composer's resolution priority in both forms. Sorting by key, as an earlier
+		// revision did, puts a public repository ahead of the private fork declared first.
 		service, projectDir := newScratchCLI(t, `{
 			"repositories": {
 				"zeta-private-fork": {"type": "composer", "url": "https://zeta.example.com"},
@@ -270,10 +262,8 @@ func TestUnresolvableReason(t *testing.T) {
 		"download failed":      {"The 'https://repo.packagist.com/acme/p2/x.json' file could not be downloaded", true},
 		"patch was rejected":   {"  - Applying patches for drupal/core\nCould not apply patch! Skipping.", false},
 		"exit-on-failure form": {`Cannot apply patch Issue #123: [Fix the thing](https://drupal.org/i/123)`, false},
-		// Composer's dist-to-source fallback prints a non-fatal "could not be downloaded" and
-		// carries on. Matching it would classify a real patch rejection as an unobtainable
-		// package, so the package would be left unpinned and the merge request would ship a patch
-		// that does not apply.
+		// The dist-to-source fallback prints a non-fatal "could not be downloaded", which
+		// matched here would ship a patch that does not apply.
 		"rejection after a non-fatal download warning": {
 			`The "https://api.github.com/repos/acme/widget/zipball/abc" file could not be downloaded (HTTP/1.1 404 Not Found)
     Now trying to download from source
@@ -293,9 +283,8 @@ Could not apply patch! Skipping. The error was: patch does not apply`, false},
 
 func TestCheckIfPatchAppliesClassifiesFailures(t *testing.T) {
 	t.Run("a package composer cannot obtain is an error, not a patch conflict", func(t *testing.T) {
-		// Reported as "the patch does not apply", this pinned the package at its current version
-		// and told the reviewer a patch conflicted -- on every run, since nothing about it ever
-		// changes. The callers leave the package alone on an error instead.
+		// Read as "the patch does not apply", this pinned the package and blamed a conflict on
+		// every run. Callers leave the package alone on an error instead.
 		stubComposerFailureWithOutput(t, "Could not find package acme/private-module in any version")
 		service, projectDir := newScratchCLI(t, `{"repositories": []}`)
 

--- a/pkg/drupal/installer.go
+++ b/pkg/drupal/installer.go
@@ -60,9 +60,8 @@ func (is *Installer) Install(ctx context.Context, path string, site string) erro
 	return nil
 }
 
-// settingsMarker tags the block ConfigureDatabase appends to settings.php. Each site is
-// configured twice against the same file — baseline, then before the update hooks — so the
-// marker keeps the append idempotent instead of stacking duplicate settings.
+// settingsMarker keeps ConfigureDatabase's append idempotent: each site is configured twice
+// against the same settings.php, baseline and then before the update hooks.
 const settingsMarker = "// Added by drupdater: test database settings."
 
 func (is *Installer) ConfigureDatabase(ctx context.Context, dir string, site string) error {
@@ -77,13 +76,10 @@ func (is *Installer) ConfigureDatabase(ctx context.Context, dir string, site str
 
 	settingsPath := dir + "/" + webroot + "/sites/" + site + "/settings.php"
 
-	// Ensured on every call, ahead of the marker check below, because the two states are
-	// independent. settings.php survives a run -- it is deliberately never committed -- while
-	// core.extension.yml comes back from git whenever the working copy is reused, and the
-	// configuration export writes it without sqlite (config_exclude_modules sees to that). A
-	// second run in the same directory therefore finds the marker set and the module entry gone,
-	// and Drupal refuses to install: "Unable to uninstall the SQLite module because: The module
-	// 'SQLite' is providing the database driver 'sqlite'".
+	// Ahead of the marker check, because the two states are independent: settings.php survives
+	// a run, while core.extension.yml comes back from git without the sqlite entry. A reused
+	// working copy would otherwise have the marker set and the module gone, and Drupal refuses
+	// to install ("SQLite is providing the database driver").
 	isSqliteEnabled, _ := is.isSqliteModuleEnabled(ctx, dir, site)
 	if !isSqliteEnabled {
 		siteLogger.Debug("enabling sqlite module")
@@ -92,9 +88,7 @@ func (is *Installer) ConfigureDatabase(ctx context.Context, dir string, site str
 		}
 	}
 
-	// The marker guards only the append: without it a repeated call stacks a second $databases
-	// block onto the file. config_exclude_modules is part of that append, so it is already there
-	// from the first call.
+	// The marker guards only the append, which a repeated call would otherwise stack.
 	if existing, err := afero.ReadFile(is.fs, settingsPath); err == nil && strings.Contains(string(existing), settingsMarker) {
 		siteLogger.Debug("settings already configured, skipping", zap.String("path", settingsPath))
 		return nil
@@ -129,8 +123,7 @@ if (isset($settings['config_exclude_modules'])) {
 
 	siteLogger.Debug("writing settings", zap.String("path", settingsPath), zap.String("settings", settings))
 
-	// A missing settings.php is an error, not something to create: this snippet alone is not a
-	// valid one, and every installed site already has the file.
+	// Never created: this snippet alone is not a valid settings.php.
 	f, err := is.fs.OpenFile(settingsPath, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open settings file: %w", err)
@@ -146,8 +139,7 @@ if (isset($settings['config_exclude_modules'])) {
 	return nil
 }
 
-// coreExtensionPath returns the site's core.extension.yml, the file that records which modules
-// and profile the site was installed with.
+// coreExtensionPath returns the site's core.extension.yml.
 func (is *Installer) coreExtensionPath(ctx context.Context, dir string, site string) (string, error) {
 	configSyncDir, err := is.drush.GetConfigSyncDir(ctx, dir, site, false)
 	if err != nil {
@@ -156,8 +148,8 @@ func (is *Installer) coreExtensionPath(ctx context.Context, dir string, site str
 	return configSyncDir + "/core.extension.yml", nil
 }
 
-// readCoreExtension reads and decodes core.extension.yml, returning its path alongside the whole
-// document and its module section — a file without one is unusable to every caller here.
+// readCoreExtension decodes core.extension.yml. A document with no module section is an error:
+// every caller here needs one.
 func (is *Installer) readCoreExtension(ctx context.Context, dir string, site string) (path string, config map[string]any, modules map[string]any, err error) {
 	path, err = is.coreExtensionPath(ctx, dir, site)
 	if err != nil {
@@ -238,8 +230,7 @@ func (is *Installer) RemoveProfile(ctx context.Context, dir string, site string)
 
 	profiles := []string{"standard"}
 
-	// Drop both the "profile: <name>" key and the profile's own entry under module:. Matched
-	// once per line rather than once per profile, or extra profiles would duplicate kept lines.
+	// Matched once per line, not once per profile, or extra profiles duplicate the kept lines.
 	var lines []string
 	scanner := bufio.NewScanner(fileToRead)
 	for scanner.Scan() {

--- a/pkg/drupal/installer_extra_test.go
+++ b/pkg/drupal/installer_extra_test.go
@@ -39,10 +39,8 @@ func newTestInstaller(t *testing.T, coreExtension string, settings string) (*Ins
 	return installer, fs, drush, composer
 }
 
-// newTestInstallerWithLogs is newTestInstaller plus the captured log output. The installer's
-// debug lines are what an operator sees with --verbose, and they are the only externally
-// visible trace of several decisions (which settings.php was written, whether the sqlite
-// module had to be enabled, whether an already-configured site was skipped).
+// newTestInstallerWithLogs captures the debug output, which is the only external trace of
+// several of the installer's decisions.
 func newTestInstallerWithLogs(t *testing.T, coreExtension string, settings string) (*Installer, afero.Fs, *MockDrush, *MockComposer, *observer.ObservedLogs) {
 	t.Helper()
 
@@ -77,9 +75,8 @@ func TestNewInstaller(t *testing.T) {
 }
 
 func TestInstallStopsAtTheFirstFailure(t *testing.T) {
-	// Install runs three steps in order and each guard must actually stop the run: continuing
-	// past a failed database configuration would install a site against the project's real
-	// database settings.
+	// Each guard must stop the run: continuing past a failed database configuration installs
+	// the site against the project's real database.
 	t.Run("database configuration fails", func(t *testing.T) {
 		installer, _, _, composer := newTestInstaller(t, coreExtensionWithSqlite, "<?php\n")
 		composer.EXPECT().GetConfig(t.Context(), "/project", "extra.drupal-scaffold.locations.web-root").
@@ -105,9 +102,8 @@ func TestInstallStopsAtTheFirstFailure(t *testing.T) {
 }
 
 func TestConfigureDatabaseIsIdempotent(t *testing.T) {
-	// The run configures each site twice — once for the baseline install, once before the
-	// update hooks — against the same settings.php. The second call must not append a second
-	// copy of the database, hash_salt and private-path settings.
+	// Each site is configured twice against the same settings.php, and the second call must
+	// not append a second copy of the settings.
 	installer, fs, drush, composer, logs := newTestInstallerWithLogs(t, coreExtensionWithSqlite, "<?php\n")
 
 	composer.EXPECT().GetConfig(t.Context(), "/project", "extra.drupal-scaffold.locations.web-root").Return("web", nil)
@@ -333,18 +329,10 @@ func TestRemoveProfileErrors(t *testing.T) {
 }
 
 func TestConfigureDatabaseRestoresSqliteOnAReusedWorkingCopy(t *testing.T) {
-	// Regression: settings.php and core.extension.yml go out of sync across runs, and only
-	// settings.php carries the marker.
-	//
-	// settings.php is deliberately never committed, so it survives a run with the marker in it.
-	// core.extension.yml does get committed, and the configuration export writes it *without*
-	// sqlite because config_exclude_modules excludes it. Reuse the working copy -- which is
-	// exactly what the integration job's idempotency check does, and what any CI runner with a
-	// cached checkout does -- and the second run finds the marker set and the module entry gone.
-	//
-	// Guarding the module entry behind the marker therefore left the site uninstallable:
-	// "Unable to uninstall the SQLite module because: The module 'SQLite' is providing the
-	// database driver 'sqlite'".
+	// Regression: settings.php keeps the marker across runs because it is never committed,
+	// while core.extension.yml comes back from git without the sqlite entry. A reused working
+	// copy therefore has the marker set and the module gone, and guarding the module entry
+	// behind the marker left the site uninstallable.
 	settingsFromEarlierRun := "<?php\n\n" + settingsMarker + "\n$databases['default']['default'] = [];\n"
 	installer, fs, drush, composer := newTestInstaller(t, coreExtensionWithoutSqlite, settingsFromEarlierRun)
 

--- a/pkg/drupal/installer_iofailure_test.go
+++ b/pkg/drupal/installer_iofailure_test.go
@@ -11,10 +11,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// failingFs fails one chosen filesystem operation and delegates the rest. The installer's I/O
-// error branches -- a settings.php that opens but cannot be written, a core.extension.yml that
-// reads short, a rewrite that cannot be flushed -- are only reached on a full disk or a
-// permission change mid-run, so an in-memory filesystem alone never exercises them.
+// failingFs fails one chosen operation and delegates the rest, reaching the installer's I/O
+// branches — otherwise only a full disk or a mid-run chmod gets there.
 type failingFs struct {
 	afero.Fs
 	failWrite  bool // writes to an opened file fail

--- a/pkg/drupalorg/drupalorg.go
+++ b/pkg/drupalorg/drupalorg.go
@@ -46,8 +46,7 @@ func (s *HTTPClient) GetIssue(ctx context.Context, issueID string) (*Issue, erro
 	}
 	defer resp.Body.Close()
 
-	// Status before decoding: drupal.org answers an unknown node or an outage with an HTML
-	// error page, which would otherwise surface as an opaque decode failure.
+	// Status first: drupal.org answers an unknown node with an HTML page, not JSON.
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch issue %s: unexpected status %s", issueID, resp.Status)
 	}

--- a/pkg/drupalorg/drupalorg_property_test.go
+++ b/pkg/drupalorg/drupalorg_property_test.go
@@ -8,10 +8,8 @@ import (
 	"pgregory.net/rapid"
 )
 
-// FindIssueNumber pulls an issue ID out of free-form text — a patch URL, a patch description, a
-// branch name — so the wrong answer silently attributes a patch to somebody else's issue. The
-// properties below pin what it extracts from arbitrary surroundings, including the cases that
-// are deliberate rather than accidental.
+// FindIssueNumber pulls an issue ID out of free-form text, so a wrong answer silently
+// attributes a patch to somebody else's issue.
 
 // nonDigitGen generates filler that cannot contribute digits of its own, so a generated issue
 // number stays exactly the number the property put there.

--- a/pkg/drupalorg/drupalorg_test.go
+++ b/pkg/drupalorg/drupalorg_test.go
@@ -161,9 +161,8 @@ func TestFindIssueNumber(t *testing.T) {
 }
 
 func TestGetIssue_NonOKStatus(t *testing.T) {
-	// drupal.org answers an unknown node or an outage with an HTML error page. Checking the
-	// status first turns that into a message that names the real problem instead of an opaque
-	// JSON decode failure.
+	// drupal.org answers an unknown node with an HTML page, which without a status check
+	// surfaces as an opaque JSON decode failure.
 	for _, status := range []int{http.StatusNotFound, http.StatusServiceUnavailable} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/drush/drush.go
+++ b/pkg/drush/drush.go
@@ -27,9 +27,8 @@ func NewCLI(logger *zap.Logger, cache otter.Cache[string, string]) *CLI {
 	}
 }
 
-// command returns the runner for a drush invocation on site. drush runs through `composer exec`
-// and inherits composer's process timeout, which `site:install` and `updatedb` both outlast;
-// SITE_NAME comes after that environment so it wins over any value the parent process set.
+// command runs drush through `composer exec`, inheriting its process timeout. SITE_NAME comes
+// after that environment so it wins over any value the parent process set.
 func (e *CLI) command(dir string, site string) composer.Command {
 	return composer.Command{
 		New:      execCommand,
@@ -47,8 +46,7 @@ func (e *CLI) execDrush(ctx context.Context, dir string, site string, args ...st
 	return e.command(dir, site).Combined(ctx, drushArgs(args)...)
 }
 
-// execDrushStreams keeps stdout and stderr apart. Commands whose stdout is parsed as JSON must
-// use this: drush's stderr notices would otherwise corrupt the payload.
+// execDrushStreams keeps the streams apart, so a stderr notice cannot corrupt a JSON payload.
 func (e *CLI) execDrushStreams(ctx context.Context, dir string, site string, args ...string) (stdout string, stderr string, err error) {
 	return e.command(dir, site).Split(ctx, drushArgs(args)...)
 }
@@ -93,8 +91,7 @@ func (e *CLI) ConfigResave(ctx context.Context, dir string, site string) error {
 	return err
 }
 
-// IsModuleEnabled uses execDrushStreams: a merged stderr notice would be folded into the
-// compared value and report an enabled module as disabled.
+// IsModuleEnabled splits the streams: a merged notice would report an enabled module as disabled.
 func (e *CLI) IsModuleEnabled(ctx context.Context, dir string, site string, module string) (bool, error) {
 	stdout, stderr, err := e.execDrushStreams(ctx, dir, site, "pm:list", "--status=enabled", "--field=name", "--filter="+module)
 	if err != nil {
@@ -118,9 +115,8 @@ func (e *CLI) GetTranslationPath(ctx context.Context, dir string, site string, r
 	if err != nil {
 		return "", err
 	}
-	// An empty result must never reach git: an empty path makes go-git's Worktree.Add stage the
-	// entire working tree. realpath() prints nothing when the target is absent, which here
-	// usually means nothing has been localized yet, so the directory was never created.
+	// An empty path must never reach git: Worktree.Add would stage the entire working tree.
+	// realpath() prints nothing when the directory was never created.
 	if strings.TrimSpace(translationPath) == "" {
 		return "", fmt.Errorf("translation path for site %s does not resolve to an existing directory", site)
 	}
@@ -140,16 +136,15 @@ type UpdateHook struct {
 	Type        string `json:"type"`
 }
 
-// UnsupportedModule is an installed module with no supported release, per Drupal's update
-// status service — no further fixes are coming.
+// UnsupportedModule is an installed module with no supported release: no further fixes coming.
 type UnsupportedModule struct {
 	Name               string `json:"name"`
 	InstalledVersion   string `json:"installed_version"`
 	RecommendedVersion string `json:"recommended_version"`
 }
 
-// GetUnsupportedModules returns the installed modules whose update status is NOT_SUPPORTED, via
-// the bundled unsupported-modules.php, which yields nothing when the update module is off.
+// GetUnsupportedModules runs the bundled unsupported-modules.php, which yields nothing when
+// Drupal's update module is off.
 func (e *CLI) GetUnsupportedModules(ctx context.Context, dir string, site string) ([]UnsupportedModule, error) {
 	stdout, stderr, err := e.execDrushStreams(ctx, dir, site, "php:script", "/opt/drupdater/unsupported-modules.php")
 	if err != nil {
@@ -174,8 +169,7 @@ func (e *CLI) GetUpdateHooks(ctx context.Context, dir string, site string) (map[
 		return nil, err
 	}
 
-	// "No database updates required" lands on stdout or stderr depending on the drush version.
-	// An empty stdout means the same thing.
+	// "No database updates required" lands on either stream, depending on the drush version.
 	if strings.Contains(stdout, "No database updates required") ||
 		strings.Contains(stderr, "No database updates required") ||
 		strings.TrimSpace(stdout) == "" {

--- a/pkg/drush/drush_env_test.go
+++ b/pkg/drush/drush_env_test.go
@@ -12,18 +12,14 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestComposerEnvironment covers what drush shares with every other package that shells out to
-// composer: `composer exec -- drush` runs drush as a subprocess of composer, so composer's
-// default 300s process timeout applies to it. `site:install` and `updatedb` on a real site
-// exceed that comfortably, and the run then dies with a killed subprocess rather than an
-// updated site — a failure that has nothing to do with the project being updated.
+// drush runs as a subprocess of composer, so composer's 300s default timeout applies — and
+// `site:install` and `updatedb` on a real site exceed it comfortably.
 func TestComposerEnvironment(t *testing.T) {
 	cache, _ := otter.MustBuilder[string, string](100).Build()
 	executor := NewCLI(zap.NewNop(), cache)
 
-	// captureCmd runs the helper process and hands back the command that actually ran, so the
-	// assertions are about the environment the subprocess was given rather than about the
-	// helper that builds it.
+	// captureCmd returns the command that actually ran, so the assertions are about the
+	// environment the subprocess was given.
 	captureCmd := func(t *testing.T) **exec.Cmd {
 		t.Helper()
 		t.Setenv("GO_WANT_HELPER_PROCESS", "1")

--- a/pkg/drush/drush_test.go
+++ b/pkg/drush/drush_test.go
@@ -635,9 +635,8 @@ func TestGetTranslationPath(t *testing.T) {
 	})
 
 	t.Run("unconfigured translation path errors instead of returning empty", func(t *testing.T) {
-		// locale.settings.translation.path unset means realpath('') resolves to false, which
-		// drush prints as an empty line. An empty path must never reach a caller: passed to
-		// go-git's Worktree.Add, it stages the entire working tree instead of "nothing".
+		// An unset translation path makes realpath('') print an empty line, and an empty path
+		// handed to Worktree.Add stages the entire working tree.
 		cache, _ := otter.MustBuilder[string, string](100).Build()
 		cli := NewCLI(logger, cache)
 		t.Setenv("GO_WANT_HELPER_PROCESS", "1")

--- a/pkg/phpcs/phpcs.go
+++ b/pkg/phpcs/phpcs.go
@@ -22,8 +22,7 @@ func NewCLI(logger *zap.Logger) *CLI {
 	}
 }
 
-// command returns the runner for a phpcs invocation. phpcs runs through `composer exec` and
-// inherits composer's process timeout.
+// command runs phpcs through `composer exec`, inheriting its process timeout.
 func (s *CLI) command(dir string) composer.Command {
 	return composer.Command{New: execCommand, Logger: s.logger, Dir: dir}
 }
@@ -54,8 +53,7 @@ type ReturnOutputTotals struct {
 	Fixable  int `json:"fixable"`
 }
 
-// Run reports the violations. Split, not combined: a PHP notice on stderr would corrupt the
-// JSON report.
+// Run reports the violations. Split: a PHP notice on stderr would corrupt the JSON report.
 func (s *CLI) Run(ctx context.Context, dir string) (ReturnOutput, error) {
 	out, _, err := s.command(dir).Split(ctx, "exec", "--", "phpcs", "--report=json", "-q", "--runtime-set", "ignore_errors_on_exit", "1", "--runtime-set", "ignore_warnings_on_exit", "1")
 	if err != nil {

--- a/pkg/phpcs/phpcs_env_test.go
+++ b/pkg/phpcs/phpcs_env_test.go
@@ -7,10 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestComposerEnvironment covers what phpcs shares with every other package that shells out to
-// composer: `composer exec -- phpcs` runs phpcs as a subprocess of composer, so composer's
-// default 300s process timeout applies to it. A phpcbf pass over a large custom-code tree
-// exceeds that, and the run then fails with a killed subprocess rather than a report.
+// phpcs runs as a subprocess of composer, so composer's 300s default timeout applies — and a
+// phpcbf pass over a large custom-code tree exceeds it.
 func TestComposerEnvironment(t *testing.T) {
 	t.Run("Run", func(t *testing.T) {
 		cli, _ := newTestCLI(t)

--- a/pkg/phpcs/phpcs_test.go
+++ b/pkg/phpcs/phpcs_test.go
@@ -19,9 +19,7 @@ import (
 // whether the stderr stream was captured separately from the stdout that gets parsed.
 const helperStderrMarker = "helper-process-stderr"
 
-// newTestCLI returns a CLI whose debug output can be asserted on. Both exec helpers log the
-// command line together with the captured output, which is the only place several of their
-// steps are observable from outside.
+// newTestCLI captures the debug output, the only place several steps are observable.
 func newTestCLI(t *testing.T) (*CLI, *observer.ObservedLogs) {
 	t.Helper()
 	core, logs := observer.New(zapcore.DebugLevel)

--- a/pkg/rector/rector.go
+++ b/pkg/rector/rector.go
@@ -23,8 +23,7 @@ func NewCLI(logger *zap.Logger) *CLI {
 	}
 }
 
-// command returns the runner for a rector invocation. rector runs through `composer exec` and
-// inherits composer's process timeout.
+// command runs rector through `composer exec`, inheriting its process timeout.
 func (s *CLI) command(dir string) composer.Command {
 	return composer.Command{New: execCommand, Logger: s.logger, Dir: dir}
 }
@@ -50,10 +49,8 @@ func (s *CLI) Run(ctx context.Context, dir string, customCodeDirectories []strin
 	if len(customCodeDirectories) == 0 {
 		s.logger.Debug("no custom code directories found")
 		return ReturnOutput{
-			// Known equivalent mutant: dropping this yields the same ReturnOutputTotals{}. Left
-			// un-suppressed because the annotation keys off the enclosing literal and would
-			// also silence the real FileDiffs and ChangedFiles mutants. The zeros are spelled
-			// out because this is the documented "nothing to do" result.
+			// Equivalent mutant, left un-suppressed: the annotation keys off the enclosing
+			// literal and would silence the real FileDiffs and ChangedFiles mutants too.
 			Totals: ReturnOutputTotals{
 				ChangedFiles: 0,
 				Errors:       0,
@@ -66,8 +63,7 @@ func (s *CLI) Run(ctx context.Context, dir string, customCodeDirectories []strin
 	args := []string{"exec", "--", "rector", "process", "--config=/opt/drupdater/rector.php", "--no-progress-bar", "--no-diffs", "--debug", "--output-format=json"}
 	args = append(args, customCodeDirectories...)
 
-	// Split, not combined: rector's --debug output and PHP notices go to stderr and would
-	// corrupt the JSON report.
+	// Split: rector's --debug output and PHP notices would corrupt the JSON report.
 	out, _, err := s.command(dir).Split(ctx, args...)
 
 	if err != nil {

--- a/pkg/rector/rector_env_test.go
+++ b/pkg/rector/rector_env_test.go
@@ -7,10 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestComposerEnvironment covers what rector shares with every other package that shells out to
-// composer: `composer exec -- rector process` runs rector as a subprocess of composer, so
-// composer's default 300s process timeout applies to it. A rector pass over a large custom-code
-// tree exceeds that, and the run then fails with a killed subprocess rather than a report.
+// rector runs as a subprocess of composer, so composer's 300s default timeout applies — and a
+// pass over a large custom-code tree exceeds it.
 func TestComposerEnvironment(t *testing.T) {
 	cli, _ := newTestCLI(t)
 	_, _, cmd := stubExec(t, `{"totals":{"changed_files":0},"file_diffs":[]}`, false)

--- a/pkg/rector/rector_test.go
+++ b/pkg/rector/rector_test.go
@@ -15,9 +15,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-// newTestCLI returns a CLI whose debug output can be asserted on. execComposerJSON logs the
-// command line together with the captured stdout and stderr, which is the only place several
-// of its steps are observable from the outside.
+// newTestCLI captures the debug output, the only place several steps are observable.
 func newTestCLI(t *testing.T) (*CLI, *observer.ObservedLogs) {
 	t.Helper()
 	core, logs := observer.New(zapcore.DebugLevel)
@@ -65,9 +63,8 @@ func TestRectorRun(t *testing.T) {
 		assert.Equal(t, 0, result.Totals.ChangedFiles)
 		assert.Equal(t, 0, result.Totals.Errors)
 
-		// Empty but *not* nil: the zero ReturnOutput would satisfy assert.Empty just as well,
-		// so pin the distinction the early return deliberately makes. It survives into the run
-		// report, where a nil slice marshals to null instead of [].
+		// Empty but not nil: the distinction survives into the report, where nil marshals to
+		// null instead of [].
 		assert.NotNil(t, result.FileDiffs)
 		assert.Empty(t, result.FileDiffs)
 		assert.NotNil(t, result.ChangedFiles)

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -17,8 +17,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// Identity used for commits when neither the VCS platform nor the checkout supplies one.
-// Both are only reached in that last-resort case; see prepareCheckout.
+// Last-resort commit identity, when neither the platform nor the checkout supplies one.
 const (
 	defaultCommitName  = "drupdater"
 	defaultCommitEmail = "drupdater@localhost"
@@ -27,11 +26,9 @@ const (
 type Repository interface {
 	Push(o *git.PushOptions) error
 	Remote(name string) (*git.Remote, error)
-	// Head resolves to a branch (Name().IsBranch()) or, when detached — the usual CI state —
-	// straight to a commit hash (Name() == plumbing.HEAD).
+	// Head resolves to a branch, or to a commit hash when detached — the usual CI state.
 	Head() (*plumbing.Reference, error)
-	// Reference looks up a single local reference by name, returning plumbing.ErrReferenceNotFound
-	// if it doesn't exist.
+	// Reference looks up a local reference, erroring with plumbing.ErrReferenceNotFound.
 	Reference(name plumbing.ReferenceName, resolved bool) (*plumbing.Reference, error)
 }
 
@@ -57,8 +54,7 @@ func BasicAuth(token string) *http.BasicAuth {
 	}
 }
 
-// open opens the checkout at path, naming it in the error — every caller here is given the path
-// by the user or by CI, so a bad one must say which.
+// open names the path in the error: it comes from the user or CI, so a bad one must say which.
 func (rs *GitRepositoryService) open(path string) (*git.Repository, error) {
 	checkout, err := git.PlainOpen(path)
 	if err != nil {
@@ -103,8 +99,7 @@ func (rs *GitRepositoryService) CloneRepository(repository string, branch string
 	return rs.prepareCheckout(checkout, username, email)
 }
 
-// OpenRepository opens an existing checkout instead of cloning, with the same git-user and hook
-// setup as CloneRepository so commits and pushes behave identically.
+// OpenRepository opens an existing checkout, with CloneRepository's git-user and hook setup.
 func (rs *GitRepositoryService) OpenRepository(path string, username string, email string) (Repository, Worktree, string, error) {
 	checkout, err := rs.open(path)
 	if err != nil {
@@ -113,9 +108,7 @@ func (rs *GitRepositoryService) OpenRepository(path string, username string, ema
 	return rs.prepareCheckout(checkout, username, email)
 }
 
-// GetRemoteURL returns the checkout's "origin" URL, which is how checkout mode learns the
-// repository without being told. Embedded credentials (GitLab CI puts a token here) are
-// stripped.
+// GetRemoteURL returns the "origin" URL, stripped of the credentials GitLab CI embeds in it.
 func (rs *GitRepositoryService) GetRemoteURL(path string) (string, error) {
 	checkout, err := rs.open(path)
 	if err != nil {
@@ -136,8 +129,7 @@ func (rs *GitRepositoryService) GetRemoteURL(path string) (string, error) {
 	return urls[0], nil
 }
 
-// GetCurrentBranch returns HEAD's branch, or "" when detached (the usual CI state) — callers
-// fall back to CI environment variables then.
+// GetCurrentBranch returns HEAD's branch, or "" when detached — the usual CI state.
 func (rs *GitRepositoryService) GetCurrentBranch(path string) (string, error) {
 	checkout, err := rs.open(path)
 	if err != nil {
@@ -153,9 +145,8 @@ func (rs *GitRepositoryService) GetCurrentBranch(path string) (string, error) {
 	return "", nil
 }
 
-// IsShallowClone reports a truncated commit history (CI's fetch-depth: 1 default). Such a
-// checkout commits fine but fails the later push with "object not found": the remote needs an
-// ancestry the clone does not have.
+// IsShallowClone reports a truncated history (CI's fetch-depth: 1). Such a checkout commits
+// fine but fails the later push with "object not found".
 func (rs *GitRepositoryService) IsShallowClone(path string) (bool, error) {
 	checkout, err := rs.open(path)
 	if err != nil {
@@ -168,15 +159,13 @@ func (rs *GitRepositoryService) IsShallowClone(path string) (bool, error) {
 	return len(shallow) > 0, nil
 }
 
-// prepareCheckout sets the commit identity and removes the prepare-commit-msg hook, then
-// returns the repository, worktree and working-tree root. Shared by clone and open.
+// prepareCheckout sets the commit identity and removes the prepare-commit-msg hook.
 func (rs *GitRepositoryService) prepareCheckout(checkout *git.Repository, username string, email string) (Repository, Worktree, string, error) {
 	config, err := checkout.Config()
 	if err != nil {
 		return checkout, nil, "", fmt.Errorf("failed to read git config: %w", err)
 	}
-	// Empty values (no VCS platform to ask, e.g. a checkout-mode --dry-run run with no token)
-	// leave the checkout's existing commit identity in place instead of blanking it out.
+	// Empty values (no platform to ask) leave the checkout's own identity in place.
 	if username != "" {
 		config.User.Name = username
 	}
@@ -184,11 +173,8 @@ func (rs *GitRepositoryService) prepareCheckout(checkout *git.Repository, userna
 		config.User.Email = email
 	}
 
-	// ...but only when there is one. A fresh clone and a CI checkout have no identity, and
-	// go-git fails the first commit with "author field is required".
-	//
-	// The scoped config is what go-git itself resolves the author from, so a developer's global
-	// user.name still wins and the default is written only when there is none anywhere.
+	// ...but a CI checkout has none at all, and go-git fails the first commit without one.
+	// Checked against the scoped config go-git resolves from, so a global user.name still wins.
 	scoped, err := checkout.ConfigScoped(gitconfig.SystemScope)
 	if err != nil {
 		return checkout, nil, "", fmt.Errorf("failed to read scoped git config: %w", err)
@@ -210,12 +196,9 @@ func (rs *GitRepositoryService) prepareCheckout(checkout *git.Repository, userna
 	}
 	root := w.Filesystem.Root()
 
-	// go-git runs no hooks, but `drush config:export --commit` shells out to real git, which
-	// does — and a hook that prompts or rejects a machine-written message would wedge a
-	// non-interactive run that cannot pass --no-verify.
-	//
-	// Via the OS filesystem, not w.Filesystem: go-git's bound worktree rejects any path with a
-	// ".git" component, so a Stat through it can never find the hook.
+	// `drush config:export --commit` shells out to real git, which does run hooks, and one that
+	// prompts would wedge a run that cannot pass --no-verify. Through the OS filesystem, since
+	// go-git's bound worktree rejects any path with a ".git" component.
 	hookPath := filepath.Join(root, ".git", "hooks", "prepare-commit-msg")
 	if _, err := rs.fs.Stat(hookPath); err == nil {
 		if err := rs.fs.Remove(hookPath); err != nil {
@@ -226,8 +209,8 @@ func (rs *GitRepositoryService) prepareCheckout(checkout *git.Repository, userna
 	return checkout, w, root, nil
 }
 
-// BranchExists queries the remote, not the checkout's cached refs/remotes/origin/*: those go
-// stale the moment the host auto-deletes a merged branch, giving a false positive.
+// BranchExists queries the remote: the cached refs/remotes/origin/* go stale the moment the host
+// auto-deletes a merged branch, giving a false positive.
 func (rs *GitRepositoryService) BranchExists(repository Repository, branch string, token string) (bool, error) {
 	remote, err := repository.Remote("origin")
 	if err != nil {
@@ -264,9 +247,8 @@ func (rs *GitRepositoryService) IsSomethingStagedInPath(worktree Worktree, dir s
 	return false
 }
 
-// pathWithin reports whether filePath is dir or lives under it. A substring test would also
-// match a prefix-sharing sibling — dir "translations" matching "translations-backup/de.po".
-// An empty dir means no path filter, so it matches everything.
+// pathWithin reports whether filePath is dir or lives under it — not a substring test, which
+// would match the sibling "translations-backup/de.po" for dir "translations". Empty dir matches all.
 func pathWithin(filePath string, dir string) bool {
 	dir = strings.Trim(filepath.ToSlash(dir), "/")
 	if dir == "" {

--- a/pkg/repo/repo_extra_test.go
+++ b/pkg/repo/repo_extra_test.go
@@ -47,9 +47,8 @@ func TestPathWithin(t *testing.T) {
 func TestIsSomethingStagedInPathIgnoresPrefixSiblings(t *testing.T) {
 	service := NewGitRepositoryService(zap.NewNop())
 
-	// A staged file in "translations-backup" must not be reported as a change in
-	// "translations": the translations addon commits based on this answer, and a false
-	// positive there makes it create a commit with no translation changes in it.
+	// The translations addon commits on this answer, so a false positive from the sibling
+	// "translations-backup" creates a commit with nothing in it.
 	worktree := NewMockWorktree(t)
 	worktree.EXPECT().Status().Return(git.Status{
 		"translations-backup/de.po": &git.FileStatus{Staging: git.Modified},
@@ -177,9 +176,8 @@ func TestCloneRepository(t *testing.T) {
 	})
 
 	t.Run("clones shallow and without tags", func(t *testing.T) {
-		// Both are deliberate CloneOptions with no other visible effect, so without this they
-		// could be dropped silently. Depth keeps the clone cheap; NoTags keeps a project's
-		// release tags out of a throwaway update clone.
+		// Both options have no other visible effect and could be dropped silently. Depth keeps
+		// the clone cheap; NoTags keeps release tags out of a throwaway clone.
 		source, r := initRepoWithCommit(t)
 
 		// Three commits in total, so the clone is distinguishable from both a full clone and a
@@ -214,9 +212,8 @@ func TestCloneRepository(t *testing.T) {
 		require.NoError(t, err)
 		clonedHead, err := cloneShallow.Head()
 		require.NoError(t, err)
-		// The graft point is the tip itself. Any greater depth grafts further back, so
-		// comparing against HEAD -- rather than counting graft points, of which there is one
-		// either way -- is what pins the depth to exactly 1.
+		// Compared against HEAD, not the graft-point count: there is one either way, so only
+		// the tip being the graft point pins the depth to exactly 1.
 		require.Len(t, shallowCommits, 1)
 		assert.Equal(t, clonedHead.Hash(), shallowCommits[0])
 
@@ -326,9 +323,8 @@ func TestIsShallowClone(t *testing.T) {
 	})
 }
 
-// isolateGitConfig points go-git's global-config lookup at an empty directory, so these tests
-// see the same identity-less environment a CI runner has rather than the developer's own
-// ~/.gitconfig.
+// isolateGitConfig gives these tests a CI runner's identity-less environment, not the
+// developer's own ~/.gitconfig.
 func isolateGitConfig(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
@@ -342,9 +338,8 @@ func TestIsSomethingStagedInPathOnStatusError(t *testing.T) {
 	service := NewGitRepositoryService(zap.New(core))
 
 	worktree := NewMockWorktree(t)
-	// The status is deliberately non-empty. With an empty one the guarded and unguarded
-	// versions both return false, so the test could not tell them apart; here, dropping the
-	// guard would let the loop below report a staged file from a status that failed to load.
+	// Non-empty on purpose: with an empty status the guarded and unguarded versions both
+	// return false, and the test could not tell them apart.
 	worktree.EXPECT().Status().Return(git.Status{
 		"file1.txt": &git.FileStatus{Staging: git.Modified},
 	}, assert.AnError)
@@ -357,9 +352,8 @@ func TestIsSomethingStagedInPathOnStatusError(t *testing.T) {
 func TestPrepareCheckoutKeepsExistingGlobalIdentity(t *testing.T) {
 	service := NewGitRepositoryService(zap.NewNop())
 
-	// The fallback must only fire when *nothing* supplies an identity. A developer running
-	// drupdater against their own checkout has a global git identity, and overwriting it in
-	// the repository config would attribute their later commits to drupdater.
+	// The fallback fires only when nothing supplies an identity: overwriting a developer's
+	// global one would attribute their later commits to drupdater.
 	home := isolateGitConfig(t)
 	require.NoError(t, os.WriteFile(filepath.Join(home, ".gitconfig"),
 		[]byte("[user]\n\tname = Real Person\n\temail = real@example.com\n"), 0o600))
@@ -382,9 +376,8 @@ func TestPrepareCheckoutKeepsExistingGlobalIdentity(t *testing.T) {
 func TestPrepareCheckoutKeepsExplicitIdentity(t *testing.T) {
 	service := NewGitRepositoryService(zap.NewNop())
 
-	// An identity passed in by the caller (resolved from the VCS platform) must win even when
-	// no git config anywhere supplies one -- otherwise every commit would be attributed to the
-	// generic fallback instead of the bot account the run authenticated as.
+	// A caller-supplied identity must win over the fallback, or every commit is attributed to
+	// the generic default instead of the bot account the run authenticated as.
 	isolateGitConfig(t)
 
 	dir := t.TempDir()
@@ -425,9 +418,8 @@ func TestPrepareCheckoutCommitIdentityFallback(t *testing.T) {
 	service := NewGitRepositoryService(zap.NewNop())
 
 	t.Run("falls back when nothing supplies an identity", func(t *testing.T) {
-		// A tokenless checkout-mode dry run has no VCS platform to ask, and a fresh clone or a
-		// CI checkout has no identity of its own, so without a fallback the first commit dies
-		// with go-git's "author field is required".
+		// A tokenless dry run has no platform to ask and a CI checkout no identity of its own,
+		// so without a fallback the first commit dies on "author field is required".
 		isolateGitConfig(t)
 		dir := t.TempDir()
 		_, err := git.PlainInit(dir, false)

--- a/pkg/repo/repo_property_test.go
+++ b/pkg/repo/repo_property_test.go
@@ -9,14 +9,11 @@ import (
 	"pgregory.net/rapid"
 )
 
-// pathWithin decides whether a changed file counts as a change to a configured directory. Its
-// doc comment names the bug a substring test would have; these properties state the containment
-// laws that rule that class of bug out for every path rather than for the one example.
+// pathWithin decides whether a changed file counts as a change to a configured directory. These
+// properties state the containment laws for every path, not just the documented example.
 
-// segmentGen generates one segment of a slash-separated repository path. Segments start with an
-// alphanumeric so the generator cannot produce "." or ".."; git status paths are already
-// relative to the worktree root and never contain either, and path.Join would silently collapse
-// them into a shape the function is not being asked about.
+// segmentGen starts each segment with an alphanumeric so it cannot produce "." or "..": git
+// status paths never contain either, and path.Join would silently collapse them.
 func segmentGen() *rapid.Generator[string] {
 	return rapid.StringMatching(`[a-z0-9][a-z0-9_.-]{0,7}`)
 }
@@ -38,9 +35,8 @@ func TestPropertyPathWithinAcceptsEveryDescendant(t *testing.T) {
 func TestPropertyPathWithinRejectsPrefixSiblings(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		dir := path.Join(segmentsGen(3).Draw(t, "dir")...)
-		// A non-empty suffix that does not start with a separator turns the last segment into a
-		// different directory name — "translations" against "translations-backup". A substring
-		// test would report every file in it as a change to dir.
+		// A suffix with no separator makes a different directory — "translations-backup" —
+		// whose every file a substring test would report as a change to dir.
 		suffix := segmentGen().Draw(t, "suffix")
 		file := segmentGen().Draw(t, "file")
 
@@ -77,9 +73,8 @@ func TestPropertyPathWithinIgnoresSurroundingSlashes(t *testing.T) {
 		lead := strings.Repeat("/", rapid.IntRange(0, 2).Draw(t, "lead"))
 		trail := strings.Repeat("/", rapid.IntRange(0, 2).Draw(t, "trail"))
 
-		// Callers pass a directory straight from configuration, where writing it as
-		// "/translations/" is a matter of taste. Git status paths never carry them, so the
-		// two forms have to mean the same thing.
+		// Callers pass a directory from configuration, where "/translations/" is a matter of
+		// taste, but git status paths never carry the slashes.
 		assert.Equal(t, pathWithin(file, dir), pathWithin(file, lead+dir+trail))
 	})
 }

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -109,10 +109,8 @@ func TestIsSomethingStaged(t *testing.T) {
 	}
 }
 
-// remoteToLocalRepo creates a real local git repo with the given branches (all pointing at one
-// empty commit) and returns a *git.Remote whose "origin" points at it. BranchExists is exercised
-// against this real, live listing rather than a hand-rolled fake of go-git's ref format, so the
-// test would catch a mismatch against go-git's actual wire format.
+// remoteToLocalRepo builds a real local repo to list against, rather than faking go-git's ref
+// format, so a mismatch with the actual wire format is caught.
 func remoteToLocalRepo(t *testing.T, branches ...string) *git.Remote {
 	t.Helper()
 	dir := t.TempDir()
@@ -160,9 +158,8 @@ func TestBranchExists(t *testing.T) {
 	})
 
 	t.Run("branch deleted on remote since the last fetch is not reported as existing", func(t *testing.T) {
-		// A checkout with a stale cached refs/remotes/origin/my-feature (e.g. left over from a
-		// branch that was merged and auto-deleted on the host) must not produce a false
-		// positive: BranchExists queries the live remote, not the checkout's own refs.
+		// A stale cached ref, left by a branch the host auto-deleted, must not produce a false
+		// positive: BranchExists queries the live remote.
 		remote := remoteToLocalRepo(t, "main")
 		repo := NewMockRepository(t)
 		repo.EXPECT().Remote("origin").Return(remote, nil)
@@ -307,10 +304,8 @@ func TestOpenRepository(t *testing.T) {
 	})
 
 	t.Run("empty identity preserves the checkout's existing commit identity", func(t *testing.T) {
-		// A checkout-mode --dry-run run with no token has no VCS platform to ask for the user's
-		// name and email (see cmd/root.go's tokenRequired), so it calls OpenRepository with
-		// empty strings. That must not blank out an identity the checkout already has configured
-		// (e.g. set up by CI) — it should be left alone.
+		// A tokenless dry run has no platform to ask, so it passes empty strings — which must
+		// not blank out an identity the checkout already has.
 		dir := t.TempDir()
 		checkout, err := git.PlainInit(dir, false)
 		require.NoError(t, err)

--- a/scripts/rector.php
+++ b/scripts/rector.php
@@ -16,9 +16,8 @@ else {
 }
 $drupalRoot = $drupalFinder->getDrupalRoot();
 
-// Composer-based sets pick the deprecation sets to run from the installed
-// `drupal/core` version, so the manual vendor-directory walk to build a set
-// list is no longer needed.
+// Composer-based sets read the deprecation sets from the installed drupal/core
+// version, replacing the manual vendor-directory walk.
 return RectorConfig::configure()
   ->withSetProviders(DrupalSetProvider::class)
   ->withComposerBased(drupal: TRUE)

--- a/scripts/unsupported-modules.php
+++ b/scripts/unsupported-modules.php
@@ -12,10 +12,8 @@ if (!\Drupal::moduleHandler()->moduleExists('update')) {
 $available = update_get_available(TRUE);
 $data = update_calculate_project_data($available);
 
-// The procedural UPDATE_* constants were deprecated in Drupal 10.3 and removed
-// in 11, where referencing one is a fatal "Undefined constant" rather than a
-// notice. The addon logs and swallows that failure, so the only symptom is that
-// no unsupported module is ever reported.
+// Not the procedural UPDATE_* constant: removed in Drupal 11, where referencing
+// it is fatal, and the addon swallows that into "nothing unsupported found".
 $notSupported = \Drupal\update\UpdateManagerInterface::NOT_SUPPORTED;
 
 $unsupported = [];


### PR DESCRIPTION
The previous guidance ("keep comments short") was too soft to change
behaviour. Make it a hard budget with concrete anti-patterns and a
bad/good example.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RygqKbmGhMmYWvpJnr5uGa