### PR TITLE
Add fuzz targets for the parsers, and fix three bugs they found

### DIFF
--- a/.claude/rules/addons.md
+++ b/.claude/rules/addons.md
@@ -10,7 +10,7 @@ When adding a new addon:
 2. Register it in `addonRegistry` in `cmd/root.go` (name → constructor).
 3. Decide: mandatory (add to `mandatoryAddons`) or configurable (add to `defaultNormalAddons` in `internal/configfile.go` if it should run by default).
 4. Unknown names in the active addon list abort the run — make sure the name in `addonRegistry` matches exactly what users put in `.drupdater.yaml`.
-5. Add `ReportKey()`/`ReportData()` in `internal/addon/report.go` — **not** in the addon's own file. Return `nil` when there is nothing to report, and sort anything unordered so reports stay byte-stable.
+5. Add `ReportKey()`/`ReportData()` in `internal/addon/report.go` — **not** in the addon's own file. Return `nil` when there is nothing to report, and sort anything unordered so reports stay byte-stable. Then add the addon to `reportingAddons()` in `internal/addon/report_golden_test.go` and regenerate with `go test ./internal/addon -update`, so its section is pinned like every other one.
 6. Document it: a new page at `docs/reference/addons/<name>.md`, a row in the catalogue table in `docs/reference/addons/index.md`, an entry in `mkdocs.yml`'s nav, and the addon list in `docs/reference/configuration.md`.
 
 The full procedure, including event/priority guidance and a checklist, is in `docs/contributing/writing-an-addon.md`.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,91 @@
+name: Fuzzing
+
+# Explores the parsers with generated input: repository URLs, .drupdater.yaml, `composer audit`
+# output, and the redactor's promise that a registered secret never reaches a sink.
+#
+# Not a pull request gate. The seed corpus and every committed counterexample already run in
+# go.yml's `test` job, which is the deterministic part; a generative run finds new inputs by
+# chance, and failing an unrelated pull request on that would make the gate a coin toss.
+#
+# When a leg fails it uploads the input that caused it. Commit that file under
+# testdata/fuzz/<target>/ -- `go test` replays it from then on, the same way rapid replays a
+# .fail file.
+
+on:
+  schedule:
+    # Mondays, 05:00 UTC -- after the mutation run rather than alongside it.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: 'How long to fuzz each target'
+        required: false
+        default: '5m'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Discovered rather than hardcoded, so adding a target adds its own leg.
+  plan:
+    name: plan
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.list.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: List fuzz targets
+        id: list
+        run: |
+          targets=$(for pkg in $(go list ./...); do
+            go test -list '^Fuzz' "$pkg" 2>/dev/null | grep '^Fuzz' | while read -r target; do
+              jq -n --arg p "$pkg" --arg t "$target" '{package: $p, target: $t}'
+            done
+          done | jq -s -c .)
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          echo "Fuzzing: $targets"
+
+  fuzz:
+    name: fuzz ${{ matrix.entry.target }}
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      # One target finding something must not cancel the others' exploration.
+      fail-fast: false
+      matrix:
+        entry: ${{ fromJson(needs.plan.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Fuzz ${{ matrix.entry.target }}
+        run: |
+          go test ${{ matrix.entry.package }} \
+            -run '^$' \
+            -fuzz '^${{ matrix.entry.target }}$' \
+            -fuzztime '${{ inputs.fuzztime || '5m' }}'
+
+      # Written into the package's testdata by the fuzzer itself, so this is the file to commit.
+      - name: Upload the failing input
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-counterexample-${{ matrix.entry.target }}
+          path: '**/testdata/fuzz/**'
+          if-no-files-found: ignore

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,6 +51,26 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
+  # Separate from `test` so the coverage profile comes from an uninstrumented run and the two
+  # go in parallel. The suite is hermetic but genuinely concurrent -- an errgroup per site, and
+  # addons accumulating state across those goroutines -- and no amount of coverage or mutation
+  # score can see a data race.
+  race:
+    name: race
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+      # Slower than it looks: pkg/composer and pkg/drush fake subprocesses by re-executing the
+      # test binary, and under -race every one of those execs starts an instrumented process.
+      - name: Test with the race detector
+        run: go test -race ./...
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Verify with `make docs-build` (runs `mkdocs build --strict`, which fails on brok
 Some pages embed files from the repo via `pymdownx.snippets`, so they cannot drift:
 
 - `internal/addon/testdata/*.md` → the "pull request section" examples on addon pages
+- `internal/addon/testdata/run_report.json` → the example report on `docs/reference/run-report.md`
 - `.github/assert-report.jq`, `.github/assert-lock-matches-report.jq` → `docs/how-to/consume-the-run-report.md`
 
 Changing a golden file changes the published example. `internal/addon/testdata/composer_diff.md` is a `Dummy Table` placeholder and is deliberately *not* embedded — that page hand-writes its example.
@@ -102,6 +103,7 @@ Where things live. For *how they work*, read `docs/explanation/` rather than dup
 | `internal/codehosting/` | GitHub and GitLab implementations, provider factory |
 | `internal/report/` | The published JSON report schema and its atomic writer |
 | `internal/logging/redact.go` | Value-based secret redaction, wrapping the zap core |
+| `internal/golden/` | Golden-file comparison and the `-update` flag; imported only from tests |
 | `pkg/` | One directory per wrapped external tool: `composer`, `drush`, `repo` (go-git), `phpcs`, `rector`, `drupal` (installer), `drupalorg` |
 | `scripts/` | PHP helpers copied into the image (`rector.php`, `unsupported-modules.php`, `config-resave.php`) |
 
@@ -109,7 +111,7 @@ Where things live. For *how they work*, read `docs/explanation/` rather than dup
 
 - **Addons never call each other.** They communicate only through mutable event payloads (`PackagesToUpdate`, `PackagesToKeep`, `MinimalChanges`, `Title`).
 - **Event priority is load-bearing** on `pre-composer-update` and `post-code-update`. See `docs/explanation/addon-architecture.md` before changing one.
-- **`internal/addon/report.go` is a published contract.** Renaming a field there is a breaking change to `schema_version`.
+- **`internal/addon/report.go` is a published contract.** Renaming a field there is a breaking change to `schema_version`, and `internal/addon/testdata/run_report.json` is what makes such a rename fail rather than ship. A new reporting addon belongs in that golden's `reportingAddons()`.
 - **Report types mirror rather than reuse internal types** (`report.PackageChange` vs `composer.PackageChange`) so an internal refactor can't rename a published field.
 - **The report's deferred write is registered first**, so it runs last and is emitted on every exit path.
 - **Per-site events fire concurrently.** Addon state accumulated across sites must be mutex-guarded, and maps handed to the report must be copies. `-race` only catches a missing guard if a test drives the handler from several sites at once — when you add cross-site state, add it to `internal/addon/concurrency_test.go` too.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Changing a golden file changes the published example. `internal/addon/testdata/c
 ```bash
 make build          # Build binary
 make test           # Run all tests (go test -v ./...)
+make test-race      # Run the suite under the race detector (~1 min; CI runs this too)
 make test-property  # Only the property tests, with far more generated cases (rapid)
 make fuzz           # Fuzz every target (FUZZTIME=30s each by default)
 make mutate         # Mutation testing over the whole module (mutago, pinned in go.mod)
@@ -111,7 +112,7 @@ Where things live. For *how they work*, read `docs/explanation/` rather than dup
 - **`internal/addon/report.go` is a published contract.** Renaming a field there is a breaking change to `schema_version`.
 - **Report types mirror rather than reuse internal types** (`report.PackageChange` vs `composer.PackageChange`) so an internal refactor can't rename a published field.
 - **The report's deferred write is registered first**, so it runs last and is emitted on every exit path.
-- **Per-site events fire concurrently.** Addon state accumulated across sites must be mutex-guarded, and maps handed to the report must be copies.
+- **Per-site events fire concurrently.** Addon state accumulated across sites must be mutex-guarded, and maps handed to the report must be copies. `-race` only catches a missing guard if a test drives the handler from several sites at once — when you add cross-site state, add it to `internal/addon/concurrency_test.go` too.
 
 ## Comments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Changing a golden file changes the published example. `internal/addon/testdata/c
 make build          # Build binary
 make test           # Run all tests (go test -v ./...)
 make test-property  # Only the property tests, with far more generated cases (rapid)
+make fuzz           # Fuzz every target (FUZZTIME=30s each by default)
 make mutate         # Mutation testing over the whole module (mutago, pinned in go.mod)
 make lint           # golangci-lint (govet, staticcheck, gosec, etc. — see .golangci.yml) + hadolint on the Dockerfile
 make fmt            # Format code
@@ -165,6 +166,12 @@ Mocks are generated with mockery v3 (config in `.mockery.yml`). After changing a
 `pgregory.net/rapid` states invariants over generated input, next to the example-based tests. Convention: file `<subject>_property_test.go`, every test named `TestProperty…` (`make test-property` selects on that prefix). A property must state a law — idempotent, order-independent, round-trips, leaks nothing — never a second implementation of the function.
 
 **The seed is random on every run.** So when a property finds a bug, fix the code *and* add an ordinary test naming the counterexample: the blocking mutation gate must not depend on the exploration happening to hit the right input. Counterexamples rapid records under `testdata/rapid/*.fail` are replayed automatically and belong in the commit. Details: `docs/contributing/development.md`.
+
+## Fuzzing
+
+Go's built-in fuzzer covers what a hand-written rapid generator cannot reach: arbitrary bytes, invalid UTF-8, degenerate separators. Convention: file `<subject>_fuzz_test.go`, every target named `Fuzz…`, seeded via `f.Add` with the real shapes *and* the degenerate ones. Four targets, on input drupdater does not control — the repository URL, `.drupdater.yaml`, `composer audit` output, and the redactor.
+
+Same discipline as properties: a failing input lands in `testdata/fuzz/<target>/<hash>`, gets committed (`go test` replays it forever after), **and** gets an ordinary test naming the counterexample, because the blocking mutation gate must not depend on a generative run. Fuzzing itself is not a PR gate — `fuzz.yml` runs weekly; `go.yml`'s `test` job runs the seeds and counterexamples on every push. Details: `docs/contributing/development.md`.
 
 ## Docker
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-property fuzz mutate clean mock lint fmt fix run docker-build docker-run docs-serve docs-build help
+.PHONY: build test test-race test-property fuzz mutate clean mock lint fmt fix run docker-build docker-run docs-serve docs-build help
 
 # Variables
 BINARY_NAME=drupdater
@@ -15,6 +15,11 @@ build: ## Build the binary
 
 test: ## Run tests
 	go test -v ./...
+
+# Around a minute rather than a couple of seconds: pkg/composer and pkg/drush fake subprocesses
+# by re-executing the test binary, and -race instruments every one of those execs.
+test-race: ## Run tests with the race detector
+	go test -race ./...
 
 # RAPID_CHECKS rather than -rapid.checks: rapid only registers its flags in test binaries that
 # import it, so passing the flag to ./... fails on every package that has no property tests. The

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-property mutate clean mock lint fmt fix run docker-build docker-run docs-serve docs-build help
+.PHONY: build test test-property fuzz mutate clean mock lint fmt fix run docker-build docker-run docs-serve docs-build help
 
 # Variables
 BINARY_NAME=drupdater
@@ -21,6 +21,19 @@ test: ## Run tests
 # environment variable is read at init and simply ignored by those packages.
 test-property: ## Run only the property tests, with far more generated cases than `make test`
 	RAPID_CHECKS=10000 go test ./... -run TestProperty
+
+# `go test ./...` already replays every seed and every committed counterexample; this is the
+# generative run. One target at a time -- `go test -fuzz` refuses a pattern matching several.
+FUZZTIME ?= 30s
+
+fuzz: ## Fuzz every target for FUZZTIME each (default 30s)
+	@set -e; \
+	for pkg in $$(go list ./...); do \
+	  for target in $$(go test -list '^Fuzz' $$pkg 2>/dev/null | grep '^Fuzz' || true); do \
+	    echo "==> $$target ($$pkg)"; \
+	    go test $$pkg -run '^$$' -fuzz "^$$target$$" -fuzztime $(FUZZTIME); \
+	  done; \
+	done
 
 clean: ## Clean build artifacts
 	rm -f ${BINARY_NAME}

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -18,6 +18,7 @@ make build
 make build          # build the binary (injects the version via -ldflags)
 make test           # go test -v ./...
 make test-property  # only the property tests, with far more generated cases
+make fuzz           # fuzz every target (FUZZTIME=30s each by default)
 make mutate         # mutation testing over the whole module (mutago)
 make lint           # golangci-lint + hadolint on the Dockerfile
 make fmt            # go fmt ./...
@@ -295,6 +296,93 @@ A function with two branches and no interesting input space is a table test, not
 `ActiveRunType` and `tokenRequired` are covered better by listing their cases than by generating
 them. Properties earn their keep where the input space is large and the promise is absolute:
 parsers, path handling, ordering, serialisation, and anything that must never leak a credential.
+
+## Fuzzing
+
+Property-based testing asks whether a law holds for every input a *generator* produces. That
+generator is written by hand, and it only ever produces inputs somebody imagined: rapid's
+`StringMatching` draws from an alphabet, `SliceOfN` from a length range. Fuzzing removes that
+ceiling. Go's built-in fuzzer mutates raw bytes and keeps whatever reaches a new branch, so it
+explores the inputs the generator's shape excludes — invalid UTF-8, a lone `%`, an embedded NUL,
+a path that is nothing but separators.
+
+The two are complementary, not alternatives, and both are kept on the same code:
+
+| | Generates | Finds | Corpus |
+|---|---|---|---|
+| rapid | Structured values from written generators | A law that is false for a plausible input | `testdata/rapid/*.fail` |
+| `go test -fuzz` | Arbitrary bytes, guided by coverage | A branch nothing plausible reaches | `testdata/fuzz/<target>/*` |
+
+```bash
+make test                      # every seed and every committed counterexample, as ordinary tests
+make fuzz                      # generative, 30s per target
+make fuzz FUZZTIME=5m          # longer
+go test ./internal/codehosting -run '^$' -fuzz '^FuzzParseGitURL$' -fuzztime 1h
+```
+
+`go test -fuzz` takes one target at a time and refuses a pattern that matches several, which is
+why `make fuzz` loops rather than passing `./...`.
+
+### The targets
+
+Four, on the code that parses input drupdater does not control:
+
+| Target | Covers |
+|---|---|
+| `FuzzParseGitURL` | The repository URL, in both the HTTP and the SCP shape, straight from a CI variable |
+| `FuzzLoadConfigFile` | `.drupdater.yaml`, including that a rejected file leaves the `Config` untouched |
+| `FuzzAuditUnmarshalJSON` | `composer audit` output, across the two shapes composer emits |
+| `FuzzRedact` | That a registered secret never survives redaction, on bytes no generator would write |
+
+### The convention
+
+- Targets live in `<subject>_fuzz_test.go`, next to `<subject>_test.go` and
+  `<subject>_property_test.go`.
+- Every target seeds `f.Add` with the real shapes **and** the degenerate ones — `""`, a bare
+  separator, a NUL. Seeds are the fuzzer's starting coverage, and they run on every `make test`.
+- Assert a law, never a second implementation — the same rule properties follow.
+- A target that writes to disk should take its directory from `f.TempDir()` once, outside
+  `f.Fuzz`, rather than calling `t.TempDir()` per execution.
+
+### When a target fails
+
+The fuzzer minimises the input, writes it to `testdata/fuzz/<target>/<hash>`, and prints how to
+re-run it:
+
+```text
+Failing input written to testdata/fuzz/FuzzParseGitURL/ea812ec424beb350
+To re-run:
+go test -run=FuzzParseGitURL/ea812ec424beb350
+```
+
+**Commit that file.** `go test` replays everything under `testdata/fuzz` before generating
+anything new, so the counterexample becomes a permanent regression case — exactly what a `.fail`
+file does for a property.
+
+Then do the other half. The mutation gate is blocking and generative exploration is not
+reproducible, so a mutant killed only because a run happened to generate the right input would
+pass on one pull request and fail on the next. **Fix the code, commit the corpus file, and add an
+ordinary test naming the concrete counterexample.** `TestParseGitURL`'s two `.git`-segment cases
+and `TestAuditUnmarshalShapes`'s ordering case are both written that way.
+
+!!! note "The generated corpus is not committed"
+
+    Inputs the fuzzer finds interesting go to `$(go env GOCACHE)/fuzz` and are local to the
+    machine that found them. Only seeds (in the target) and counterexamples (in `testdata/fuzz`)
+    are checked in. `go clean -fuzzcache` empties the cache when a stale corpus makes a run slow.
+
+### In CI
+
+| Where | Scope | Blocking |
+|---|---|---|
+| `test` job in `go.yml` | Seeds and committed counterexamples only, as ordinary tests | **Yes** |
+| `fuzz.yml` | Generative, one leg per target, weekly and on demand | No |
+
+Fuzzing is deliberately not a pull request gate: whether a generative run finds something is
+partly chance, and failing an unrelated pull request on a coin toss trains people to re-run
+until green. The deterministic half — every seed, every counterexample ever committed — does
+gate, on every push. A failing weekly leg uploads the input as a `fuzz-counterexample-<target>`
+artifact, ready to commit.
 
 ## Integration tests
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -17,6 +17,7 @@ make build
 ```bash
 make build          # build the binary (injects the version via -ldflags)
 make test           # go test -v ./...
+make test-race      # the suite under the race detector
 make test-property  # only the property tests, with far more generated cases
 make fuzz           # fuzz every target (FUZZTIME=30s each by default)
 make mutate         # mutation testing over the whole module (mutago)
@@ -118,6 +119,52 @@ get past it — fix the code.
 
 Changed packages must reach **≥ 90%** coverage. The hook prints per-package totals; add
 tests before committing if any package is below.
+
+## The race detector
+
+Drupdater runs the per-site phases concurrently — an `errgroup` bounded by `--concurrency`, one
+goroutine per site — and several addons accumulate state across those goroutines. That state is
+mutex-guarded, and nothing else in the toolchain can tell you when it stops being: coverage
+proves a line ran, mutation testing proves a test would notice a *changed* line, and both are
+blind to two goroutines touching the same map.
+
+```bash
+make test-race
+```
+
+CI runs it as its own `race` job in `go.yml`, in parallel with `test` so the coverage profile
+still comes from an uninstrumented run.
+
+!!! note "It takes about a minute, not a couple of seconds"
+
+    `pkg/composer` and `pkg/drush` fake subprocesses with the `TestHelperProcess` pattern, which
+    re-executes the test binary once per faked command. Under `-race` every one of those execs
+    starts an instrumented process, so those two packages account for almost all of the runtime.
+    Nothing is wrong; they simply have no concurrency for the detector to find either.
+
+### The detector only sees what actually runs
+
+This is the part worth internalising. `-race` is not a static check — it observes real memory
+accesses, so it finds nothing in code no test drives concurrently. Every `StartUpdate` test used
+to run a single site, which walks the per-site phases on one goroutine: the addon maps were
+written by one writer, and removing their mutexes would have gone unnoticed.
+
+So the concurrency tests and the detector are one tool, not two:
+
+| Test | Drives |
+|---|---|
+| `TestStartUpdateWithConcurrentSites` | The real workflow with four sites, asserting the baseline installs overlap and the committing tail does not |
+| `internal/addon/concurrency_test.go` | Each mutex-guarded addon's per-site handler, fired from all sites at once |
+| `TestForEachSite` | The fan-out itself: the concurrency bound, and cancellation on first error |
+
+Deleting a mutex from `internal/addon` makes the matching test fail under `-race` and **pass
+without it**. When you add state that accumulates across sites, add it to
+`concurrency_test.go` — otherwise the guard around it is untested however green CI looks.
+
+Where the shared resource is not memory, the detector cannot help and the test has to assert
+directly. `siteCommitMu` serialises the tail of `updateSite` because the sites share one git
+index — which is mocked in the suite, so there is no shared memory to observe.
+`TestStartUpdateWithConcurrentSites` measures peak occupancy instead.
 
 ## Mutation testing
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -120,6 +120,54 @@ get past it — fix the code.
 Changed packages must reach **≥ 90%** coverage. The hook prints per-package totals; add
 tests before committing if any package is below.
 
+## Golden files
+
+Some output is a contract with somebody outside this repository: the merge request sections a
+reviewer reads, and the `--report` document automation parses. For those, the whole shape matters
+— a renamed field breaks a consumer, and no assertion anybody remembers to write covers every
+field. So the expected output lives in a file under `testdata/` and the test compares against it
+byte for byte.
+
+```bash
+go test ./...                       # compare
+go test ./... -update               # rewrite every golden file
+go test ./internal/addon -update    # just one package's
+```
+
+`-update` is registered by `internal/golden`, which every golden assertion goes through. Always
+read the resulting `git diff` before committing: `-update` makes a change invisible if you let it,
+which is the one way a golden file can make tests worse rather than better.
+
+| Golden file | Pins |
+|---|---|
+| `internal/addon/testdata/*.md` | Each addon's merge request section, from its template |
+| `internal/services/testdata/dependency_update.md` | The assembled description a full run produces |
+| `internal/addon/testdata/run_report.json` | The whole `--report` document, every reporting addon at once |
+
+Most of these are embedded into this documentation with `pymdownx.snippets`, so the published
+examples cannot drift from what the code emits. Changing a golden file changes the docs.
+
+### Why the report has one
+
+`internal/addon/report.go` and `internal/report/report.go` are a published schema, and struct tags
+are invisible to everything else: coverage sees a line that ran, mutation testing does not mutate
+tags, and the property tests assert values rather than names. Before `run_report.json` existed,
+renaming `fixable` to `fixable_count` and `remaining` to `still_open` broke **no test at all**.
+`.github/assert-report.jq` does check field names, but only in the label-triggered integration
+run — never on a pull request.
+
+The golden is built through the real `report.Recorder`, so it also pins how `AddAddons` keys each
+section. Everything a clock produced is overwritten with fixed values first — otherwise the file
+would differ on every run — which is the one thing the golden deliberately does not check.
+
+### When not to write one
+
+A golden file freezes *everything* about its subject, so on an internal value it turns every
+unrelated change into a diff to re-approve and says nothing about which part mattered. The
+composer diff table and the preflight results are better served by the assertions they already
+have, which name the thing under test. Reach for a golden when the output is a published
+contract, not when it is merely large.
+
 ## The race detector
 
 Drupdater runs the per-site phases concurrently — an `errgroup` bounded by `--concurrency`, one

--- a/docs/reference/run-report.md
+++ b/docs/reference/run-report.md
@@ -14,40 +14,11 @@ drupdater --dry-run --report ./drupdater-report.json
 
 ## Example
 
+A `--security` run with every reporting addon contributing. Embedded from the test suite's
+golden file, so this example cannot drift from what the code emits:
+
 ```json
-{
-  "schema_version": 1,
-  "drupdater_version": "v0.3.6",
-  "composer_version": "2.10.2",
-  "php_version": "8.3.14",
-  "started_at": "2026-07-25T02:00:00Z",
-  "finished_at": "2026-07-25T02:14:31Z",
-  "duration_seconds": 871.4,
-  "status": "success",
-  "mode": "security",
-  "dry_run": false,
-  "repository": "https://github.com/org/site.git",
-  "base_branch": "main",
-  "update_branch": "update-3f81a2c",
-  "merge_request": {
-    "url": "https://github.com/org/site/pull/42",
-    "auto_merge": { "enabled": true }
-  },
-  "merge_request_title": "July 2026: Drupal Security Updates",
-  "merge_request_description": "This automated merge request by Drupdater …",
-  "sites": ["default"],
-  "packages": [
-    { "action": "Upgrade", "package": "drupal/core", "from": "10.1.8", "to": "10.2.0" }
-  ],
-  "phases": [
-    { "name": "composer install", "started_at": "…", "duration_seconds": 63.2, "ok": true },
-    { "name": "baseline site install", "started_at": "…", "duration_seconds": 121.9, "ok": true }
-  ],
-  "addons": {
-    "composer_audit": { "fixed": [], "remaining": [], "abandoned": [] },
-    "update_hooks": { "default": {} }
-  }
-}
+--8<-- "internal/addon/testdata/run_report.json"
 ```
 
 ## Fields

--- a/internal/addon/composer_allow_plugins_test.go
+++ b/internal/addon/composer_allow_plugins_test.go
@@ -2,9 +2,9 @@ package addon
 
 import (
 	"context"
-	"os"
 	"testing"
 
+	"github.com/drupdater/drupdater/internal/golden"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/go-git/go-git/v5"
 	"github.com/stretchr/testify/assert"
@@ -97,10 +97,6 @@ func TestDefaultAllowPlugins_PostComposerUpdateHandler(t *testing.T) {
 }
 
 func TestDefaultAllowPlugins_RenderTemplate(t *testing.T) {
-	fixture, err := os.ReadFile("testdata/allowplugins.md")
-	require.NoError(t, err, "Failed to read test fixture")
-
-	expected := string(fixture)
 	logger := zap.NewNop()
 	composerRunner := NewMockComposer(t)
 
@@ -110,7 +106,7 @@ func TestDefaultAllowPlugins_RenderTemplate(t *testing.T) {
 	result, err := ap.RenderTemplate()
 
 	require.NoError(t, err)
-	assert.Equal(t, expected, result)
+	golden.Assert(t, "testdata/allowplugins.md", result)
 }
 
 func TestDefaultAllowPlugins_RenderTemplate_Empty(t *testing.T) {

--- a/internal/addon/composer_audit_test.go
+++ b/internal/addon/composer_audit_test.go
@@ -2,10 +2,10 @@ package addon
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
+	"github.com/drupdater/drupdater/internal/golden"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/gookit/event"
@@ -260,13 +260,9 @@ func TestComposerAudit_RenderTemplate(t *testing.T) {
 		},
 	}
 
-	fixture, err := os.ReadFile("testdata/composer_audit.md")
-	require.NoError(t, err)
-	expected := string(fixture)
-
 	result, err := audit.RenderTemplate()
 	require.NoError(t, err)
-	assert.Equal(t, expected, result)
+	golden.Assert(t, "testdata/composer_audit.md", result)
 }
 
 // TestComposerAudit_RenderTemplate_EscapesPipes ensures a "|" in an advisory

--- a/internal/addon/composer_diff_test.go
+++ b/internal/addon/composer_diff_test.go
@@ -2,9 +2,9 @@ package addon
 
 import (
 	"context"
-	"os"
 	"testing"
 
+	"github.com/drupdater/drupdater/internal/golden"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/gookit/event"
 	"github.com/stretchr/testify/assert"
@@ -54,11 +54,6 @@ func TestComposerDiff_PostComposerUpdateHandler_Success(t *testing.T) {
 }
 
 func TestComposerDiff_RenderTemplate(t *testing.T) {
-	// Setup - Read expected output from fixture file
-	fixture, err := os.ReadFile("testdata/composer_diff.md")
-	require.NoError(t, err, "Failed to read test fixture")
-
-	expected := string(fixture)
 	logger := zap.NewNop()
 
 	composerRunner := NewMockComposer(t)
@@ -68,7 +63,7 @@ func TestComposerDiff_RenderTemplate(t *testing.T) {
 	result, err := composerDiff.RenderTemplate()
 
 	require.NoError(t, err)
-	assert.Equal(t, expected, result)
+	golden.Assert(t, "testdata/composer_diff.md", result)
 	composerRunner.AssertExpectations(t)
 }
 

--- a/internal/addon/composer_patches_1_test.go
+++ b/internal/addon/composer_patches_1_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/drupdater/drupdater/internal/golden"
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/drupdater/drupdater/pkg/drupalorg"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -926,10 +927,6 @@ func TestUpdatePatches(t *testing.T) {
 }
 
 func TestComposer_Patches_1_RenderTemplate(t *testing.T) {
-	fixture, err := os.ReadFile("testdata/composer_patches_1.md")
-	require.NoError(t, err, "Failed to read test fixture")
-
-	expected := string(fixture)
 	logger := zap.NewNop()
 	composerRunner := NewMockComposer(t)
 	drupalorgService := NewMockDrupalOrg(t)
@@ -972,7 +969,7 @@ func TestComposer_Patches_1_RenderTemplate(t *testing.T) {
 	result, err := ap.RenderTemplate()
 
 	require.NoError(t, err)
-	assert.Equal(t, expected, result)
+	golden.Assert(t, "testdata/composer_patches_1.md", result)
 }
 
 func TestDownloadFile(t *testing.T) {

--- a/internal/addon/concurrency_test.go
+++ b/internal/addon/concurrency_test.go
@@ -1,0 +1,123 @@
+package addon
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/drupdater/drupdater/internal/services"
+	"github.com/drupdater/drupdater/pkg/drush"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// The per-site events fire from errgroup goroutines, one per site, so every addon accumulating
+// state across sites writes its map concurrently. These tests are the ones that give `-race`
+// something to observe: the rest of the suite drives each handler with a single site, where an
+// unguarded map write is invisible. Each also asserts no site is lost, which stands on its own.
+
+// concurrentSites returns the site names to drive the handlers with. Enough of them that a lost
+// update is not masked by the goroutines happening to serialise.
+func concurrentSites(n int) []string {
+	sites := make([]string, 0, n)
+	for i := range n {
+		sites = append(sites, "site"+strconv.Itoa(i))
+	}
+	return sites
+}
+
+// runPerSite fires fn for every site at once and waits for all of them.
+func runPerSite(t *testing.T, sites []string, fn func(site string) error) {
+	t.Helper()
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for _, site := range sites {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			assert.NoError(t, fn(site))
+		}()
+	}
+	// Released together, so the handlers overlap instead of finishing as they are spawned.
+	close(start)
+	wg.Wait()
+}
+
+func TestUpdateHooksRecordsEverySiteUnderConcurrency(t *testing.T) {
+	mockDrush := NewMockDrush(t)
+	updateHooks := NewUpdateHooks(zap.NewNop(), mockDrush)
+
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+	sites := concurrentSites(8)
+
+	for _, site := range sites {
+		mockDrush.EXPECT().GetUpdateHooks(ctx, "/project", site).
+			Return(map[string]drush.UpdateHook{site + "_update_8001": {Module: site}}, nil)
+	}
+
+	runPerSite(t, sites, func(site string) error {
+		return updateHooks.preSiteUpdateHandler(services.NewPreSiteUpdateEvent(ctx, "/project", worktree, site))
+	})
+
+	require.Len(t, updateHooks.hooks, len(sites))
+	for _, site := range sites {
+		assert.Contains(t, updateHooks.hooks, site)
+	}
+}
+
+func TestUnsupportedModulesRecordsEverySiteUnderConcurrency(t *testing.T) {
+	mockDrush := NewMockDrush(t)
+	um := NewUnsupportedModules(zap.NewNop(), mockDrush)
+
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+	sites := concurrentSites(8)
+
+	// A module per site plus one they all report, so the run exercises both a fresh key and the
+	// deduplicating overwrite while the goroutines overlap.
+	for _, site := range sites {
+		mockDrush.EXPECT().GetUnsupportedModules(ctx, "/project", site).Return([]drush.UnsupportedModule{
+			{Name: "module_" + site, InstalledVersion: "1.0.0", RecommendedVersion: "2.0.0"},
+			{Name: "shared_module", InstalledVersion: "1.0.0", RecommendedVersion: "None"},
+		}, nil)
+	}
+
+	runPerSite(t, sites, func(site string) error {
+		return um.preSiteUpdateHandler(services.NewPreSiteUpdateEvent(ctx, "/project", worktree, site))
+	})
+
+	require.Len(t, um.modules, len(sites)+1)
+	assert.Contains(t, um.modules, "shared_module")
+	for _, site := range sites {
+		assert.Contains(t, um.modules, "module_"+site)
+	}
+}
+
+func TestTranslationsUpdaterRecordsEverySiteUnderConcurrency(t *testing.T) {
+	mockDrush := NewMockDrush(t)
+	tu := NewTranslationsUpdater(zap.NewNop(), mockDrush, NewMockRepository(t))
+
+	ctx := context.Background()
+	worktree := NewMockWorktree(t)
+	sites := concurrentSites(8)
+
+	// The skip path is the one that writes without touching the worktree, so the goroutines
+	// reach `record` with nothing else serialising them.
+	for _, site := range sites {
+		mockDrush.EXPECT().IsModuleEnabled(ctx, "/project", site, "locale_deploy").Return(false, nil)
+	}
+
+	runPerSite(t, sites, func(site string) error {
+		return tu.postSiteUpdateHandler(services.NewPostSiteUpdateEvent(ctx, "/project", worktree, site))
+	})
+
+	require.Len(t, tu.results, len(sites))
+	for _, site := range sites {
+		assert.Contains(t, tu.results, site)
+	}
+}

--- a/internal/addon/report.go
+++ b/internal/addon/report.go
@@ -31,7 +31,7 @@ type SecurityAdvisories struct {
 // ReportKey implements report.Reporter.
 func (ca *ComposerAudit) ReportKey() string { return "composer_audit" }
 
-// ReportData implements report.Reporter. Abandoned packages arrive sorted, so this stays stable.
+// ReportData implements report.Reporter. Both lists arrive sorted, so this stays stable.
 func (ca *ComposerAudit) ReportData() any {
 	fixed := ca.GetFixedAdvisories()
 	remaining := ca.afterAudit.Advisories

--- a/internal/addon/report_golden_test.go
+++ b/internal/addon/report_golden_test.go
@@ -1,0 +1,146 @@
+package addon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/golden"
+	"github.com/drupdater/drupdater/internal/report"
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/drupdater/drupdater/pkg/drush"
+	"github.com/stretchr/testify/require"
+)
+
+// The --report document is a published contract: consumers key off these names, and renaming one
+// is a SchemaVersion bump. Nothing else in the suite notices such a rename — struct tags are
+// invisible to coverage, and mutation testing does not mutate them — so the whole document is
+// pinned here, with every reporting addon contributing at once.
+//
+// The file this compares against is embedded into docs/reference/run-report.md, so the published
+// example cannot drift from what the code emits either.
+//
+// Regenerate after a deliberate change with: go test ./internal/addon -update
+
+// fixedTime is the instant every timestamp in the golden report is normalised to.
+var fixedTime = time.Date(2026, 3, 14, 9, 30, 0, 0, time.UTC)
+
+// reportingAddons builds one of every addon that contributes a section, populated so no field is
+// left at its zero value — an omitempty field that is never set cannot be pinned.
+func reportingAddons() []internal.Addon {
+	beforeAudit := composer.Audit{
+		Advisories: []composer.Advisory{
+			{
+				PackageName: "drupal/core", AdvisoryID: "PKSA-2026-0001", CVE: "CVE-2026-1111",
+				Title: "Cross site scripting in the render pipeline", Link: "https://www.drupal.org/sa-core-2026-001",
+				AffectedVersions: ">=10.3.0,<10.3.9", Severity: "critical", ReportedAt: "2026-02-01T00:00:00+00:00",
+			},
+			{
+				PackageName: "drupal/token", AdvisoryID: "PKSA-2026-0002", CVE: "CVE-2026-2222",
+				Title: "Access bypass", Link: "https://www.drupal.org/sa-contrib-2026-002",
+				AffectedVersions: "<1.15.0", Severity: "moderate", ReportedAt: "2026-02-10T00:00:00+00:00",
+			},
+		},
+	}
+	afterAudit := composer.Audit{
+		// drupal/token stays: its fix needs a major bump the update did not take.
+		Advisories: beforeAudit.Advisories[1:],
+		Abandoned: []composer.AbandonedPackage{
+			{PackageName: "swiftmailer/swiftmailer", Replacement: "symfony/mailer"},
+			{PackageName: "patchwork/jsqueeze"},
+		},
+	}
+
+	return []internal.Addon{
+		&ComposerAudit{beforeAudit: beforeAudit, afterAudit: afterAudit},
+		&UpdateHooks{hooks: UpdateHooksPerSite{
+			"default": {"token_update_8002": {Module: "token", UpdateID: 8002, Description: "Rebuild the token cache", Type: "hook_update_n"}},
+			"second":  {"node_post_update_index": {Module: "node", UpdateID: "index", Description: "Reindex nodes", Type: "post_update"}},
+		}},
+		&UnsupportedModules{modules: map[string]drush.UnsupportedModule{
+			"legacy_feature": {Name: "legacy_feature", InstalledVersion: "1.2.0", RecommendedVersion: "None"},
+			"old_widget":     {Name: "old_widget", InstalledVersion: "2.0.0", RecommendedVersion: "3.1.0"},
+		}},
+		&ComposerPatches1{patchUpdates: PatchUpdates{
+			Removed: []RemovedPatch{{
+				Package: "drupal/core", PatchDescription: "Fix the thing",
+				PatchPath: "https://www.drupal.org/files/issues/3001-12.patch", Reason: "fixed upstream in 10.4.0",
+			}},
+			Updated: []UpdatedPatch{{
+				Package: "drupal/paragraphs", PatchDescription: "Support the other thing",
+				PreviousPatchPath: "https://www.drupal.org/files/issues/3002-4.patch",
+				NewPatchPath:      "https://www.drupal.org/files/issues/3002-9.patch",
+			}},
+			Conflicts: []ConflictPatch{{
+				Package: "drupal/webform", FixedVersion: "6.2.7",
+				PatchPath:        "https://www.drupal.org/files/issues/3003-2.patch",
+				PatchDescription: "Adjust the form", NewVersion: "6.3.0",
+			}},
+		}},
+		&CodeBeautifier{fixedFiles: []string{"web/modules/custom/acme/acme.module", "web/modules/custom/acme/src/Controller/AcmeController.php"}, fixable: 3},
+		&DeprecationsRemover{fixes: []DeprecationFix{{
+			File:           "web/modules/custom/acme/src/Plugin/Block/AcmeBlock.php",
+			AppliedRectors: []string{"Drupal\\Rector\\Rector\\Deprecation\\DrupalSetMessageRector"},
+		}}},
+		&TranslationsUpdater{results: map[string]TranslationResult{
+			"default": {Path: "translations", Updated: true},
+			"second":  {Skipped: "locale_deploy not enabled"},
+		}},
+	}
+}
+
+// normaliseTimes replaces everything a clock produced, so the document is byte-stable while every
+// field name it carries stays pinned.
+func normaliseTimes(rep *report.Report) {
+	rep.StartedAt = fixedTime
+	rep.FinishedAt = fixedTime.Add(14*time.Minute + 31*time.Second)
+	rep.DurationSeconds = rep.FinishedAt.Sub(rep.StartedAt).Seconds()
+	for i := range rep.Phases {
+		rep.Phases[i].StartedAt = fixedTime.Add(time.Duration(i) * time.Minute)
+		rep.Phases[i].DurationSeconds = float64(i+1) * 1.5
+	}
+}
+
+func TestRunReportMatchesItsGoldenFile(t *testing.T) {
+	// The real recorder rather than a hand-built struct, so the golden also pins how AddAddons
+	// keys the sections and what Finish fills in.
+	rec := report.NewRecorder("v1.4.0", report.ModeSecurity, false,
+		"https://oauth2:token@github.com/org/site.git", "main", []string{"default", "second"})
+
+	rec.SetToolVersions(report.ToolVersions{ComposerVersion: "2.10.2", PHPVersion: "8.3.14"})
+	require.NoError(t, rec.Run("preflight", func() error { return nil }))
+	require.NoError(t, rec.Run("update shared code", func() error { return nil }))
+	require.NoError(t, rec.Run("site update", func() error { return nil }))
+	rec.SetUpdateBranch("update-3f81a2c")
+	rec.SetPackages([]report.PackageChange{
+		{Action: "Upgrade", Package: "drupal/core", From: "10.3.8", To: "10.3.9"},
+		{Action: "Install", Package: "drupal/redirect", To: "1.10.0"},
+		{Action: "Remove", Package: "drupal/legacy_feature", From: "1.2.0"},
+	})
+	rec.SetMergeRequestContent("Drupal Security Update", "## 🔒 **Security Report**\n")
+	rec.SetMergeRequest("https://github.com/org/site/pull/42")
+	rec.SetAutoMerge(nil)
+	rec.AddAddons(reportingAddons())
+
+	rep := rec.Finish()
+	normaliseTimes(&rep)
+
+	encoded, err := json.MarshalIndent(rep, "", "  ")
+	require.NoError(t, err)
+
+	golden.Assert(t, "testdata/run_report.json", string(encoded)+"\n")
+}
+
+// The credential in the repository URL above must not reach the document, and a golden file is a
+// poor place to notice it: a leak would simply be baked in on the next -update.
+func TestRunReportGoldenCarriesNoCredential(t *testing.T) {
+	rec := report.NewRecorder("v1.4.0", report.ModeSecurity, false,
+		"https://oauth2:token@github.com/org/site.git", "main", []string{"default"})
+	rec.AddAddons(reportingAddons())
+
+	encoded, err := json.Marshal(rec.Finish())
+	require.NoError(t, err)
+
+	require.NotContains(t, string(encoded), "oauth2:token")
+}

--- a/internal/addon/testdata/run_report.json
+++ b/internal/addon/testdata/run_report.json
@@ -1,0 +1,187 @@
+{
+  "schema_version": 1,
+  "drupdater_version": "v1.4.0",
+  "composer_version": "2.10.2",
+  "php_version": "8.3.14",
+  "started_at": "2026-03-14T09:30:00Z",
+  "finished_at": "2026-03-14T09:44:31Z",
+  "duration_seconds": 871,
+  "status": "success",
+  "mode": "security",
+  "dry_run": false,
+  "repository": "https://github.com/org/site.git",
+  "base_branch": "main",
+  "update_branch": "update-3f81a2c",
+  "merge_request": {
+    "url": "https://github.com/org/site/pull/42",
+    "auto_merge": {
+      "enabled": true
+    }
+  },
+  "merge_request_title": "Drupal Security Update",
+  "merge_request_description": "## 🔒 **Security Report**\n",
+  "sites": [
+    "default",
+    "second"
+  ],
+  "packages": [
+    {
+      "action": "Upgrade",
+      "package": "drupal/core",
+      "from": "10.3.8",
+      "to": "10.3.9"
+    },
+    {
+      "action": "Install",
+      "package": "drupal/redirect",
+      "to": "1.10.0"
+    },
+    {
+      "action": "Remove",
+      "package": "drupal/legacy_feature",
+      "from": "1.2.0"
+    }
+  ],
+  "phases": [
+    {
+      "name": "preflight",
+      "started_at": "2026-03-14T09:30:00Z",
+      "duration_seconds": 1.5,
+      "ok": true
+    },
+    {
+      "name": "update shared code",
+      "started_at": "2026-03-14T09:31:00Z",
+      "duration_seconds": 3,
+      "ok": true
+    },
+    {
+      "name": "site update",
+      "started_at": "2026-03-14T09:32:00Z",
+      "duration_seconds": 4.5,
+      "ok": true
+    }
+  ],
+  "addons": {
+    "code_beautifier": {
+      "files": [
+        "web/modules/custom/acme/acme.module",
+        "web/modules/custom/acme/src/Controller/AcmeController.php"
+      ],
+      "fixable": 3
+    },
+    "composer_audit": {
+      "fixed": [
+        {
+          "reportedAt": "2026-02-01T00:00:00+00:00",
+          "severity": "critical",
+          "advisoryId": "PKSA-2026-0001",
+          "cve": "CVE-2026-1111",
+          "sources": null,
+          "link": "https://www.drupal.org/sa-core-2026-001",
+          "packageName": "drupal/core",
+          "affectedVersions": "\u003e=10.3.0,\u003c10.3.9",
+          "title": "Cross site scripting in the render pipeline"
+        }
+      ],
+      "remaining": [
+        {
+          "reportedAt": "2026-02-10T00:00:00+00:00",
+          "severity": "moderate",
+          "advisoryId": "PKSA-2026-0002",
+          "cve": "CVE-2026-2222",
+          "sources": null,
+          "link": "https://www.drupal.org/sa-contrib-2026-002",
+          "packageName": "drupal/token",
+          "affectedVersions": "\u003c1.15.0",
+          "title": "Access bypass"
+        }
+      ],
+      "abandoned": [
+        {
+          "packageName": "swiftmailer/swiftmailer",
+          "replacement": "symfony/mailer"
+        },
+        {
+          "packageName": "patchwork/jsqueeze",
+          "replacement": ""
+        }
+      ]
+    },
+    "composer_patches": {
+      "removed": [
+        {
+          "package": "drupal/core",
+          "patch_description": "Fix the thing",
+          "patch_path": "https://www.drupal.org/files/issues/3001-12.patch",
+          "reason": "fixed upstream in 10.4.0"
+        }
+      ],
+      "updated": [
+        {
+          "package": "drupal/paragraphs",
+          "patch_description": "Support the other thing",
+          "previous_patch_path": "https://www.drupal.org/files/issues/3002-4.patch",
+          "new_patch_path": "https://www.drupal.org/files/issues/3002-9.patch"
+        }
+      ],
+      "conflicts": [
+        {
+          "package": "drupal/webform",
+          "fixed_version": "6.2.7",
+          "patch_path": "https://www.drupal.org/files/issues/3003-2.patch",
+          "patch_description": "Adjust the form",
+          "new_version": "6.3.0"
+        }
+      ]
+    },
+    "deprecations_remover": [
+      {
+        "file": "web/modules/custom/acme/src/Plugin/Block/AcmeBlock.php",
+        "applied_rectors": [
+          "Drupal\\Rector\\Rector\\Deprecation\\DrupalSetMessageRector"
+        ]
+      }
+    ],
+    "translations_updater": {
+      "default": {
+        "path": "translations",
+        "updated": true
+      },
+      "second": {
+        "updated": false,
+        "skipped": "locale_deploy not enabled"
+      }
+    },
+    "unsupported_modules": [
+      {
+        "name": "legacy_feature",
+        "installed_version": "1.2.0",
+        "recommended_version": "None"
+      },
+      {
+        "name": "old_widget",
+        "installed_version": "2.0.0",
+        "recommended_version": "3.1.0"
+      }
+    ],
+    "update_hooks": {
+      "default": {
+        "token_update_8002": {
+          "module": "token",
+          "update_id": 8002,
+          "description": "Rebuild the token cache",
+          "type": "hook_update_n"
+        }
+      },
+      "second": {
+        "node_post_update_index": {
+          "module": "node",
+          "update_id": "index",
+          "description": "Reindex nodes",
+          "type": "post_update"
+        }
+      }
+    }
+  }
+}

--- a/internal/addon/unsupported_modules_test.go
+++ b/internal/addon/unsupported_modules_test.go
@@ -3,9 +3,9 @@ package addon
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
+	"github.com/drupdater/drupdater/internal/golden"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/composer"
 	"github.com/drupdater/drupdater/pkg/drush"
@@ -45,10 +45,6 @@ func TestUnsupportedModules_SubscribedEvents(t *testing.T) {
 }
 
 func TestUnsupportedModules_RenderTemplate(t *testing.T) {
-	fixture, err := os.ReadFile("testdata/unsupported_modules.md")
-	require.NoError(t, err)
-	expected := string(fixture)
-
 	logger := zap.NewNop()
 	mockDrush := NewMockDrush(t)
 
@@ -65,7 +61,7 @@ func TestUnsupportedModules_RenderTemplate(t *testing.T) {
 	result, err := um.RenderTemplate()
 
 	require.NoError(t, err)
-	assert.Equal(t, expected, result)
+	golden.Assert(t, "testdata/unsupported_modules.md", result)
 }
 
 func TestUnsupportedModules_RenderTemplate_Empty(t *testing.T) {

--- a/internal/addon/update_hooks_test.go
+++ b/internal/addon/update_hooks_test.go
@@ -3,9 +3,9 @@ package addon
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
+	"github.com/drupdater/drupdater/internal/golden"
 	"github.com/drupdater/drupdater/internal/services"
 	"github.com/drupdater/drupdater/pkg/drush"
 	"github.com/gookit/event"
@@ -37,10 +37,6 @@ func TestUpdateHooks_SubscribedEvents(t *testing.T) {
 }
 
 func TestUpdateHooks_RenderTemplate(t *testing.T) {
-	fixture, err := os.ReadFile("testdata/update_hooks.md")
-	require.NoError(t, err)
-	expected := string(fixture)
-
 	logger := zap.NewNop()
 	mockDrush := NewMockDrush(t)
 
@@ -58,7 +54,7 @@ func TestUpdateHooks_RenderTemplate(t *testing.T) {
 	result, err := ap.RenderTemplate()
 
 	require.NoError(t, err)
-	assert.Equal(t, expected, result)
+	golden.Assert(t, "testdata/update_hooks.md", result)
 }
 
 func TestUpdateHooks_RenderTemplate_Empty(t *testing.T) {

--- a/internal/codehosting/factory.go
+++ b/internal/codehosting/factory.go
@@ -100,7 +100,7 @@ func parseGitURL(raw string) (host string, path string, err error) {
 		if !found || host == "" || path == "" {
 			return "", "", fmt.Errorf("invalid repository URL %q", raw)
 		}
-		return host, strings.TrimSuffix(strings.Trim(path, "/"), ".git"), nil
+		return host, normalizeRepoPath(path), nil
 	}
 
 	u, err := url.Parse(raw)
@@ -110,5 +110,18 @@ func parseGitURL(raw string) (host string, path string, err error) {
 	if u.Host == "" {
 		return "", "", fmt.Errorf("invalid repository URL %q: missing host", raw)
 	}
-	return u.Host, strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git"), nil
+	return u.Host, normalizeRepoPath(u.Path), nil
+}
+
+// normalizeRepoPath reduces a URL path to "owner/repo". Slashes are trimmed on both sides of the
+// suffix removal: a path ending in "/.git" keeps a trailing separator if they are trimmed only
+// before it, and that separator reaches the API call as part of the project name.
+func normalizeRepoPath(path string) string {
+	path = strings.Trim(path, "/")
+	// Repeated, not a single TrimSuffix: neither GitHub nor GitLab permits a project name ending
+	// in ".git", so "repo.git.git" is a doubled suffix rather than a project called "repo.git".
+	for strings.HasSuffix(path, ".git") {
+		path = strings.Trim(strings.TrimSuffix(path, ".git"), "/")
+	}
+	return path
 }

--- a/internal/codehosting/factory_fuzz_test.go
+++ b/internal/codehosting/factory_fuzz_test.go
@@ -1,0 +1,46 @@
+package codehosting
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The repository URL arrives from a CI variable or a flag and is parsed by hand, because the SCP
+// form url.Parse does not accept is the one most CI systems export. The property test generates
+// well-formed URLs; fuzzing covers what an operator actually mistypes.
+func FuzzParseGitURL(f *testing.F) {
+	for _, seed := range []string{
+		"https://github.com/drupdater/drupdater.git",
+		"git@gitlab.com:group/subgroup/project.git",
+		"ssh://git@example.com:2222/owner/repo.git",
+		"https://oauth2:token@gitlab.example.com:8443/owner/repo",
+		"",
+		"://",
+		"h:",
+		":/",
+		"\x00",
+		strings.Repeat("@", 32),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		host, path, err := parseGitURL(raw)
+		if err != nil {
+			assert.Empty(t, host)
+			assert.Empty(t, path)
+			return
+		}
+
+		assert.NotEmpty(t, host, "a URL that parsed has to name the host the token is sent to")
+		assert.False(t, strings.HasSuffix(path, ".git"), "path %q kept its .git suffix", path)
+		assert.False(t, strings.HasPrefix(path, "/"), "path %q kept a leading slash", path)
+		assert.False(t, strings.HasSuffix(path, "/"), "path %q kept a trailing slash", path)
+
+		// ValidateRepositoryURL is the preflight check. Disagreeing means a check passes and
+		// the run then fails on the very URL it just approved.
+		assert.NoError(t, ValidateRepositoryURL(raw))
+	})
+}

--- a/internal/codehosting/factory_test.go
+++ b/internal/codehosting/factory_test.go
@@ -194,6 +194,13 @@ func TestParseGitURL(t *testing.T) {
 		{name: "scp with empty host", raw: ":owner/repo", wantErr: true},
 		// The user part is optional: a bare "@" prefix still leaves a usable host.
 		{name: "scp with empty user", raw: "@github.com:owner/repo.git", wantHost: "github.com", wantPath: "owner/repo"},
+		// Found by FuzzParseGitURL. Trimming the slashes only before removing ".git" left the
+		// separator in front of it behind, and the path went to the API with a trailing slash.
+		{name: "scp with a bare .git segment", raw: "git@github.com:owner/.git", wantHost: "github.com", wantPath: "owner"},
+		{name: "https with a bare .git segment", raw: "https://gitlab.com/group/user/.git", wantHost: "gitlab.com", wantPath: "group/user"},
+		// Also from FuzzParseGitURL. TrimSuffix removes one occurrence, so a doubled suffix
+		// survived; no forge allows a project name ending in ".git" for it to have been one.
+		{name: "doubled .git suffix", raw: "git@github.com:owner/repo.git.git", wantHost: "github.com", wantPath: "owner/repo"},
 	}
 
 	for _, tt := range tests {

--- a/internal/codehosting/testdata/fuzz/FuzzParseGitURL/2f7ed94e9205b85e
+++ b/internal/codehosting/testdata/fuzz/FuzzParseGitURL/2f7ed94e9205b85e
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0:.git.git")

--- a/internal/codehosting/testdata/fuzz/FuzzParseGitURL/ea812ec424beb350
+++ b/internal/codehosting/testdata/fuzz/FuzzParseGitURL/ea812ec424beb350
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0:0/.git")

--- a/internal/configfile_fuzz_test.go
+++ b/internal/configfile_fuzz_test.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// .drupdater.yaml is committed by the project and read before anything else happens, so a broken
+// one has to be rejected whole. The invariant worth fuzzing is not that the parser accepts the
+// right files but that a rejected file leaves the Config the run proceeds with untouched.
+func FuzzLoadConfigFile(f *testing.F) {
+	for _, seed := range []string{
+		"sites: [default]\ntimeout: 30m\n",
+		"timeout: 0\n",
+		"run_types:\n  security:\n    addons: []\n    auto_merge: true\n",
+		"addons:\n  normal: []\n",
+		"sites: []\n",
+		"sites:\n  - default\n  - second\n",
+		"# comment only\n",
+		"",
+		"\x00",
+		"timeout: [not, a, duration]\n",
+		"unknown_key: 1\n",
+	} {
+		f.Add(seed)
+	}
+
+	// One directory per worker, rewritten per input, rather than a t.TempDir() inside the target
+	// creating and removing one on every execution. Workers are separate processes running one
+	// input at a time, so sharing the path is safe.
+	path := filepath.Join(f.TempDir(), ".drupdater.yaml")
+
+	f.Fuzz(func(t *testing.T, body string) {
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+		before := Config{Sites: []string{"sentinel"}, Timeout: time.Hour}
+		c := before
+		found, err := LoadConfigFile(path, &c)
+
+		assert.True(t, found, "the file exists, so it was found whatever it contains")
+		if err != nil {
+			assert.Equal(t, before, c, "a rejected config must not apply half of itself")
+			return
+		}
+
+		// An empty list would silently skip every per-site phase and then open the merge
+		// request anyway, which reads as a successful run that did nothing.
+		assert.NotEmpty(t, c.Sites, "an accepted config always names at least one site")
+	})
+}

--- a/internal/golden/golden.go
+++ b/internal/golden/golden.go
@@ -1,0 +1,53 @@
+// Package golden compares test output against a committed file, and rewrites those files when
+// the suite runs with -update. Imported only from _test.go files, so the flag it registers never
+// reaches the drupdater binary.
+//
+// Golden files earn their keep on published output — the merge request sections and the --report
+// document — where the whole shape is the contract and a field rename has to show up as a diff
+// somebody reviews. They are the wrong tool for an internal value, where they freeze incidental
+// detail and churn on unrelated changes.
+package golden
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var update = flag.Bool("update", false, "rewrite golden files instead of comparing against them")
+
+// TB is the part of testing.TB this package needs. Narrower than testing.TB, which cannot be
+// implemented outside the standard library, so the failure paths here are themselves testable.
+type TB interface {
+	Helper()
+	Logf(format string, args ...any)
+	Errorf(format string, args ...any)
+	FailNow()
+}
+
+// Assert compares actual against the file at path, or writes actual there when -update is set.
+func Assert(t TB, path string, actual string) {
+	t.Helper()
+
+	if *update {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(actual), 0o600))
+		t.Logf("updated %s", path)
+		return
+	}
+
+	want, err := os.ReadFile(path) // #nosec G304 -- test-only, path comes from the test itself
+	require.NoError(t, err, "missing golden file %s — regenerate with: go test ./... -update", path)
+	if string(want) == actual {
+		return
+	}
+
+	// Compared line by line rather than as one string: testify prints both sides in full, and
+	// for a golden of any size the diff is the only readable part of that.
+	assert.Equal(t, strings.Split(string(want), "\n"), strings.Split(actual, "\n"),
+		"%s is out of date — inspect the diff, then regenerate with: go test ./... -update", path)
+}

--- a/internal/golden/golden_test.go
+++ b/internal/golden/golden_test.go
@@ -1,0 +1,96 @@
+package golden
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubTB records what Assert reported instead of failing the real test, so both failure paths
+// can be checked. FailNow only marks: a require inside Assert would otherwise abort this test.
+type stubTB struct {
+	errors []string
+	failed bool
+}
+
+func (s *stubTB) Helper()             {}
+func (s *stubTB) Logf(string, ...any) {}
+func (s *stubTB) Errorf(format string, args ...any) {
+	s.errors = append(s.errors, fmt.Sprintf(format, args...))
+}
+func (s *stubTB) FailNow() { s.failed = true }
+
+// withUpdate flips the -update flag for one test and restores it, so the package's own tests do
+// not depend on how the suite was invoked.
+func withUpdate(t *testing.T, on bool) {
+	t.Helper()
+	previous := *update
+	*update = on
+	t.Cleanup(func() { *update = previous })
+}
+
+func TestAssertPassesWhenTheFileMatches(t *testing.T) {
+	withUpdate(t, false)
+	path := filepath.Join(t.TempDir(), "golden.txt")
+	require.NoError(t, os.WriteFile(path, []byte("hello\nworld\n"), 0o600))
+
+	stub := &stubTB{}
+	Assert(stub, path, "hello\nworld\n")
+
+	assert.Empty(t, stub.errors)
+}
+
+func TestAssertReportsAMismatch(t *testing.T) {
+	withUpdate(t, false)
+	path := filepath.Join(t.TempDir(), "golden.txt")
+	require.NoError(t, os.WriteFile(path, []byte("hello\nworld\n"), 0o600))
+
+	stub := &stubTB{}
+	Assert(stub, path, "hello\nthere\n")
+
+	assert.NotEmpty(t, stub.errors, "a differing file has to fail the test")
+}
+
+func TestAssertReportsAMissingFile(t *testing.T) {
+	withUpdate(t, false)
+
+	stub := &stubTB{}
+	Assert(stub, filepath.Join(t.TempDir(), "absent.txt"), "anything")
+
+	// Not merely reported: without FailNow the comparison would run on empty content and
+	// report a confusing diff instead of "there is no golden file".
+	assert.True(t, stub.failed)
+	assert.NotEmpty(t, stub.errors)
+}
+
+func TestUpdateWritesTheFileAndItsDirectory(t *testing.T) {
+	withUpdate(t, true)
+	path := filepath.Join(t.TempDir(), "nested", "golden.txt")
+
+	stub := &stubTB{}
+	Assert(stub, path, "generated\n")
+
+	require.Empty(t, stub.errors)
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "generated\n", string(written))
+}
+
+func TestUpdateOverwritesAndThenCompares(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "golden.txt")
+	require.NoError(t, os.WriteFile(path, []byte("stale\n"), 0o600))
+
+	withUpdate(t, true)
+	Assert(&stubTB{}, path, "fresh\n")
+
+	// The round trip is the contract: whatever -update wrote must then compare clean, or
+	// regenerating would leave the suite red.
+	withUpdate(t, false)
+	stub := &stubTB{}
+	Assert(stub, path, "fresh\n")
+	assert.Empty(t, stub.errors)
+}

--- a/internal/logging/redact_fuzz_test.go
+++ b/internal/logging/redact_fuzz_test.go
@@ -1,0 +1,55 @@
+package logging
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A missed redaction is a credential in a log. The property test draws secrets from the alphabet
+// real tokens use; fuzzing drops that restriction, so the promise is checked against bytes no
+// generator would think to produce — invalid UTF-8, lone percent signs, embedded NULs.
+func FuzzRedact(f *testing.F) {
+	for _, seed := range [][3]string{
+		{"glpat-abc123", "ghp_def456", "cloning https://oauth2:glpat-abc123@gitlab.com/o/r.git"},
+		{"tok en", "tok", "tok en and tok"},
+		{"secret", "secret", "secret"},
+		{"%2F", "/", "a%2Fb"},
+		{"pässwörd", "ß", "pässwörd and ß"},
+		{"", "x", "x"},
+		{"a", "ba", "ab ba"},
+	} {
+		f.Add(seed[0], seed[1], seed[2])
+	}
+
+	f.Fuzz(func(t *testing.T, first, second, text string) {
+		// The placeholder is asterisks, so a secret containing one can be reassembled out of a
+		// replacement — a leak by construction rather than a defect. Same exclusion the property
+		// test makes, stated on the character that causes it.
+		if strings.Contains(first, "*") || strings.Contains(second, "*") {
+			t.Skip("a secret containing the placeholder character cannot be hidden by it")
+		}
+
+		redactor := NewRedactor()
+		redactor.Register(first, second)
+		out := redactor.Redact(text)
+
+		for _, secret := range []string{first, second} {
+			// Register ignores "": redacting it would replace every character of every line.
+			if secret == "" {
+				continue
+			}
+			assert.NotContains(t, out, secret)
+			// Which escaping a subprocess emits depends on where in a URL the token landed, and
+			// either form is still a usable credential.
+			assert.NotContains(t, out, url.QueryEscape(secret))
+			assert.NotContains(t, out, url.PathEscape(secret))
+		}
+
+		// Log lines pass the redactor once per sink; a second pass must not change what the
+		// first one produced.
+		assert.Equal(t, out, redactor.Redact(out))
+	})
+}

--- a/internal/services/workflow_base_test.go
+++ b/internal/services/workflow_base_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/drupdater/drupdater/internal"
 	"github.com/drupdater/drupdater/internal/codehosting"
+	"github.com/drupdater/drupdater/internal/golden"
 	"github.com/drupdater/drupdater/pkg/composer"
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -64,11 +65,17 @@ func TestStartUpdate(t *testing.T) {
 
 	repository.EXPECT().Push(mock.Anything).Return(nil)
 
-	fixture, err := os.ReadFile("testdata/dependency_update.md")
-	require.NoError(t, err, "Failed to read test fixture")
+	// Captured rather than matched on: as an expectation a changed description fails as an
+	// unexpected call, and the diff that would say what changed is never printed. The other
+	// tests below still match on the file, and share this one's regeneration.
+	var description string
 
 	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
-	vcsProvider.EXPECT().CreateMergeRequest(anyCtx, mock.Anything, string(fixture), mock.Anything, config.Branch).Return(codehosting.MergeRequest{}, nil)
+	vcsProvider.EXPECT().CreateMergeRequest(anyCtx, mock.Anything, mock.Anything, mock.Anything, config.Branch).
+		RunAndReturn(func(_ context.Context, _ string, got string, _ string, _ string) (codehosting.MergeRequest, error) {
+			description = got
+			return codehosting.MergeRequest{}, nil
+		})
 
 	mockComposer.EXPECT().Update(anyCtx, "/tmp", mock.Anything, mock.Anything, false, false).Return([]composer.PackageChange{
 		{
@@ -81,9 +88,10 @@ func TestStartUpdate(t *testing.T) {
 	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
 
 	workflowService := NewWorkflowBaseService(logger, config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
-	err = workflowService.StartUpdate(ctx, nil)
+	err := workflowService.StartUpdate(ctx, nil)
 
 	require.NoError(t, err)
+	golden.Assert(t, "testdata/dependency_update.md", description)
 	installer.AssertExpectations(t)
 	repositoryService.AssertExpectations(t)
 	repository.AssertExpectations(t)

--- a/internal/services/workflow_concurrency_test.go
+++ b/internal/services/workflow_concurrency_test.go
@@ -1,0 +1,122 @@
+package services
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/drupdater/drupdater/internal"
+	"github.com/drupdater/drupdater/internal/codehosting"
+	"github.com/drupdater/drupdater/pkg/composer"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/gookit/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// occupancyProbe counts how many goroutines are inside a mocked call at once, so a phase can
+// assert it fans out and another that it does not.
+type occupancyProbe struct {
+	current, high atomic.Int32
+}
+
+func newOccupancyProbe() *occupancyProbe { return &occupancyProbe{} }
+
+// probe matches the (ctx, path, site) shape both mocked calls share.
+func (o *occupancyProbe) probe(context.Context, string, string) error {
+	n := o.current.Add(1)
+	defer o.current.Add(-1)
+	for {
+		seen := o.high.Load()
+		if n <= seen || o.high.CompareAndSwap(seen, n) {
+			break
+		}
+	}
+	// Long enough that overlapping callers are still inside when the next one arrives; without
+	// it a fan-out could finish one at a time and read as serialised.
+	time.Sleep(5 * time.Millisecond)
+	return nil
+}
+
+func (o *occupancyProbe) peak() int32 { return o.high.Load() }
+
+// Every other StartUpdate test runs a single site, which walks the per-site phases on one
+// goroutine and leaves forEachSite's fan-out and siteCommitMu untested against each other. This
+// one drives the real workflow with several sites, and asserts both halves of the design: the
+// independent phase overlaps, the committing one does not.
+func TestStartUpdateWithConcurrentSites(t *testing.T) {
+	installer := NewMockInstaller(t)
+	repositoryService := NewMockRepository(t)
+	vcsProvider := NewMockPlatform(t)
+	repository := NewMockGitRepository(t)
+	mockComposer := NewMockComposer(t)
+	expectVersionLookup(mockComposer)
+	drush := NewMockDrush(t)
+
+	sites := []string{"site1", "site2", "site3", "site4"}
+	config := internal.Config{
+		RepositoryURL: "https://example.com/repo.git",
+		Branch:        "main",
+		Token:         "token",
+		Clone:         true,
+		Sites:         sites,
+		// Unbounded, so the sites genuinely overlap rather than running one at a time.
+		Concurrency: len(sites),
+	}
+
+	worktree := NewMockWorktree(t)
+	worktree.EXPECT().Commit(mock.Anything, mock.Anything).Return(plumbing.NewHash(""), nil)
+	worktree.EXPECT().AddGlob(mock.Anything).Return(nil)
+	worktree.EXPECT().Status().Return(git.Status{}, nil).Maybe()
+	worktree.EXPECT().Checkout(workBranchCheckout).Return(nil)
+
+	// Two opposite invariants, measured by peak occupancy rather than by the race detector: the
+	// git index the commit tail writes is mocked here, so nothing about it is shared memory.
+	baseline := newOccupancyProbe()
+	commitTail := newOccupancyProbe()
+
+	for _, site := range sites {
+		installer.EXPECT().Install(anyCtx, "/tmp", site).RunAndReturn(baseline.probe)
+		installer.EXPECT().ConfigureDatabase(anyCtx, "/tmp", site).Return(nil)
+		drush.EXPECT().UpdateSite(anyCtx, "/tmp", site).Return(nil)
+		drush.EXPECT().ExportConfiguration(anyCtx, "/tmp", site).RunAndReturn(commitTail.probe)
+		drush.EXPECT().ConfigResave(anyCtx, "/tmp", site).Return(nil)
+	}
+
+	repositoryService.EXPECT().CloneRepository(config.RepositoryURL, config.Branch, config.Token, "user", "mail").Return(repository, worktree, "/tmp", nil)
+	repositoryService.EXPECT().IsShallowClone("/tmp").Return(false, nil)
+	repositoryService.EXPECT().BranchExists(repository, mock.Anything, mock.Anything).Return(false, nil)
+	repository.EXPECT().Reference(mock.Anything, mock.Anything).Return(nil, plumbing.ErrReferenceNotFound)
+	repository.EXPECT().Push(mock.Anything).Return(nil)
+
+	mockComposer.EXPECT().CheckPlatformReqs(anyCtx, "/tmp").Return("", nil)
+	mockComposer.EXPECT().Install(anyCtx, "/tmp").Return(nil)
+	mockComposer.EXPECT().GetLockHash("/tmp").Return("dummy-hash", nil)
+	mockComposer.EXPECT().Update(anyCtx, "/tmp", mock.Anything, mock.Anything, false, false).
+		Return([]composer.PackageChange{{Package: "drupal/core", From: "9.0.0", To: "9.1.0"}}, nil)
+
+	vcsProvider.EXPECT().GetUser(mock.Anything).Return("user", "mail")
+	vcsProvider.EXPECT().CreateMergeRequest(anyCtx, mock.Anything, mock.Anything, mock.Anything, config.Branch).
+		Return(codehosting.MergeRequest{}, nil)
+
+	workflowService := NewWorkflowBaseService(zap.NewNop(), config, drush, vcsProvider, repositoryService, installer, mockComposer, event.NewManager(""))
+
+	require.NoError(t, workflowService.StartUpdate(context.Background(), nil))
+
+	// The baseline installs are the fan-out: independent per site, so they must overlap or the
+	// concurrency the whole design rests on is not happening.
+	assert.Greater(t, baseline.peak(), int32(1), "baseline site installs never overlapped")
+	// The tail of updateSite commits into one shared working tree, so siteCommitMu has to keep
+	// it to one site at a time however many are running.
+	assert.EqualValues(t, 1, commitTail.peak(), "the committing tail of updateSite overlapped")
+
+	installer.AssertExpectations(t)
+	drush.AssertExpectations(t)
+	repositoryService.AssertExpectations(t)
+	mockComposer.AssertExpectations(t)
+	vcsProvider.AssertExpectations(t)
+}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -311,7 +312,20 @@ func flattenAdvisories(advisoriesData any) ([]Advisory, error) {
 		}
 	}
 
+	slices.SortFunc(advisories, compareAdvisories)
+
 	return advisories, nil
+}
+
+// compareAdvisories orders the flattened list. Ranging a Go map is random, and this list reaches
+// the run report, the merge request description and a security run's `composer update` arguments.
+func compareAdvisories(a, b Advisory) int {
+	return cmp.Or(
+		strings.Compare(a.PackageName, b.PackageName),
+		strings.Compare(a.AdvisoryID, b.AdvisoryID),
+		strings.Compare(a.CVE, b.CVE),
+		strings.Compare(a.Title, b.Title),
+	)
 }
 
 // flattenAbandoned flattens composer audit's `abandoned` object into a sorted list. With nothing

--- a/pkg/composer/composer_extra_test.go
+++ b/pkg/composer/composer_extra_test.go
@@ -433,6 +433,23 @@ func TestAuditUnmarshalShapes(t *testing.T) {
 		assert.Equal(t, []AbandonedPackage{{PackageName: "foo/bar"}}, a.Abandoned)
 	})
 
+	t.Run("advisories are ordered by package, then advisory id", func(t *testing.T) {
+		// Ranging a Go map is random, so without the sort one audit output renders a different
+		// report, a different description and a different `composer update` argument list on
+		// every run. Named here as well as in the fuzz target: the mutation gate is blocking
+		// and must not depend on the fuzzer happening to generate two packages.
+		var a Audit
+		require.NoError(t, a.UnmarshalJSON([]byte(
+			`{"advisories":{"z/one":[{"advisoryId":"Z1","packageName":"z/one"}],`+
+				`"a/two":[{"advisoryId":"A2","packageName":"a/two"},{"advisoryId":"A1","packageName":"a/two"}]}}`)))
+
+		ids := make([]string, 0, len(a.Advisories))
+		for _, advisory := range a.Advisories {
+			ids = append(ids, advisory.AdvisoryID)
+		}
+		assert.Equal(t, []string{"A1", "A2", "Z1"}, ids)
+	})
+
 	t.Run("advisories and abandoned are captured from the same payload", func(t *testing.T) {
 		// The parser used to stop at the advisories key; a payload carrying both has to yield
 		// both.

--- a/pkg/composer/composer_fuzz_test.go
+++ b/pkg/composer/composer_fuzz_test.go
@@ -1,0 +1,46 @@
+package composer
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// `composer audit` output is flattened by hand across the two shapes composer emits, from a
+// subprocess whose version the project pins rather than drupdater. The property test states the
+// laws over generated JSON; fuzzing drops the generator's structure and works on arbitrary bytes.
+func FuzzAuditUnmarshalJSON(f *testing.F) {
+	for _, seed := range []string{
+		`{"advisories":{"drupal/core":[{"advisoryId":"PKSA-1","cve":"CVE-1","packageName":"drupal/core"}]}}`,
+		`{"advisories":{"drupal/core":{"k":{"advisoryId":"PKSA-2","packageName":"drupal/core"}}}}`,
+		`{"advisories":{"z/one":[{"advisoryId":"Z"}],"a/two":[{"advisoryId":"A"}]}}`,
+		`{"advisories":{"drupal/core":"unexpected"}}`,
+		`{"abandoned":{"swiftmailer/swiftmailer":"symfony/mailer","patchwork/jsqueeze":null}}`,
+		`{"abandoned":[]}`,
+		`{"advisories":{},"abandoned":{}}`,
+		`{}`,
+		`[]`,
+		`null`,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, data string) {
+		var audit Audit
+		if err := json.Unmarshal([]byte(data), &audit); err != nil {
+			return
+		}
+
+		// Both lists are published — the run report, the merge request description, and the
+		// package list a security run hands to `composer update`. Ranging a Go map is random,
+		// so an unsorted list means the same audit output produces a different run every time.
+		require.True(t, slices.IsSortedFunc(audit.Advisories, compareAdvisories),
+			"advisories came out unsorted, so the report order varies between identical runs")
+		require.True(t, slices.IsSortedFunc(audit.Abandoned, func(a, b AbandonedPackage) int {
+			return strings.Compare(a.PackageName, b.PackageName)
+		}), "abandoned packages came out unsorted")
+	})
+}

--- a/pkg/composer/composer_property_test.go
+++ b/pkg/composer/composer_property_test.go
@@ -221,7 +221,8 @@ func TestPropertyAuditUnmarshalFlattensEveryShape(t *testing.T) {
 		var audit Audit
 		require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(`{"advisories":{%s}}`, strings.Join(entries, ","))), &audit))
 
-		// Compared as a set: the map iteration inside UnmarshalJSON has no defined order.
+		// Compared as a set: this property is about losing none of them, not about their
+		// order — TestAuditUnmarshalShapes and FuzzAuditUnmarshalJSON cover the sort.
 		got := make([]string, 0, len(audit.Advisories))
 		for _, advisory := range audit.Advisories {
 			got = append(got, advisory.AdvisoryID)


### PR DESCRIPTION
Property tests cover what a hand-written generator produces. Fuzzing covers
what it excludes: invalid UTF-8, degenerate separators, doubled suffixes.
Four targets, on input drupdater does not control -- the repository URL,
.drupdater.yaml, `composer audit` output, and the redactor's promise.

Three defects surfaced, each fixed with both a committed corpus file and an
ordinary test naming the counterexample, because the blocking mutation gate
must not depend on a generative run reproducing the input:

- Advisories were flattened by ranging a Go map and never sorted, so one
  audit output produced a different run report, a different merge request
  description and a different `composer update` argument list every time.
  The abandoned list already had this fix and the reasoning behind it; the
  advisory list was missed. Found by inspection while writing the target.
- normalizeRepoPath trimmed slashes before removing ".git", so a path ending
  in "/.git" kept the separator and sent it to the API as part of the
  project name.
- TrimSuffix removes one occurrence, so "repo.git.git" survived
  normalization with its suffix intact.

The last two were already claimed by TestPropertyParseGitURLNormalisesItsOutput,
which had simply never generated the inputs.

Fuzzing runs weekly rather than per pull request: whether a generative run
finds something is partly chance, and failing an unrelated pull request on
that trains people to re-run until green. The deterministic half -- every
seed and every counterexample ever committed -- runs on every push via the
existing test job.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0165cwNRgAA8FRabWFK8vTTr